### PR TITLE
dynamic confidence and duplicate thresholds from system_settings

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -62,6 +62,23 @@ from backend.services.rag_service import RagService
 # ---------------------------------------------------------------------------
 # Request / Response models
 # ---------------------------------------------------------------------------
+def get_system_settings(company_id: str) -> dict:
+    defaults = {
+        "ai_confidence_threshold": 0.80,
+        "duplicate_sensitivity": 0.85,
+        "enable_auto_resolve": False
+    }
+    if not supabase or not company_id:
+        return defaults
+    try:
+        res = supabase.table("system_settings").select(
+            "ai_confidence_threshold, duplicate_sensitivity, enable_auto_resolve"
+        ).eq("company_id", company_id).single().execute()
+        if res.data:
+            return {**defaults, **res.data}
+    except Exception as e:
+        print(f"[WARNING] Could not fetch system_settings for company_id={company_id}: {e}")
+    return defaults
 class TicketRequest(BaseModel):
     text: str
     image_base64: str = ""
@@ -610,6 +627,11 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
     Main endpoint for analyzing a new ticket using the cascade of local AI models.
     """
     text = request_body.text
+
+    settings = get_system_settings(request_body.company)
+    confidence_threshold = settings["ai_confidence_threshold"]
+    duplicate_sensitivity = settings["duplicate_sensitivity"]
+    enable_auto_resolve = settings["enable_auto_resolve"]
     
     # Grab client metadata
     client_ip = request.client.host if request.client else "unknown"
@@ -642,7 +664,11 @@ async def analyze_only(request_body: TicketRequest):
     and duplicate check before committing to a ticket creation.
     """
     text = request_body.text
-    print(f"[AI] Starting Analysis (READ-ONLY) for: {text[:50]}...")
+    print(f"[AI] Starting Analysis (READ-ONLY) for: {text[:50]}...") 
+    settings = get_system_settings(request_body.company)
+    confidence_threshold = settings["ai_confidence_threshold"]
+    duplicate_sensitivity = settings["duplicate_sensitivity"]
+    enable_auto_resolve = settings["enable_auto_resolve"]
     
     # --- Context & Environment ---
     import datetime
@@ -718,7 +744,7 @@ async def analyze_only(request_body: TicketRequest):
 
     # --- Duplicate detection ---
     try:
-        dup_result = duplicate_service.check_duplicate(text, threshold=request_body.duplicate_sensitivity)
+        dup_result = duplicate_service.check_duplicate(text, threshold=duplicate_sensitivity)
     except Exception:
         dup_result = {"is_duplicate": False, "duplicate_ticket_id": None, "similarity": 0.0}
 
@@ -736,7 +762,7 @@ async def analyze_only(request_body: TicketRequest):
 
     # --- Reasoning ---
     decision_factors = []
-    if classification["confidence"] > request_body.confidence_threshold:
+    if classification["confidence"] > confidence_threshold:
         decision_factors.append(f"High confidence match for '{classification['subcategory']}'")
     if entities:
         decision_factors.append(f"Detected entities: {', '.join([e['text'] for e in entities[:2]])}")
@@ -746,6 +772,8 @@ async def analyze_only(request_body: TicketRequest):
         decision_factors.append(f"Found solution article: '{rag_match['title']}'")
 
     reasoning = f"Categorized as '{classification['category']}' - {classification['subcategory']}."
+    if not enable_auto_resolve:
+        classification["auto_resolve"] = False
     if classification["auto_resolve"]:
         reasoning += " Flagged for AI auto-resolution via Knowledge Base." if rag_match else " Flagged for auto-resolution."
     
@@ -771,7 +799,7 @@ async def analyze_only(request_body: TicketRequest):
         entities=[EntityInfo(**e) for e in entities],
         duplicate_ticket=DuplicateInfo(**dup_result),
         confidence=classification["confidence"],
-        needs_review=classification["confidence"] < 0.20,
+        needs_review=classification["confidence"] < confidence_threshold,
         reasoning=reasoning,
         decision_factors=decision_factors,
         image_description=gemini_analysis["image_description"],
@@ -798,7 +826,11 @@ async def analyze_stream(request_body: TicketRequest):
             "model_version": "3.0.0-PRO",
             "api_endpoint": "/ai/analyze_stream"
         }
-        timeline = {"received": get_now_ist()}
+        timeline = {"received": get_now_ist()} 
+        settings = get_system_settings(request_body.company)
+        confidence_threshold = settings["ai_confidence_threshold"]
+        duplicate_sensitivity = settings["duplicate_sensitivity"]
+        enable_auto_resolve = settings["enable_auto_resolve"]
 
         # 1. Reading
         yield f"data: {json.dumps({'step': 'Reading your message', 'status': 'in_progress'})}\n\n"
@@ -860,7 +892,7 @@ async def analyze_stream(request_body: TicketRequest):
         yield f"data: {json.dumps({'step': 'Checking duplicate issues', 'status': 'in_progress'})}\n\n"
         await asyncio.sleep(0.2)
         try:
-            dup_result = duplicate_service.check_duplicate(text, threshold=request_body.duplicate_sensitivity)
+            dup_result = duplicate_service.check_duplicate(text, threshold=duplicate_sensitivity)
         except Exception:
             dup_result = {"is_duplicate": False, "duplicate_ticket_id": None, "similarity": 0.0}
 
@@ -878,7 +910,7 @@ async def analyze_stream(request_body: TicketRequest):
             pass
 
         decision_factors = []
-        if classification["confidence"] > request_body.confidence_threshold:
+        if classification["confidence"] > confidence_threshold:
             decision_factors.append(f"High confidence match for '{classification['subcategory']}'")
         if entities:
             decision_factors.append(f"Detected entities: {', '.join([e['text'] for e in entities[:2]])}")
@@ -887,6 +919,8 @@ async def analyze_stream(request_body: TicketRequest):
         if rag_match:
             decision_factors.append(f"Found solution article: '{rag_match['title']}'")
 
+        if not enable_auto_resolve:
+            classification["auto_resolve"] = False
         reasoning = f"Categorized as '{classification['category']}' - {classification['subcategory']}."
         if classification["auto_resolve"]:
             reasoning += " Flagged for AI auto-resolution via Knowledge Base." if rag_match else " Flagged for auto-resolution."
@@ -911,7 +945,7 @@ async def analyze_stream(request_body: TicketRequest):
             "entities": [e for e in entities],
             "duplicate_ticket": dup_result,
             "confidence": classification["confidence"],
-            "needs_review": classification["confidence"] < 0.20,
+            "needs_review": classification["confidence"] < confidence_threshold,
             "reasoning": reasoning,
             "decision_factors": decision_factors,
             "image_description": gemini_analysis["image_description"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -772,7 +772,13 @@ async def analyze_only(request_body: TicketRequest):
         decision_factors.append(f"Found solution article: '{rag_match['title']}'")
 
     reasoning = f"Categorized as '{classification['category']}' - {classification['subcategory']}."
-    if not enable_auto_resolve:
+    if (
+        enable_auto_resolve
+        and classification["confidence"] >= confidence_threshold
+        and classification["auto_resolve"]
+    ):
+        classification["auto_resolve"] = True
+    else:
         classification["auto_resolve"] = False
     if classification["auto_resolve"]:
         reasoning += " Flagged for AI auto-resolution via Knowledge Base." if rag_match else " Flagged for auto-resolution."


### PR DESCRIPTION
Closes #40

## Changes
- Added `get_system_settings()` to fetch `ai_confidence_threshold`, `duplicate_sensitivity`, and `enable_auto_resolve` from DB per company
- Applied dynamic settings in `analyze_only` and `analyze_stream`
- `auto_resolve` is now `True` only if `enable_auto_resolve` is `True` AND `confidence >= ai_confidence_threshold`
- Falls back to safe defaults if DB is unavailable or `company_id` is missing