### PR TITLE
fix: graceful degradation for SentenceTransformer offline load (#54)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,18 @@
+# Supabase Configuration
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_KEY=your-service-key
+
+# Startup Mode
+# Set ALLOW_DEGRADED_STARTUP=1 to allow backend startup even if duplicate/RAG models fail to load
+# Useful for offline/dev environments where model downloads may not be available
+ALLOW_DEGRADED_STARTUP=0
+
+# Sentence Transformers Model Path
+# Provide a local path to the sentence-transformers model to avoid downloading from HuggingFace
+# If not set, model will be downloaded from HuggingFace (requires internet)
+# Example: ./models/all-MiniLM-L6-v2 or /opt/models/all-MiniLM-L6-v2
+SENTENCE_TRANSFORMER_MODEL_PATH=
+
+# Readiness Check
+# Set REQUIRE_SUPABASE=true to include Supabase configuration in the strict readiness gate
+REQUIRE_SUPABASE=false

--- a/backend/main.py
+++ b/backend/main.py
@@ -381,18 +381,29 @@ async def health_check():
 @app.get("/ready", response_model=ReadinessResponse)
 async def readiness_check():
     require_supabase = os.environ.get("REQUIRE_SUPABASE", "false").lower() == "true"
+    allow_degraded = os.environ.get("ALLOW_DEGRADED_STARTUP", "0") == "1"
+    
     checks = {
         "api": True,
         "classifier_loaded": classifier_service._loaded,
         "ner_loaded": ner_service._loaded,
-        "duplicate_index_loaded": duplicate_service._loaded,
-        "rag_loaded": rag_service._loaded,
+        "duplicate_index_loaded": duplicate_service.is_available(),
+        "rag_loaded": rag_service.is_available(),
     }
     if require_supabase:
         checks["supabase_configured"] = supabase is not None
 
-    if all(checks.values()):
-        return ReadinessResponse(status="ready", checks=checks)
+    # In degraded mode, duplicate and RAG services are optional
+    if allow_degraded:
+        required_checks = {k: v for k, v in checks.items() if k not in ["duplicate_index_loaded", "rag_loaded"]}
+        all_required_pass = all(required_checks.values())
+        
+        if all_required_pass:
+            return ReadinessResponse(status="ready", checks=checks)
+    else:
+        # Strict mode: all checks must pass
+        if all(checks.values()):
+            return ReadinessResponse(status="ready", checks=checks)
 
     return JSONResponse(
         status_code=503,

--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -4,44 +4,66 @@ Uses sentence-transformers all-MiniLM-L6-v2 to detect similar tickets.
 """
 
 import uuid
+import os
 from sentence_transformers import SentenceTransformer, util
 
 SIMILARITY_THRESHOLD = 0.70
 
 
-import os
-
 class DuplicateService:
     def __init__(self):
         self.model = None
         self._loaded = False
+        self._load_failed = False
         # In-memory store: list of (ticket_id, embedding, text)
         self._tickets: list[tuple[str, object, str]] = []
         self.storage_file = os.path.join(os.path.dirname(__file__), "..", "data", "case_history_cache.json")
         os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
 
+    def is_available(self) -> bool:
+        """Check if the model is available for duplicate detection."""
+        return self._loaded and not self._load_failed
+
     def load(self):
         """Load the sentence-transformer model and saved tickets."""
-        if self._loaded:
+        if self._loaded or self._load_failed:
             return
         
         print("[DuplicateService] Loading model...")
-        self.model = SentenceTransformer("all-MiniLM-L6-v2")
-        self._loaded = True
-        
-        if os.path.exists(self.storage_file):
-            print(f"[DuplicateService] Syncing previous ticket history from {self.storage_file}...")
-            import json
-            try:
-                with open(self.storage_file, "r") as f:
-                    data = json.load(f)
-                    for item in data:
-                        text = item["text"]
-                        embedding = self.model.encode(text, convert_to_tensor=True)
-                        self._tickets.append((item["ticket_id"], embedding, text))
-                print(f"[DuplicateService] Loaded {len(self._tickets)} tickets.")
-            except Exception as e:
-                print(f"[DuplicateService] Error loading storage: {e}")
+        try:
+            # Check if a local model path is provided
+            model_path = os.environ.get("SENTENCE_TRANSFORMER_MODEL_PATH")
+            if model_path and os.path.exists(model_path):
+                print(f"[DuplicateService] Loading from local path: {model_path}")
+                self.model = SentenceTransformer(model_path)
+            else:
+                # Download from HuggingFace
+                self.model = SentenceTransformer("all-MiniLM-L6-v2")
+            self._loaded = True
+            
+            if os.path.exists(self.storage_file):
+                print(f"[DuplicateService] Syncing previous ticket history from {self.storage_file}...")
+                import json
+                try:
+                    with open(self.storage_file, "r") as f:
+                        data = json.load(f)
+                        for item in data:
+                            text = item["text"]
+                            embedding = self.model.encode(text, convert_to_tensor=True)
+                            self._tickets.append((item["ticket_id"], embedding, text))
+                    print(f"[DuplicateService] Loaded {len(self._tickets)} tickets.")
+                except Exception as e:
+                    print(f"[DuplicateService] Error loading storage: {e}")
+        except Exception as e:
+            allow_degraded = os.environ.get("ALLOW_DEGRADED_STARTUP", "0") == "1"
+            self._load_failed = True
+            print(f"[DuplicateService] Failed to load model: {e}")
+            if allow_degraded:
+                print("[DuplicateService] DEGRADED: Continuing without model (ALLOW_DEGRADED_STARTUP=1)")
+                self.model = None
+                self._loaded = False
+            else:
+                raise
 
     def save_to_disk(self, ticket_id: str, text: str):
         """Append a new ticket to the JSON storage."""
@@ -68,6 +90,9 @@ class DuplicateService:
     def add_ticket(self, ticket_id: str, text: str):
         """Add a ticket to the in-memory store and persist to disk."""
         self.load()
+        if not self.is_available():
+            print(f"[DuplicateService] DEGRADED: Skipping embedding for ticket {ticket_id} (model not available)")
+            return
         embedding = self.model.encode(text, convert_to_tensor=True)
         self._tickets.append((ticket_id, embedding, text))
         self.save_to_disk(ticket_id, text)
@@ -88,6 +113,15 @@ class DuplicateService:
             }
         """
         self.load()
+        
+        # If model is not available, return no duplicate found
+        if not self.is_available():
+            print("[DuplicateService] DEGRADED: Duplicate check skipped (model not available)")
+            return {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "similarity": 0.0,
+            }
         
         # Use provided threshold or default to global constant
         active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -7,6 +7,7 @@ class RagService:
     def __init__(self):
         self.model = None
         self._loaded = False
+        self._load_failed = False
         
         load_dotenv()
         url = os.environ.get("SUPABASE_URL")
@@ -16,11 +17,37 @@ class RagService:
         else:
             self.supabase = None
 
+    def is_available(self) -> bool:
+        """Check if the model is available for RAG queries."""
+        return self._loaded and not self._load_failed
+
     def load(self):
+        """Load the SentenceTransformer model for knowledge base queries."""
+        if self._loaded or self._load_failed:
+            return
+        
         print("[RAG] Loading SentenceTransformer for Knowledge Base...")
-        self.model = SentenceTransformer('all-MiniLM-L6-v2')
-        self._loaded = True
-        print("[RAG] Model loaded successfully.")
+        try:
+            # Check if a local model path is provided
+            model_path = os.environ.get("SENTENCE_TRANSFORMER_MODEL_PATH")
+            if model_path and os.path.exists(model_path):
+                print(f"[RAG] Loading from local path: {model_path}")
+                self.model = SentenceTransformer(model_path)
+            else:
+                # Download from HuggingFace
+                self.model = SentenceTransformer('all-MiniLM-L6-v2')
+            self._loaded = True
+            print("[RAG] Model loaded successfully.")
+        except Exception as e:
+            allow_degraded = os.environ.get("ALLOW_DEGRADED_STARTUP", "0") == "1"
+            self._load_failed = True
+            print(f"[RAG] Failed to load model: {e}")
+            if allow_degraded:
+                print("[RAG] DEGRADED: Continuing without model (ALLOW_DEGRADED_STARTUP=1)")
+                self.model = None
+                self._loaded = False
+            else:
+                raise
 
     def search_knowledge_base(self, text: str, threshold: float = 0.85, match_count: int = 1):
         """
@@ -28,6 +55,8 @@ class RagService:
         Returns the article text if found above threshold, else None.
         """
         if not self._loaded or not self.supabase:
+            if self._load_failed:
+                print("[RAG] DEGRADED: Knowledge base search skipped (model not available)")
             return None
 
         try:


### PR DESCRIPTION
## Summary
Fixes #54

Backend readiness was failing with 503 when `all-MiniLM-L6-v2` couldn't 
load in an offline/clean environment.

## Changes
- `duplicate_service.py` — try/except on model load, SENTENCE_TRANSFORMER_MODEL_PATH 
  support, is_available() method
- `rag_service.py` — same graceful degradation pattern
- `main.py` — /ready treats duplicate & RAG as optional when ALLOW_DEGRADED_STARTUP=1
- `.env.example` — documented new env vars

## Behavior After Fix
| Mode | /ready result |
|------|--------------|
| Online (default) | Full readiness 200 ✅ |
| Offline + `ALLOW_DEGRADED_STARTUP=1` | Graceful degradation 200 ✅ |
| Local model cache path set | Works air-gapped ✅ |

## Type of Change
- [x] Bug fix

Closes #54