### PR TITLE
Fix tenant ticket orphaning by persisting company_id on save

### DIFF
--- a/Frontend/src/user/pages/TicketTracking.jsx
+++ b/Frontend/src/user/pages/TicketTracking.jsx
@@ -52,6 +52,7 @@ const TicketTracking = () => {
                     confidence: aiTicket.confidence,
                     image_url: aiTicket.image_url || null,
                     company: profile?.company || "System",
+                    company_id: profile?.company_id || null,
                     sla_breach_at: aiTicket.sla_breach_at,
                     metadata: {
                         confidence: aiTicket.confidence,

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ import json
 import datetime
 import traceback
 import warnings
+import logging
 from contextlib import asynccontextmanager
 
 # Suppress harmless PyTorch CPU pin_memory warning
@@ -513,11 +514,13 @@ async def save_ticket(request_body: TicketSaveRequest):
     if not supabase:
         raise HTTPException(status_code=500, detail="Supabase connection not initialized.")
 
+    logger = logging.getLogger(__name__)
     try:
         final_data = request_body.dict()
 
-        # Backfill tenant id from user profile when client payload omits it.
-        if not final_data.get("company_id") and request_body.user_id:
+        # Resolve tenant linkage from user profile with authorization validation.
+        profile = {}
+        if request_body.user_id:
             try:
                 profile_res = (
                     supabase.table("profiles")
@@ -527,12 +530,33 @@ async def save_ticket(request_body: TicketSaveRequest):
                     .execute()
                 )
                 profile = profile_res.data or {}
-                if profile.get("company_id"):
-                    final_data["company_id"] = profile["company_id"]
-                if not final_data.get("company") and profile.get("company"):
-                    final_data["company"] = profile["company"]
+                if not profile:
+                    raise HTTPException(status_code=404, detail="User profile not found")
+            except HTTPException:
+                raise
             except Exception as profile_error:
-                print(f"[WARNING] Failed to resolve company_id from profile: {profile_error}")
+                logger.error(f"Tenant resolution error for user {request_body.user_id}: {profile_error}")
+                raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
+
+        # Validate tenant consistency and authorization.
+        profile_company_id = profile.get("company_id")
+        if final_data.get("company_id"):
+            # User provided company_id: verify it matches their profile.
+            if profile_company_id and final_data["company_id"] != profile_company_id:
+                logger.warning(f"Tenant mismatch: user {request_body.user_id} attempted {final_data['company_id']}, assigned to {profile_company_id}")
+                raise HTTPException(status_code=403, detail="User not authorized for this tenant")
+        elif profile_company_id:
+            # Backfill company_id from profile.
+            final_data["company_id"] = profile_company_id
+        elif request_body.user_id:
+            # User has no tenant assignment.
+            raise HTTPException(status_code=400, detail="User has no tenant assignment")
+
+        # Backfill company name if missing.
+        if not final_data.get("company") and profile.get("company"):
+            final_data["company"] = profile["company"]
+
+        logger.info(f"Tenant linkage: user_id={request_body.user_id}, company_id={final_data.get('company_id')}")
 
         res = supabase.table("tickets").insert(final_data).execute()
         

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ import datetime
 import traceback
 import warnings
 import logging
+import hashlib
 from contextlib import asynccontextmanager
 
 # Suppress harmless PyTorch CPU pin_memory warning
@@ -535,7 +536,8 @@ async def save_ticket(request_body: TicketSaveRequest):
             except HTTPException:
                 raise
             except Exception as profile_error:
-                logger.error(f"Tenant resolution error for user {request_body.user_id}: {profile_error}")
+                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+                logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
                 raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
 
         # Validate tenant consistency and authorization.
@@ -543,7 +545,8 @@ async def save_ticket(request_body: TicketSaveRequest):
         if final_data.get("company_id"):
             # User provided company_id: verify it matches their profile.
             if profile_company_id and final_data["company_id"] != profile_company_id:
-                logger.warning(f"Tenant mismatch: user {request_body.user_id} attempted {final_data['company_id']}, assigned to {profile_company_id}")
+                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+                logger.warning(f"Tenant mismatch: user {user_hash} attempted {final_data['company_id']}, assigned to {profile_company_id}")
                 raise HTTPException(status_code=403, detail="User not authorized for this tenant")
         elif profile_company_id:
             # Backfill company_id from profile.
@@ -556,7 +559,9 @@ async def save_ticket(request_body: TicketSaveRequest):
         if not final_data.get("company") and profile.get("company"):
             final_data["company"] = profile["company"]
 
-        logger.info(f"Tenant linkage: user_id={request_body.user_id}, company_id={final_data.get('company_id')}")
+        user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+        logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
+
 
         res = supabase.table("tickets").insert(final_data).execute()
         

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,7 +85,8 @@ class TicketSaveRequest(BaseModel):
     is_duplicate: bool
     confidence: float
     image_url: str | None = None
-    company: str
+    company: str | None = None
+    company_id: str | None = None
     sla_breach_at: str
     metadata: dict
     entities: list = []
@@ -514,6 +515,25 @@ async def save_ticket(request_body: TicketSaveRequest):
 
     try:
         final_data = request_body.dict()
+
+        # Backfill tenant id from user profile when client payload omits it.
+        if not final_data.get("company_id") and request_body.user_id:
+            try:
+                profile_res = (
+                    supabase.table("profiles")
+                    .select("company_id, company")
+                    .eq("id", request_body.user_id)
+                    .single()
+                    .execute()
+                )
+                profile = profile_res.data or {}
+                if profile.get("company_id"):
+                    final_data["company_id"] = profile["company_id"]
+                if not final_data.get("company") and profile.get("company"):
+                    final_data["company"] = profile["company"]
+            except Exception as profile_error:
+                print(f"[WARNING] Failed to resolve company_id from profile: {profile_error}")
+
         res = supabase.table("tickets").insert(final_data).execute()
         
         if not res.data:


### PR DESCRIPTION
## Summary
Fixes a multi-tenant data integrity bug where ticket records could be created without `company_id`, causing tenant-scoped dashboards and queries to miss those tickets.

Fixes #67

## Root cause
- Frontend `/tickets/save` payload included `company` but omitted `company_id`.
- Backend accepted and inserted payload as-is.
- Multiple read paths filter by `company_id`, so null linkage creates orphaned records from tenant perspective.

## Changes
- Frontend: add `company_id: profile?.company_id || null` in `TicketTracking` save payload.
- Backend:
  - `TicketSaveRequest.company` made optional for safer compatibility.
  - Added `company_id` field to `TicketSaveRequest`.
  - In `/tickets/save`, if `company_id` is missing and `user_id` exists, backfill from `profiles` (`company_id`, and `company` fallback).

## Validation
- `python -m py_compile backend/main.py` passes.
- Diff reviewed for targeted scope (2 files).

## Risk
Low. Changes are backward-compatible and only affect ticket save-path tenant linkage behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable company handling when escalating tickets: the client now includes company identifier when present, and the server validates or backfills company information from user profile data. This prevents mismatched tenant data, returns clear errors when profile tenant info is missing, and improves consistency of saved ticket records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->