### PR TITLE
fix: validate signup passwords while typing

### DIFF
--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import useAuthStore from "../store/authStore";
 import { Select } from "../components/ui/select";
+import { getPasswordValidation, getPasswordValidationMessage } from "../utils/passwordValidation";
 
 /**
  * AdminSignup — Premium Multi-step Company Registration
@@ -44,6 +45,14 @@ function AdminSignup() {
 
     const navigate = useNavigate();
     const { signup, loading, user, profile } = useAuthStore();
+    const passwordRules = {
+        minLength: 8,
+        requireUppercase: true,
+        requireNumber: true,
+        requireSpecial: true,
+    };
+    const passwordChecks = getPasswordValidation(formData.password, passwordRules);
+    const passwordWarning = getPasswordValidationMessage(passwordChecks, passwordRules);
 
     // Redirect if already logged in and verified
     useEffect(() => {
@@ -80,8 +89,8 @@ function AdminSignup() {
                 setError("Please fill in all required personal information.");
                 return;
             }
-            if (formData.password.length < 8) {
-                setError("Password must be at least 8 characters long.");
+            if (passwordWarning) {
+                setError(passwordWarning);
                 return;
             }
             if (formData.password !== formData.confirmPassword) {
@@ -422,7 +431,7 @@ function AdminSignup() {
                                             </div>
                                             {/* Strength Meter */}
                                             {formData.password && (
-                                                <div className="mt-2 space-y-1">
+                                                <div className="mt-2 space-y-2">
                                                     <div className="flex justify-between items-center text-[10px] font-bold uppercase tracking-widest text-gray-400">
                                                         <span>Strength: {getStrengthText()}</span>
                                                         <span>{passwordStrength}%</span>
@@ -433,6 +442,12 @@ function AdminSignup() {
                                                             initial={{ width: 0 }}
                                                             animate={{ width: `${passwordStrength}%` }}
                                                         />
+                                                    </div>
+                                                    <div
+                                                        aria-live="polite"
+                                                        className={`text-[11px] font-semibold ${passwordWarning ? "text-red-600" : "text-emerald-700"}`}
+                                                    >
+                                                        {passwordWarning || "Password requirements met."}
                                                     </div>
                                                 </div>
                                             )}

--- a/Frontend/src/pages/Signup.jsx
+++ b/Frontend/src/pages/Signup.jsx
@@ -3,6 +3,7 @@ import { useNavigate, Link } from "react-router-dom";
 import useAuthStore from "../store/authStore";
 import { supabase } from "../lib/supabaseClient";
 import { Eye, EyeOff, BrainCircuit, ArrowRight, Loader2, CheckCircle2, ChevronDown, Search, Building2, ArrowLeft } from "lucide-react";
+import { getPasswordValidation, getPasswordValidationMessage } from "../utils/passwordValidation";
 
 function Signup() {
   const [email, setEmail] = useState("");
@@ -27,6 +28,10 @@ function Signup() {
   const dropdownRef = useRef(null);
   const navigate = useNavigate();
   const { signup, user, profile } = useAuthStore();
+  const passwordRules = { minLength: 6 };
+  const passwordChecks = getPasswordValidation(password, passwordRules);
+  const passwordWarning = getPasswordValidationMessage(passwordChecks, passwordRules);
+  const confirmPasswordWarning = confirmPassword && password !== confirmPassword ? "Passwords do not match." : "";
 
   // Fetch and subscribe to companies
   useEffect(() => {
@@ -113,13 +118,13 @@ function Signup() {
       return;
     }
 
-    if (password.length < 6) {
-      setError("Password must be at least 6 characters long.");
+    if (passwordWarning) {
+      setError(passwordWarning);
       return;
     }
 
-    if (password !== confirmPassword) {
-      setError("Passwords do not match.");
+    if (confirmPasswordWarning) {
+      setError(confirmPasswordWarning);
       return;
     }
 
@@ -321,6 +326,11 @@ function Signup() {
                     {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                   </button>
                 </div>
+                {password && (
+                  <p aria-live="polite" className={`mt-2 text-[11px] font-semibold ${passwordWarning ? "text-red-600" : "text-emerald-700"}`}>
+                    {passwordWarning || "Password looks good."}
+                  </p>
+                )}
               </div>
               <div className="relative">
                 <label className="block mb-2" style={labelStyle}>Confirm</label>
@@ -331,6 +341,11 @@ function Signup() {
                     {showConfirmPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                   </button>
                 </div>
+                {confirmPasswordWarning && (
+                  <p aria-live="polite" className="mt-2 text-[11px] font-semibold text-red-600">
+                    {confirmPasswordWarning}
+                  </p>
+                )}
               </div>
             </div>
 

--- a/Frontend/src/utils/passwordValidation.js
+++ b/Frontend/src/utils/passwordValidation.js
@@ -1,0 +1,55 @@
+const SEQUENTIAL_PATTERNS = [
+  "abcdefghijklmnopqrstuvwxyz",
+  "zyxwvutsrqponmlkjihgfedcba",
+  "0123456789",
+  "9876543210",
+  "qwertyuiop",
+  "poiuytrewq",
+  "asdfghjkl",
+  "lkjhgfdsa",
+  "zxcvbnm",
+  "mnbvcxz",
+];
+
+export function hasSequentialCharacters(password, span = 3) {
+  const normalized = password.toLowerCase();
+  if (normalized.length < span) return false;
+
+  return SEQUENTIAL_PATTERNS.some((pattern) => {
+    for (let index = 0; index <= pattern.length - span; index += 1) {
+      if (normalized.includes(pattern.slice(index, index + span))) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+export function getPasswordValidation(password, options = {}) {
+  const {
+    minLength = 8,
+    requireUppercase = false,
+    requireNumber = false,
+    requireSpecial = false,
+  } = options;
+
+  return {
+    hasValue: password.length > 0,
+    minLength: password.length >= minLength,
+    uppercase: !requireUppercase || /[A-Z]/.test(password),
+    number: !requireNumber || /\d/.test(password),
+    special: !requireSpecial || /[^A-Za-z0-9]/.test(password),
+    noSequence: !hasSequentialCharacters(password),
+  };
+}
+
+export function getPasswordValidationMessage(checks, options = {}) {
+  const { minLength = 8 } = options;
+  if (!checks.hasValue) return "";
+  if (!checks.minLength) return `Use at least ${minLength} characters.`;
+  if (!checks.uppercase) return "Add at least one uppercase letter.";
+  if (!checks.number) return "Add at least one number.";
+  if (!checks.special) return "Add at least one special character.";
+  if (!checks.noSequence) return "Avoid sequential characters like abc or 123.";
+  return "";
+}

--- a/Frontend/src/utils/passwordValidation.test.js
+++ b/Frontend/src/utils/passwordValidation.test.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getPasswordValidation,
+  getPasswordValidationMessage,
+  hasSequentialCharacters,
+} from "./passwordValidation.js";
+
+test("detects common keyboard and numeric sequences", () => {
+  assert.equal(hasSequentialCharacters("safeQwe9!"), true);
+  assert.equal(hasSequentialCharacters("Ticket123!"), true);
+  assert.equal(hasSequentialCharacters("Route975!"), false);
+});
+
+test("validates required password rules", () => {
+  const checks = getPasswordValidation("Support9!", {
+    minLength: 8,
+    requireUppercase: true,
+    requireNumber: true,
+    requireSpecial: true,
+  });
+
+  assert.deepEqual(checks, {
+    hasValue: true,
+    minLength: true,
+    uppercase: true,
+    number: true,
+    special: true,
+    noSequence: true,
+  });
+});
+
+test("returns the first actionable validation message", () => {
+  const checks = getPasswordValidation("abc123", { minLength: 8 });
+
+  assert.equal(getPasswordValidationMessage(checks, { minLength: 8 }), "Use at least 8 characters.");
+});


### PR DESCRIPTION
Fixes #30

## What changed
- Added reusable password validation helpers for signup flows.
- Shows password feedback while users type instead of waiting for form submission.
- Blocks common sequential patterns such as `abc`, `qwe`, and `123` in both user and admin signup flows.
- Keeps confirm-password mismatch feedback live on the user signup form.
- Added focused Node tests for the password validation helper.

## Validation
- `node --test Frontend/src/utils/passwordValidation.test.js`
- `git diff --check`

Note: this local environment has Node but no `npm` binary and no frontend `node_modules`, so I could not run the full Vite build locally. The PR targets `gssoc` so the repo CI can run the frontend install/build path.