### PR TITLE
fix: clear ticketStore persisted state on logout to prevent cross-user data leakage

### DIFF
--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { supabase } from '../lib/supabaseClient';
+import useTicketStore from './ticketStore';
 
 const useAuthStore = create(
     persist(
@@ -90,7 +91,7 @@ const useAuthStore = create(
                         set({ user: null, profile: null });
                     }
                     return user;
-// eslint-disable-next-line no-unused-vars
+                    // eslint-disable-next-line no-unused-vars
                 } catch (error) {
                     set({ user: null, profile: null });
                     return null;
@@ -173,9 +174,9 @@ const useAuthStore = create(
                     const profile = await get().getProfile(user);
 
                     if (profile?.status === 'pending_email_verification') {
-                         await supabase.auth.signOut();
-                         set({ user: null, profile: null });
-                         throw new Error("Please verify your email address before continuing.");
+                        await supabase.auth.signOut();
+                        set({ user: null, profile: null });
+                        throw new Error("Please verify your email address before continuing.");
                     }
                     return { user, profile };
                 } catch (error) {
@@ -234,10 +235,14 @@ const useAuthStore = create(
                     const { error } = await supabase.auth.signOut();
                     if (error) throw error;
                     set({ user: null, profile: null });
+                    // clear persisted ticket state to prevent cross-user data leakage
+                    useTicketStore.getState().clearTicket();
+                    useTicketStore.setState({ notifications: [], tickets: [] });
                 } finally {
                     set({ loading: false });
                 }
             },
+
 
             updateProfile: async (updates) => {
                 const { profile } = get();


### PR DESCRIPTION
## Fixes #50

## Problem
When a user logged out, `authStore.logout()` only cleared `user` and `profile` 
state. The `ticketStore` (persisted to localStorage via Zustand persist middleware) 
was never reset, causing the following data from the previous user to leak into 
the next login session on the same device:

- `notifications` — previous user's ticket notifications
- `aiTicket` — last AI-processed ticket details
- `tickets` — full cached ticket queue
- `activeTicket` — last viewed ticket

## Fix
Added two lines inside `logout()` in `authStore.js`:

```js
useTicketStore.getState().clearTicket();
useTicketStore.setState({ notifications: [], tickets: [] });
```

This clears all persisted ticket state immediately after Supabase signOut.

## Testing Done
- ✅ Logged in as User A → created tickets → notifications appeared
- ✅ Logged out → ticketStore cleared from localStorage (verified in DevTools)
- ✅ Logged in as User B → notifications empty, tickets empty, aiTicket null
- ✅ No console errors during logout flow

## Files Changed
- `Frontend/src/store/authStore.js`