### PR TITLE
test: cover ticket route tenant boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: HELPDESK.AI Continuous Integration (CI)
 
 on:
     push:
-        branches: [main]
+        branches: [main, gssoc]
     pull_request:
-        branches: [main]
+        branches: [main, gssoc]
 
 jobs:
     # --- JOB 1: Frontend Build Verification ---
@@ -49,6 +49,11 @@ jobs:
               run: |
                   cd backend
                   pip install -r requirements.txt
+                  pip install -r requirements-dev.txt
+
+            - name: Run Backend Route Tests
+              run: |
+                  pytest backend/tests
 
             - name: Verify Model Loading (Classifier Service)
               # This checks if the distilbert models are correctly structured and loadable

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,8 @@ POST /ai/analyze_ticket  →  full analysis of a support ticket
 GET  /health             →  service health check
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import uuid
@@ -786,6 +788,8 @@ async def save_ticket(request_body: TicketSaveRequest):
             response["duplicate_index_warning"] = duplicate_index_warning
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=8.0.0
+httpx>=0.27.0
+eval-type-backport>=0.2.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,159 @@
+import importlib
+import datetime as dt
+import sys
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _install_slowapi_stub():
+    slowapi = types.ModuleType("slowapi")
+
+    class Limiter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def limit(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    slowapi.Limiter = Limiter
+    slowapi._rate_limit_exceeded_handler = lambda *args, **kwargs: None
+
+    util = types.ModuleType("slowapi.util")
+    util.get_remote_address = lambda request: "127.0.0.1"
+
+    errors = types.ModuleType("slowapi.errors")
+
+    class RateLimitExceeded(Exception):
+        pass
+
+    errors.RateLimitExceeded = RateLimitExceeded
+
+    sys.modules["slowapi"] = slowapi
+    sys.modules["slowapi.util"] = util
+    sys.modules["slowapi.errors"] = errors
+
+
+def _install_dotenv_stub():
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = dotenv
+
+
+def _install_service_stubs():
+    classifier_service = types.ModuleType("backend.services.classifier_service")
+
+    class ClassifierService:
+        def load(self):
+            pass
+
+        def predict(self, text):
+            return {
+                "category": "Network",
+                "subcategory": "VPN",
+                "priority": "High",
+                "confidence": 0.92,
+                "needs_review": False,
+                "routing_confidence": 0.9,
+            }
+
+    classifier_service.ClassifierService = ClassifierService
+
+    classifier_v2 = types.ModuleType("backend.services.classifier_v2")
+    classifier_v2.classifier_v2 = ClassifierService()
+
+    classifier_v3 = types.ModuleType("backend.services.classifier_v3")
+    classifier_v3.classifier_v3 = ClassifierService()
+
+    ner_service = types.ModuleType("backend.services.ner_service")
+
+    class NERService:
+        def load(self):
+            pass
+
+        def extract_entities(self, text):
+            return []
+
+    ner_service.NERService = NERService
+
+    duplicate_service = types.ModuleType("backend.services.duplicate_service")
+
+    class DuplicateService:
+        def load(self):
+            pass
+
+        def is_available(self):
+            return True
+
+        def find_semantic_duplicate(self, text, threshold, company_id=None, supabase_client=None):
+            return {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "parent_ticket_id": None,
+                "is_potential_duplicate": False,
+                "similarity": 0.0,
+            }
+
+        def check_duplicate(self, text, threshold=0.85):
+            return {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "similarity": 0.0,
+            }
+
+        def generate_embedding(self, text):
+            return [0.1, 0.2, 0.3]
+
+        def add_ticket(self, ticket_id, text):
+            pass
+
+    duplicate_service.DuplicateService = DuplicateService
+
+    rag_service = types.ModuleType("backend.services.rag_service")
+
+    class RagService:
+        def load(self):
+            pass
+
+        def is_available(self):
+            return True
+
+    rag_service.RagService = RagService
+
+    sla_service = types.ModuleType("backend.services.sla_service")
+    sla_service.calculate_sla_response_at = lambda priority: dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+    sla_service.calculate_sla_breach_at = lambda priority: dt.datetime(2026, 1, 2, tzinfo=dt.timezone.utc)
+    sla_service.classify_sla_status = lambda value: "on_track"
+    sla_service.load = lambda: None
+    sla_service.run_sla_escalation_loop = lambda *args, **kwargs: None
+
+    for name, module in {
+        "backend.services.classifier_service": classifier_service,
+        "backend.services.classifier_v2": classifier_v2,
+        "backend.services.classifier_v3": classifier_v3,
+        "backend.services.ner_service": ner_service,
+        "backend.services.duplicate_service": duplicate_service,
+        "backend.services.rag_service": rag_service,
+        "backend.services.sla_service": sla_service,
+    }.items():
+        sys.modules[name] = module
+
+
+@pytest.fixture()
+def backend_main(monkeypatch):
+    _install_slowapi_stub()
+    _install_dotenv_stub()
+    _install_service_stubs()
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    sys.modules.pop("backend.main", None)
+    return importlib.import_module("backend.main")
+
+
+@pytest.fixture()
+def client(backend_main):
+    return TestClient(backend_main.app)

--- a/backend/tests/test_ticket_routes.py
+++ b/backend/tests/test_ticket_routes.py
@@ -1,0 +1,155 @@
+import types
+
+
+class FakeTableQuery:
+    def __init__(self, supabase, table_name):
+        self.supabase = supabase
+        self.table_name = table_name
+        self.filters = {}
+        self.insert_payload = None
+
+    def select(self, *_args):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, key, value):
+        self.filters[key] = value
+        return self
+
+    def single(self):
+        return self
+
+    def insert(self, payload):
+        self.insert_payload = payload
+        self.supabase.inserts.setdefault(self.table_name, []).append(payload)
+        return self
+
+    def execute(self):
+        if self.table_name == "profiles":
+            return types.SimpleNamespace(data=self.supabase.profile)
+        if self.table_name == "system_settings":
+            return types.SimpleNamespace(data=self.supabase.system_settings)
+        if self.table_name == "tickets" and self.insert_payload is not None:
+            return types.SimpleNamespace(data=[{"id": "ticket-1"}])
+        if self.table_name == "ticket_messages" and self.insert_payload is not None:
+            return types.SimpleNamespace(data=[{"id": "message-1"}])
+        return types.SimpleNamespace(data=[])
+
+
+class FakeRpcQuery:
+    def __init__(self, supabase, name, params):
+        self.supabase = supabase
+        self.name = name
+        self.params = params
+
+    def execute(self):
+        self.supabase.rpc_calls.append((self.name, self.params))
+        return types.SimpleNamespace(data=[{"id": "ticket-1", "company_id": self.params["company_id"]}])
+
+
+class FakeSupabase:
+    def __init__(self, profile=None, system_settings=None):
+        self.profile = profile or {}
+        self.system_settings = system_settings or {}
+        self.inserts = {}
+        self.rpc_calls = []
+
+    def table(self, table_name):
+        return FakeTableQuery(self, table_name)
+
+    def rpc(self, name, params):
+        return FakeRpcQuery(self, name, params)
+
+
+def valid_ticket_payload(**overrides):
+    payload = {
+        "user_id": "user-1",
+        "subject": "VPN outage",
+        "description": "VPN disconnects every few minutes",
+        "category": "Network",
+        "subcategory": "VPN",
+        "priority": "High",
+        "assigned_team": "Network Support",
+        "status": "Open",
+        "auto_resolve": False,
+        "is_duplicate": False,
+        "confidence": 0.91,
+        "company": None,
+        "company_id": None,
+        "description_vector": None,
+        "is_potential_duplicate": False,
+        "parent_ticket_id": None,
+        "sla_response_due_at": None,
+        "sla_breach_at": "2026-01-02T00:00:00Z",
+        "sla_status": None,
+        "escalation_level": 0,
+        "metadata": {},
+        "entities": [{"text": "VPN", "label": "SYSTEM", "confidence": 0.95}],
+        "solution_steps": ["Restart VPN client"],
+        "ocr_text": "",
+        "needs_review": True,
+        "routing_confidence": 0.82,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_search_tickets_requires_company_id(client, backend_main):
+    backend_main.supabase = FakeSupabase()
+
+    response = client.get("/tickets/search?q=vpn")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "company_id is required for tenant-safe search"
+
+
+def test_search_tickets_scopes_rpc_by_company_id(client, backend_main):
+    fake_supabase = FakeSupabase()
+    backend_main.supabase = fake_supabase
+
+    response = client.get("/tickets/search?q=vpn&company_id=company-1&limit=5&offset=10")
+
+    assert response.status_code == 200
+    assert fake_supabase.rpc_calls == [
+        (
+            "search_tickets",
+            {
+                "query_text": "vpn",
+                "company_id": "company-1",
+                "limit_rows": 5,
+                "offset_rows": 10,
+            },
+        )
+    ]
+
+
+def test_save_ticket_returns_403_for_profile_company_mismatch(client, backend_main):
+    backend_main.supabase = FakeSupabase(profile={"company_id": "company-a", "company": "Company A"})
+
+    response = client.post("/tickets/save", json=valid_ticket_payload(company_id="company-b"))
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "User not authorized for this tenant"
+
+
+def test_save_ticket_backfills_tenant_and_preserves_ai_metadata(client, backend_main):
+    fake_supabase = FakeSupabase(
+        profile={"company_id": "company-a", "company": "Company A"},
+        system_settings={"duplicate_sensitivity": 0.7},
+    )
+    backend_main.supabase = fake_supabase
+
+    response = client.post("/tickets/save", json=valid_ticket_payload())
+
+    assert response.status_code == 200
+    assert response.json()["ticket_id"] == "ticket-1"
+    saved_ticket = fake_supabase.inserts["tickets"][0]
+    assert saved_ticket["company_id"] == "company-a"
+    assert saved_ticket["company"] == "Company A"
+    assert saved_ticket["metadata"]["entities"] == [{"text": "VPN", "label": "SYSTEM", "confidence": 0.95}]
+    assert saved_ticket["metadata"]["solution_steps"] == ["Restart VPN client"]
+    assert saved_ticket["metadata"]["needs_review"] is True
+    assert saved_ticket["metadata"]["routing_confidence"] == 0.82
+    assert fake_supabase.inserts["ticket_messages"][0]["ticket_id"] == "ticket-1"


### PR DESCRIPTION
Fixes #69

## What changed
- Added backend pytest coverage for tenant-safe ticket search and ticket save flows.
- Covered required `company_id` search validation, Supabase RPC scoping, profile/company mismatch rejection, tenant backfill, AI metadata preservation, and initial system message insertion.
- Added a backend dev requirements file for pytest/httpx test execution.
- Updated CI to run on `gssoc` PRs and execute the backend test suite.
- Preserved FastAPI `HTTPException` status codes in `/tickets/save` so tenant authorization failures return the intended 403 instead of being wrapped as a 500.

## Validation
- `python3 -m pytest backend/tests`
- `git diff --check`

Note: local Python is 3.9, so `eval-type-backport` is included in dev requirements to support the current Pydantic/type-hint combination during local tests. CI still uses Python 3.10 as configured.