### PR TITLE
Secure ticket audit logs and automated escalation actions (fix #72)

### DIFF
--- a/Frontend/src/admin/components/TicketAuditTimeline.jsx
+++ b/Frontend/src/admin/components/TicketAuditTimeline.jsx
@@ -1,0 +1,299 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import { AlertTriangle, ArrowRight, History, Loader2, ShieldCheck, Sparkles, User } from 'lucide-react';
+import { supabase } from '../../lib/supabaseClient';
+import { API_CONFIG } from '../../config';
+import { formatFullTimestamp } from '../../utils/dateUtils';
+
+const ACTION_META = {
+    TICKET_CREATED: {
+        label: 'Ticket Created',
+        tone: 'emerald',
+        icon: Sparkles,
+        description: 'The ticket entered the secure audit trail.'
+    },
+    STATUS_CHANGED: {
+        label: 'Status Changed',
+        tone: 'blue',
+        icon: ArrowRight,
+        description: 'The ticket status was updated.'
+    },
+    STATUS_ESCALATED: {
+        label: 'Status Escalated',
+        tone: 'orange',
+        icon: AlertTriangle,
+        description: 'The ticket moved into an escalation state.'
+    },
+    PRIORITY_CHANGED: {
+        label: 'Priority Changed',
+        tone: 'amber',
+        icon: ArrowRight,
+        description: 'The ticket priority was revised.'
+    },
+    PRIORITY_ESCALATED: {
+        label: 'Priority Escalated',
+        tone: 'red',
+        icon: AlertTriangle,
+        description: 'The ticket priority increased.'
+    },
+    TICKET_ASSIGNED: {
+        label: 'Ticket Assigned',
+        tone: 'emerald',
+        icon: User,
+        description: 'Ownership was reassigned.'
+    },
+    TEAM_ROUTED: {
+        label: 'Team Routed',
+        tone: 'emerald',
+        icon: ShieldCheck,
+        description: 'The ticket was routed to a new support team.'
+    },
+    METADATA_UPDATED: {
+        label: 'Metadata Updated',
+        tone: 'slate',
+        icon: History,
+        description: 'Supporting details changed on the ticket.'
+    },
+    AUTO_ESCALATED: {
+        label: 'Auto Escalated',
+        tone: 'red',
+        icon: AlertTriangle,
+        description: 'A scheduled escalation rule fired automatically.'
+    }
+};
+
+const TONE_CLASSES = {
+    emerald: 'border-emerald-200 bg-emerald-50/80 text-emerald-700',
+    blue: 'border-blue-200 bg-blue-50/80 text-blue-700',
+    amber: 'border-amber-200 bg-amber-50/80 text-amber-700',
+    orange: 'border-orange-200 bg-orange-50/80 text-orange-700',
+    red: 'border-red-200 bg-red-50/80 text-red-700',
+    slate: 'border-slate-200 bg-slate-50/80 text-slate-700'
+};
+
+const formatFieldValue = (value) => {
+    if (value === null || value === undefined || value === '') return 'None';
+    if (typeof value === 'object') {
+        if ('value' in value) return formatFieldValue(value.value);
+        if ('reason' in value) return String(value.reason);
+        return JSON.stringify(value);
+    }
+    return String(value);
+};
+
+const extractValue = (value) => {
+    if (value && typeof value === 'object' && 'value' in value) return value.value;
+    return value;
+};
+
+const getActorLabel = (record) => {
+    const profile = record.performed_by_profile;
+    if (profile?.full_name) return profile.full_name;
+    if (profile?.email) return profile.email;
+    if (record.performed_by) return 'System / API';
+    return 'System';
+};
+
+const buildChangeDescription = (record) => {
+    const action = record.action || 'TICKET_UPDATED';
+    if (action === 'TICKET_CREATED') return 'Ticket was created and entered the audit ledger.';
+    if (action === 'AUTO_ESCALATED') {
+        const reason = record.new_value?.reason || record.old_value?.reason || 'stale state';
+        return `Automated escalation logged because the ticket remained ${reason}.`;
+    }
+
+    const field = record.old_value?.field || record.new_value?.field || 'value';
+    const previous = formatFieldValue(extractValue(record.old_value));
+    const next = formatFieldValue(extractValue(record.new_value));
+
+    if (action === 'STATUS_CHANGED' || action === 'STATUS_ESCALATED') {
+        return `Status changed from ${previous} to ${next}.`;
+    }
+    if (action === 'PRIORITY_CHANGED' || action === 'PRIORITY_ESCALATED') {
+        return `Priority moved from ${previous} to ${next}.`;
+    }
+    if (action === 'TICKET_ASSIGNED') {
+        return `Assignment updated from ${previous} to ${next}.`;
+    }
+    if (action === 'TEAM_ROUTED') {
+        return `Support routing changed from ${previous} to ${next}.`;
+    }
+    if (action === 'METADATA_UPDATED') {
+        return `Context metadata was updated for ${field}.`;
+    }
+
+    return `Audited field ${field} changed from ${previous} to ${next}.`;
+};
+
+const buildBadgeTitle = (record) => {
+    const action = record.action || 'TICKET_UPDATED';
+    const meta = ACTION_META[action];
+    return meta?.description || 'Tracked ticket mutation';
+};
+
+const mergeLogs = (existing, incoming) => {
+    const map = new Map();
+    [...existing, ...incoming].forEach((item) => {
+        if (item?.id) map.set(item.id, item);
+    });
+    return Array.from(map.values()).sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+};
+
+const TicketAuditTimeline = ({ ticketId, companyId }) => {
+    const [logs, setLogs] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        if (!ticketId || !companyId) {
+            setLogs([]);
+            setLoading(false);
+            return undefined;
+        }
+
+        let cancelled = false;
+
+        const loadLogs = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const { data } = await axios.get(`${API_CONFIG.BACKEND_URL}/tickets/${ticketId}/audit_logs`, {
+                    params: { company_id: companyId }
+                });
+
+                if (!cancelled) {
+                    setLogs(Array.isArray(data) ? data : []);
+                }
+            } catch (err) {
+                if (!cancelled) {
+                    setError(err?.response?.data?.detail || err.message || 'Failed to load audit history.');
+                }
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        loadLogs();
+
+        const channel = supabase
+            .channel(`ticket_audit_${ticketId}`)
+            .on(
+                'postgres_changes',
+                {
+                    event: 'INSERT',
+                    schema: 'public',
+                    table: 'audit_logs',
+                    filter: `ticket_id=eq.${ticketId}`
+                },
+                (payload) => {
+                    setLogs((current) => mergeLogs(current, [payload.new]));
+                }
+            )
+            .subscribe();
+
+        return () => {
+            cancelled = true;
+            supabase.removeChannel(channel);
+        };
+    }, [ticketId, companyId]);
+
+    const hasLogs = useMemo(() => logs.length > 0, [logs.length]);
+
+    return (
+        <section className="rounded-[28px] border border-emerald-100/70 bg-white/70 backdrop-blur-xl shadow-[0_18px_60px_rgba(15,31,18,0.08)] overflow-hidden">
+            <div className="px-6 sm:px-8 pt-6 pb-5 border-b border-emerald-50 bg-gradient-to-r from-white/90 via-emerald-50/60 to-white/80">
+                <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-2xl bg-emerald-600 text-white flex items-center justify-center shadow-lg shadow-emerald-500/20">
+                        <History className="w-5 h-5" />
+                    </div>
+                    <div>
+                        <p className="text-[10px] uppercase tracking-[0.24em] font-black text-emerald-500">Audit Log Timeline</p>
+                        <h3 className="text-lg font-black text-slate-900">Secure change history</h3>
+                    </div>
+                    <span className="ml-auto text-[10px] uppercase tracking-[0.18em] font-black text-slate-400 bg-white/80 border border-slate-100 rounded-full px-3 py-1">
+                        Chronological
+                    </span>
+                </div>
+            </div>
+
+            <div className="px-6 sm:px-8 py-6">
+                {loading ? (
+                    <div className="flex items-center gap-3 text-sm font-semibold text-slate-500">
+                        <Loader2 className="w-4 h-4 animate-spin text-emerald-600" />
+                        Loading secure audit history...
+                    </div>
+                ) : error ? (
+                    <div className="rounded-2xl border border-rose-200 bg-rose-50/70 p-4 text-sm text-rose-700">
+                        {error}
+                    </div>
+                ) : !hasLogs ? (
+                    <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/70 p-5 text-sm text-slate-500">
+                        No audit events have been recorded yet.
+                    </div>
+                ) : (
+                    <div className="relative space-y-4 before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-gradient-to-b before:from-emerald-200 before:via-slate-200 before:to-transparent">
+                        {logs.map((record) => {
+                            const meta = ACTION_META[record.action] || ACTION_META.METADATA_UPDATED;
+                            const Icon = meta.icon;
+                            const toneClass = TONE_CLASSES[meta.tone] || TONE_CLASSES.slate;
+                            const actorLabel = getActorLabel(record);
+                            const description = buildChangeDescription(record);
+                            const fieldName = record.old_value?.field || record.new_value?.field || record.action || 'event';
+                            const previousValue = formatFieldValue(extractValue(record.old_value));
+                            const nextValue = formatFieldValue(extractValue(record.new_value));
+
+                            return (
+                                <article key={record.id} className="relative pl-10">
+                                    <div className={`absolute left-[6px] top-4 w-4 h-4 rounded-full border-4 border-white shadow ${record.action?.includes('ESCALATED') ? 'bg-rose-500' : 'bg-emerald-500'}`}></div>
+                                    <div className="rounded-[22px] border border-slate-100 bg-white/80 backdrop-blur-md shadow-[0_12px_30px_rgba(15,31,18,0.06)] p-4 sm:p-5">
+                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                            <div className="space-y-2">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <span
+                                                        className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${toneClass}`}
+                                                        title={buildBadgeTitle(record)}
+                                                    >
+                                                        <Icon className="w-3.5 h-3.5" />
+                                                        {meta.label}
+                                                    </span>
+                                                    <span className="text-[10px] uppercase tracking-[0.2em] font-black text-slate-400">
+                                                        {fieldName}
+                                                    </span>
+                                                </div>
+                                                <p className="text-sm font-semibold text-slate-900 leading-6">
+                                                    {description}
+                                                </p>
+                                            </div>
+                                            <div className="text-right shrink-0">
+                                                <p className="text-[10px] uppercase tracking-[0.18em] font-black text-slate-400">Performed By</p>
+                                                <p className="text-sm font-bold text-slate-800" title={record.performed_by || 'System generated'}>
+                                                    {actorLabel}
+                                                </p>
+                                                <p className="text-xs text-slate-500 mt-1">
+                                                    {formatFullTimestamp(record.created_at)}
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                            <div className="rounded-2xl border border-slate-100 bg-slate-50/80 p-3">
+                                                <p className="text-[10px] uppercase tracking-[0.18em] font-black text-slate-400 mb-1">Previous Value</p>
+                                                <p className="text-sm font-semibold text-slate-800 break-words">{previousValue}</p>
+                                            </div>
+                                            <div className="rounded-2xl border border-slate-100 bg-emerald-50/70 p-3">
+                                                <p className="text-[10px] uppercase tracking-[0.18em] font-black text-emerald-500 mb-1">Current Value</p>
+                                                <p className="text-sm font-semibold text-emerald-900 break-words">{nextValue}</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </article>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </section>
+    );
+};
+
+export default TicketAuditTimeline;

--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -16,6 +16,7 @@ import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
 import { formatFullTimestamp } from "../../utils/dateUtils";
 import TicketTimeline from "../../user/components/TicketTimeline";
+import TicketAuditTimeline from "../components/TicketAuditTimeline";
 
 const AdminTicketDetail = () => {
     const { ticket_id } = useParams();
@@ -342,6 +343,8 @@ const AdminTicketDetail = () => {
                         </div>
                         <TicketTimeline ticket={ticket} />
                     </div>
+
+                    <TicketAuditTimeline ticketId={ticket.id} companyId={ticket.company_id} />
                 </div>
 
                 {/* AI Column */}

--- a/backend/main.py
+++ b/backend/main.py
@@ -55,6 +55,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from backend.services.classifier_service import ClassifierService
 from backend.services.classifier_v2 import classifier_v2
 from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
+from backend.services.audit_service import AuditLogService, AuditLogAccessError
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
@@ -216,6 +217,24 @@ class TicketRecord(BaseModel):
     messages: list[Message] = []
     metadata: dict = {}
     timeline: dict = {} # Milestones: created, analyzed, triaged, routed, in_progress, resolved
+
+
+class AuditLogProfile(BaseModel):
+    full_name: str | None = None
+    email: str | None = None
+    profile_picture: str | None = None
+
+
+class AuditLogRecord(BaseModel):
+    id: str
+    ticket_id: str
+    company_id: str
+    performed_by: str | None = None
+    action: str
+    old_value: dict | list | str | None = None
+    new_value: dict | list | str | None = None
+    created_at: str
+    performed_by_profile: AuditLogProfile | None = None
 
 
 # --- In-Memory Database (to be replaced with SQL later) ---
@@ -780,6 +799,19 @@ async def get_ticket_by_id(ticket_id: str):
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return res.data
+
+
+@app.get("/tickets/{ticket_id}/audit_logs", response_model=list[AuditLogRecord])
+async def get_ticket_audit_logs(ticket_id: str, company_id: str):
+    """Return a company-scoped chronological audit trail for a ticket."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    try:
+        service = AuditLogService(supabase)
+        return service.get_ticket_audit_logs(ticket_id, company_id)
+    except AuditLogAccessError as err:
+        raise HTTPException(status_code=err.status_code, detail=err.detail)
 
 
 @app.post("/tickets", response_model=TicketRecord)

--- a/backend/services/audit_service.py
+++ b/backend/services/audit_service.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+
+class AuditLogAccessError(Exception):
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class AuditLogService:
+    def __init__(self, supabase_client):
+        self.supabase = supabase_client
+
+    def get_ticket_audit_logs(self, ticket_id: str, company_id: str):
+        ticket_result = (
+            self.supabase.table("tickets")
+            .select("id, company_id")
+            .eq("id", ticket_id)
+            .single()
+            .execute()
+        )
+
+        ticket_row = ticket_result.data
+        if not ticket_row:
+            raise AuditLogAccessError(404, "Ticket not found")
+
+        ticket_company_id = str(ticket_row.get("company_id") or "")
+        requested_company_id = str(company_id or "")
+        if not ticket_company_id or ticket_company_id != requested_company_id:
+            raise AuditLogAccessError(404, "Ticket not found")
+
+        logs_result = (
+            self.supabase.table("audit_logs")
+            .select(
+                "id, ticket_id, company_id, performed_by, action, old_value, new_value, created_at, performed_by_profile:profiles!audit_logs_performed_by_fkey(full_name, email, profile_picture)"
+            )
+            .eq("ticket_id", ticket_id)
+            .eq("company_id", company_id)
+            .order("created_at")
+            .execute()
+        )
+
+        return logs_result.data or []

--- a/backend/tests/test_audit_service.py
+++ b/backend/tests/test_audit_service.py
@@ -1,0 +1,87 @@
+import unittest
+
+from backend.services.audit_service import AuditLogAccessError, AuditLogService
+
+
+class FakeResult:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeQuery:
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def select(self, *_args, **_kwargs):
+        self.calls.append(("select", _args, _kwargs))
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        self.calls.append(("eq", _args, _kwargs))
+        return self
+
+    def single(self):
+        self.calls.append(("single", (), {}))
+        return self
+
+    def order(self, *_args, **_kwargs):
+        self.calls.append(("order", _args, _kwargs))
+        return self
+
+    def execute(self):
+        self.calls.append(("execute", (), {}))
+        return self._result
+
+
+class FakeSupabaseClient:
+    def __init__(self, ticket_row, audit_rows):
+        self.ticket_query = FakeQuery(FakeResult(ticket_row))
+        self.audit_query = FakeQuery(FakeResult(audit_rows))
+
+    def table(self, name):
+        if name == "tickets":
+            return self.ticket_query
+        if name == "audit_logs":
+            return self.audit_query
+        raise AssertionError(f"Unexpected table: {name}")
+
+
+class AuditLogServiceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_rejects_cross_company_ticket_access(self):
+        client = FakeSupabaseClient({"id": "ticket-1", "company_id": "company-a"}, [])
+        service = AuditLogService(client)
+
+        with self.assertRaises(AuditLogAccessError) as ctx:
+            service.get_ticket_audit_logs("ticket-1", "company-b")
+
+        self.assertEqual(ctx.exception.status_code, 404)
+        self.assertEqual(ctx.exception.detail, "Ticket not found")
+
+    async def test_returns_logs_for_matching_company(self):
+        rows = [
+            {
+                "id": "log-1",
+                "ticket_id": "ticket-1",
+                "company_id": "company-a",
+                "performed_by": "user-1",
+                "action": "STATUS_CHANGED",
+                "old_value": {"field": "status", "value": "open"},
+                "new_value": {"field": "status", "value": "in_progress"},
+                "created_at": "2026-05-22T10:00:00Z",
+                "performed_by_profile": {"full_name": "Alex Admin"},
+            }
+        ]
+        client = FakeSupabaseClient({"id": "ticket-1", "company_id": "company-a"}, rows)
+        service = AuditLogService(client)
+
+        result = service.get_ticket_audit_logs("ticket-1", "company-a")
+
+        self.assertEqual(result, rows)
+        self.assertEqual(client.ticket_query.calls[0][0], "select")
+        self.assertEqual(client.audit_query.calls[0][0], "select")
+        self.assertEqual(client.audit_query.calls[-1][0], "execute")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/supabase/migrations/20260522000000_audit_logs.sql
+++ b/supabase/migrations/20260522000000_audit_logs.sql
@@ -1,0 +1,236 @@
+create extension if not exists pg_cron;
+
+create table if not exists public.audit_logs (
+    id uuid primary key default gen_random_uuid(),
+    ticket_id uuid not null references public.tickets(id) on delete cascade,
+    company_id uuid not null references public.companies(id) on delete cascade,
+    performed_by uuid references public.profiles(id) on delete set null,
+    action varchar(64) not null,
+    old_value jsonb,
+    new_value jsonb,
+    created_at timestamptz not null default timezone('utc'::text, now())
+);
+
+create index if not exists audit_logs_ticket_company_created_idx
+    on public.audit_logs (ticket_id, company_id, created_at desc);
+
+alter table public.audit_logs enable row level security;
+
+drop policy if exists "Audit logs are readable within the same company" on public.audit_logs;
+
+create policy "Audit logs are readable within the same company"
+on public.audit_logs
+for select
+to authenticated
+using (
+    company_id = (
+        select p.company_id
+        from public.profiles p
+        where p.id = auth.uid()
+    )
+);
+
+create or replace function public.priority_rank(priority_text text)
+returns integer
+language sql
+immutable
+as $$
+    select case lower(coalesce(priority_text, ''))
+        when 'critical' then 4
+        when 'high' then 3
+        when 'medium' then 2
+        when 'low' then 1
+        else 0
+    end;
+$$;
+
+create or replace function public.log_ticket_audit()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    actor_id uuid := auth.uid();
+    status_action varchar(64);
+    priority_action varchar(64);
+begin
+    if tg_op = 'INSERT' then
+        insert into public.audit_logs (
+            ticket_id, company_id, performed_by, action, old_value, new_value
+        ) values (
+            new.id,
+            new.company_id,
+            actor_id,
+            'TICKET_CREATED',
+            null,
+            jsonb_build_object(
+                'field', 'status',
+                'value', new.status,
+                'summary', new.subject,
+                'priority', new.priority,
+                'assigned_team', new.assigned_team
+            )
+        );
+        return new;
+    end if;
+
+    if new.status is distinct from old.status then
+        status_action := case
+            when lower(coalesce(new.status, '')) like '%escalat%' then 'STATUS_ESCALATED'
+            else 'STATUS_CHANGED'
+        end;
+
+        insert into public.audit_logs (
+            ticket_id, company_id, performed_by, action, old_value, new_value
+        ) values (
+            new.id,
+            new.company_id,
+            actor_id,
+            status_action,
+            jsonb_build_object('field', 'status', 'value', old.status),
+            jsonb_build_object('field', 'status', 'value', new.status)
+        );
+    end if;
+
+    if new.priority is distinct from old.priority then
+        priority_action := case
+            when public.priority_rank(new.priority) > public.priority_rank(old.priority) then 'PRIORITY_ESCALATED'
+            else 'PRIORITY_CHANGED'
+        end;
+
+        insert into public.audit_logs (
+            ticket_id, company_id, performed_by, action, old_value, new_value
+        ) values (
+            new.id,
+            new.company_id,
+            actor_id,
+            priority_action,
+            jsonb_build_object('field', 'priority', 'value', old.priority),
+            jsonb_build_object('field', 'priority', 'value', new.priority)
+        );
+    end if;
+
+    if new.assigned_agent_id is distinct from old.assigned_agent_id then
+        insert into public.audit_logs (
+            ticket_id, company_id, performed_by, action, old_value, new_value
+        ) values (
+            new.id,
+            new.company_id,
+            actor_id,
+            'TICKET_ASSIGNED',
+            jsonb_build_object('field', 'assigned_agent_id', 'value', old.assigned_agent_id),
+            jsonb_build_object('field', 'assigned_agent_id', 'value', new.assigned_agent_id)
+        );
+    end if;
+
+    if new.assigned_team is distinct from old.assigned_team then
+        insert into public.audit_logs (
+            ticket_id, company_id, performed_by, action, old_value, new_value
+        ) values (
+            new.id,
+            new.company_id,
+            actor_id,
+            'TEAM_ROUTED',
+            jsonb_build_object('field', 'assigned_team', 'value', old.assigned_team),
+            jsonb_build_object('field', 'assigned_team', 'value', new.assigned_team)
+        );
+    end if;
+
+    if new.metadata is distinct from old.metadata then
+        insert into public.audit_logs (
+            ticket_id, company_id, performed_by, action, old_value, new_value
+        ) values (
+            new.id,
+            new.company_id,
+            actor_id,
+            'METADATA_UPDATED',
+            old.metadata,
+            new.metadata
+        );
+    end if;
+
+    return new;
+end;
+$$;
+
+drop trigger if exists ticket_audit_logs_trigger on public.tickets;
+
+create trigger ticket_audit_logs_trigger
+after insert or update on public.tickets
+for each row
+execute function public.log_ticket_audit();
+
+create or replace function public.log_stale_ticket_escalations()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    insert into public.audit_logs (
+        ticket_id,
+        company_id,
+        performed_by,
+        action,
+        old_value,
+        new_value
+    )
+    select
+        t.id,
+        t.company_id,
+        null,
+        'AUTO_ESCALATED',
+        jsonb_build_object(
+            'field', 'ticket_state',
+            'status', t.status,
+            'assigned_agent_id', t.assigned_agent_id,
+            'age_minutes', floor(extract(epoch from (now() - t.created_at)) / 60)::int
+        ),
+        jsonb_build_object(
+            'reason', case
+                when t.assigned_agent_id is null then 'unassigned'
+                else 'unanswered'
+            end,
+            'threshold_minutes', case
+                when public.priority_rank(t.priority) >= 3 then 60
+                else 120
+            end,
+            'escalation_level', case
+                when public.priority_rank(t.priority) >= 4 then 'critical'
+                when public.priority_rank(t.priority) >= 3 then 'high'
+                else 'standard'
+            end
+        )
+    from public.tickets t
+    where lower(coalesce(t.status, '')) not in ('resolved', 'closed', 'done')
+      and (
+        (t.assigned_agent_id is null and t.created_at <= now() - interval '2 hours')
+        or (t.assigned_agent_id is not null and coalesce(t.updated_at, t.created_at) <= now() - interval '4 hours')
+      )
+      and not exists (
+        select 1
+        from public.audit_logs a
+        where a.ticket_id = t.id
+          and a.action = 'AUTO_ESCALATED'
+          and a.created_at >= now() - interval '6 hours'
+      );
+end;
+$$;
+
+do $$
+begin
+    if exists (select 1 from pg_extension where extname = 'pg_cron') then
+        if not exists (
+            select 1
+            from cron.job
+            where jobname = 'ticket-escalation-audit'
+        ) then
+            perform cron.schedule(
+                'ticket-escalation-audit',
+                '*/15 * * * *',
+                $schedule$select public.log_stale_ticket_escalations();$schedule$
+            );
+        end if;
+    end if;
+end $$;


### PR DESCRIPTION
## Summary

This PR adds secure ticket audit logging and automated escalation tracking for enterprise support workflows.

### What changed

* Added a new `audit_logs` Supabase table with row-level security scoped by company
* Added database triggers on `tickets` to automatically record:

  * status changes
  * priority changes and escalations
  * assignment and routing updates
  * metadata updates
  * ticket creation
* Added a scheduled escalation function to log stale tickets that remain unassigned or unanswered for too long
* Added a backend endpoint to fetch ticket audit history:

  * `GET /tickets/{ticket_id}/audit_logs`
* Added a company-scoped backend audit service with test coverage to prevent cross-company access
* Added a glassmorphic Audit Log Timeline section in the admin ticket detail view

### Validation

* Backend unit tests passed
* Frontend production build passed
* Frontend files passed lint checks cleanly
closes #72 