### PR TITLE
fix: prevent voice visualizer freeze on recognition auto-pause

### DIFF
--- a/Frontend/src/user/pages/CreateTicket.jsx
+++ b/Frontend/src/user/pages/CreateTicket.jsx
@@ -33,6 +33,7 @@ const CreateTicket = () => {
     const [extractedOCR, setExtractedOCR] = useState('');
     const [isOcrLoading, setIsOcrLoading] = useState(false);
     const [isListening, setIsListening] = useState(false);
+    const isListeningRef = useRef(false);
     const fileInputRef = useRef(null);
     const navigate = useNavigate();
     const MAX_CHARS = 1000;
@@ -59,6 +60,7 @@ const CreateTicket = () => {
 
     useEffect(() => {
         return () => {
+            isListeningRef.current = false;
             if (recognitionRef.current) recognitionRef.current.stop();
             if (audioContextRef.current) audioContextRef.current.close();
             if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
@@ -166,13 +168,22 @@ const CreateTicket = () => {
                 console.error("Speech Recognition Error:", event.error);
                 if (event.error !== 'no-speech') {
                     setError(`Microphone error: ${event.error}`);
+                    stopListening();
                 }
             };
 
             recognition.onend = () => {
-                // Only stop visualizer if we actually intended to stop
-                if (!isListening) {
-                    if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
+                if (isListeningRef.current) {
+                    try {
+                        recognitionRef.current?.start();
+                    } catch {
+                        // start() may throw if already running — safely ignore
+                    }
+                } else {
+                    if (animationFrameRef.current) {
+                        cancelAnimationFrame(animationFrameRef.current);
+                        animationFrameRef.current = null;
+                    }
                 }
             };
 
@@ -180,6 +191,7 @@ const CreateTicket = () => {
             recognition.start();
 
             setIsListening(true);
+            isListeningRef.current = true;
             setShowVoiceModal(true);
             setVoiceTranscript('');
             setInterimVoice('');
@@ -193,6 +205,7 @@ const CreateTicket = () => {
 
     const stopListening = () => {
         setIsListening(false);
+        isListeningRef.current = false;
         if (recognitionRef.current) {
             recognitionRef.current.stop();
             recognitionRef.current = null;


### PR DESCRIPTION
## Summary
Fix stale closure in `recognition.onend` in `CreateTicket.jsx` by using `isListeningRef` instead of relying on stale React state.

This prevents the voice visualizer from freezing when the browser auto-pauses speech recognition after silence. The mic state and visual feedback now stay in sync.

Fixes #49

## Changes
- Added `isListeningRef` to track the live listening state inside speech recognition callbacks.
- Updated `recognition.onend` to restart recognition on silence pauses instead of stopping the visualizer.
- Kept cleanup behavior intact when the user manually stops the mic.
- Ensured the animation frame is canceled only on actual stop, not on silence auto-pause.

## Testing
- Not run locally.

## Manual verification
1. Log in and open `/create-ticket`
2. Click the mic and speak for a few seconds
3. Stay silent for ~7–10 seconds
4. Confirm the visualizer keeps running and the mic remains listening
5. Click the mic to stop
6. Confirm the visualizer stops and listening state clears cleanly