### PR TITLE
Fix SLA timestamp propagation in ticket flow (fix#63)

### DIFF
--- a/Frontend/src/services/aiAssistant.js
+++ b/Frontend/src/services/aiAssistant.js
@@ -159,6 +159,12 @@ const localFallbackSummary = (issueText) => {
     return { summary, image_description: '' };
 };
 
+const getSlaBreachAt = (priority = 'Medium') => {
+    const hoursMap = { Critical: 2, High: 8, Medium: 24, Low: 72 };
+    const slaHours = hoursMap[priority] || 24;
+    return new Date(Date.now() + slaHours * 60 * 60 * 1000).toISOString();
+};
+
 
 // ============================================================
 // EXPORT 1: askAI — Used by the chat troubleshooting assistant
@@ -231,11 +237,15 @@ User Issue: "${issueText}"${imageNote}${imageInstruction}`;
             subcategory: parsed.subcategory,
             priority: parsed.priority,
             assigned_team: parsed.assigned_team,
-            confidence: parsed.confidence || 0.9
+            confidence: parsed.confidence || 0.9,
+            sla_breach_at: getSlaBreachAt(parsed.priority)
         };
     } catch (err) {
         // All providers failed — use smart local fallback so ticket flow never breaks
         console.warn('[analyzeTicketWithAI] All providers exhausted, using local fallback:', err.message);
-        return localFallbackSummary(issueText);
+        return {
+            ...localFallbackSummary(issueText),
+            sla_breach_at: getSlaBreachAt()
+        };
     }
 };

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -7,6 +7,12 @@ const API_BASE_URL = API_CONFIG.BACKEND_URL;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const getSlaBreachAt = (priority = 'Low') => {
+  const hoursMap = { Critical: 2, High: 8, Medium: 24, Low: 72 };
+  const slaHours = hoursMap[priority] || 72;
+  return new Date(Date.now() + slaHours * 60 * 60 * 1000).toISOString();
+};
+
 // Safe helper to get data from storage or default
 const getStorage = (key, defaultData) => {
   try {
@@ -95,7 +101,8 @@ export const api = {
           reasoning: result.reasoning,
           decision_factors: result.decision_factors,
           image_description: result.image_description,
-          ocr_text: result.ocr_text
+          ocr_text: result.ocr_text,
+          sla_breach_at: result.sla_breach_at || getSlaBreachAt(result.priority)
         }
       };
     } catch (error) {
@@ -112,7 +119,8 @@ export const api = {
           routing_confidence: 0.5,
           duplicate_probability: 0.0,
           summary: issueText.substring(0, 50) + "...",
-          entities: []
+          entities: [],
+          sla_breach_at: getSlaBreachAt("Medium")
         }
       };
     }

--- a/Frontend/src/user/pages/TicketTracking.jsx
+++ b/Frontend/src/user/pages/TicketTracking.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
     Activity, CheckCircle2, ShieldCheck, User,
@@ -20,13 +20,19 @@ const TicketTracking = () => {
     const [error, setError] = useState(null);
     const [createdTicket, setCreatedTicket] = useState(null);
     const hasCreated = useRef(false);
+    const resolutionSteps = useMemo(() => location.state?.resolutionSteps || [], [location.state?.resolutionSteps]);
+
+    const getSlaBreachAt = (priority = 'Medium') => {
+        const hoursMap = { Critical: 2, High: 8, Medium: 24, Low: 72 };
+        const slaHours = hoursMap[priority] || 24;
+        return new Date(Date.now() + slaHours * 60 * 60 * 1000).toISOString();
+    };
+
     useEffect(() => {
         if (!aiTicket) {
             navigate('/create-ticket');
             return;
         }
-
-        const resolutionSteps = location.state?.resolutionSteps || [];
 
         const finalizeTracking = async () => {
             if (hasCreated.current) return;
@@ -54,7 +60,7 @@ const TicketTracking = () => {
                     image_url: aiTicket.image_url || null,
                     company: profile?.company || null,
                     company_id: profile?.company_id || null,
-                    sla_breach_at: aiTicket.sla_breach_at,
+                    sla_breach_at: aiTicket.sla_breach_at || getSlaBreachAt(aiTicket.priority),
                     metadata: {
                         confidence: aiTicket.confidence,
                         entities: aiTicket.entities,
@@ -92,7 +98,7 @@ const TicketTracking = () => {
         };
 
         finalizeTracking();
-    }, [aiTicket, addTicket, navigate, user, profile?.company, location.state]);
+    }, [aiTicket, addTicket, navigate, user, profile?.company, profile?.company_id, resolutionSteps]);
 
     if (!aiTicket) return null;
 


### PR DESCRIPTION
This PR fixes the ticket finalization flow so `sla_breach_at` is consistently preserved from AI analysis through the final ticket save.

### What changed

* Propagates `sla_breach_at` through the frontend AI analysis mapping
* Adds a fallback SLA timestamp when the backend response omits the field
* Ensures the final ticket save payload always includes a valid `sla_breach_at`
* Stabilizes the ticket tracking resolution steps value to keep effect dependencies clean

### Validation

* Frontend lint passed for the touched files
* Frontend production build completed successfully
Closes #63
