### PR TITLE
feat: persist admin settings to Supabase

### DIFF
--- a/Frontend/src/admin/pages/AdminSettings.jsx
+++ b/Frontend/src/admin/pages/AdminSettings.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Settings,
     Cpu,
@@ -8,6 +8,14 @@ import {
     ShieldCheck
 } from 'lucide-react';
 import useAdminStore from '../store/adminStore';
+import useAuthStore from '../../store/authStore';
+import { supabase } from '../../lib/supabaseClient';
+import {
+    DEFAULT_ADMIN_SETTINGS,
+    resolveCompanyId,
+    settingsFromSystemSettingsRow,
+    settingsToSystemSettingsRow
+} from '../../utils/adminSettingsPersistence';
 import { Card, CardContent } from "../../components/ui/card";
 import { Select } from "../../components/ui/select";
 
@@ -17,11 +25,96 @@ import { Select } from "../../components/ui/select";
  */
 const AdminSettings = () => {
     const { settings, updateSettings } = useAdminStore();
+    const { user, profile } = useAuthStore();
+    const [isLoadingSettings, setIsLoadingSettings] = useState(false);
+    const [isSavingSettings, setIsSavingSettings] = useState(false);
+    const [statusMessage, setStatusMessage] = useState('');
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
-    // Handlers
+    const companyId = useMemo(() => resolveCompanyId(profile, user), [profile, user]);
+
+    useEffect(() => {
+        let isMounted = true;
+
+        const loadCompanySettings = async () => {
+            if (!companyId) {
+                setStatusMessage('Company profile is required before settings can be synced.');
+                return;
+            }
+
+            setIsLoadingSettings(true);
+            setStatusMessage('');
+
+            const { data, error } = await supabase
+                .from('system_settings')
+                .select('ai_confidence_threshold, duplicate_sensitivity, enable_auto_resolve, auto_close_days, email_notifications, admin_alerts')
+                .eq('company_id', companyId)
+                .maybeSingle();
+
+            if (!isMounted) return;
+
+            if (error) {
+                setStatusMessage(`Unable to load saved settings: ${error.message}`);
+            } else if (data) {
+                updateSettings(settingsFromSystemSettingsRow(data, DEFAULT_ADMIN_SETTINGS));
+                setHasUnsavedChanges(false);
+                setStatusMessage('Saved company settings loaded.');
+            }
+
+            setIsLoadingSettings(false);
+        };
+
+        loadCompanySettings();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [companyId, updateSettings]);
+
+    const saveCompanySettings = useCallback(async (nextSettings, { silent = false } = {}) => {
+        if (!companyId) {
+            setStatusMessage('Company profile is required before settings can be saved.');
+            return;
+        }
+
+        setIsSavingSettings(true);
+        if (!silent) {
+            setStatusMessage('');
+        }
+
+        const { error } = await supabase
+            .from('system_settings')
+            .upsert(settingsToSystemSettingsRow(nextSettings, companyId), { onConflict: 'company_id' });
+
+        if (error) {
+            setStatusMessage(`Unable to save settings: ${error.message}`);
+        } else {
+            setHasUnsavedChanges(false);
+            setStatusMessage('Settings saved for this company.');
+        }
+
+        setIsSavingSettings(false);
+    }, [companyId]);
+
     const handleChange = (key, value) => {
         updateSettings({ [key]: value });
+        setHasUnsavedChanges(true);
+        setStatusMessage('Saving changes...');
     };
+
+    const handleSaveSettings = useCallback(() => {
+        saveCompanySettings(settings);
+    }, [saveCompanySettings, settings]);
+
+    useEffect(() => {
+        if (!hasUnsavedChanges || isLoadingSettings || isSavingSettings) return undefined;
+
+        const saveTimer = window.setTimeout(() => {
+            saveCompanySettings(settings, { silent: true });
+        }, 800);
+
+        return () => window.clearTimeout(saveTimer);
+    }, [hasUnsavedChanges, isLoadingSettings, isSavingSettings, saveCompanySettings, settings]);
 
     return (
         <div className="max-w-4xl mx-auto py-6 space-y-10 pb-20 animate-in fade-in duration-700">
@@ -34,6 +127,22 @@ const AdminSettings = () => {
                     <p className="text-sm font-bold text-slate-400 mt-1 flex items-center gap-2 uppercase tracking-[0.2em]">
                         <ShieldCheck size={14} className="text-emerald-500" /> Administrator Account
                     </p>
+                </div>
+                <div className="flex flex-col items-start md:items-end gap-2">
+                    <button
+                        type="button"
+                        onClick={handleSaveSettings}
+                        disabled={!companyId || isLoadingSettings || isSavingSettings || !hasUnsavedChanges}
+                        className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-5 py-3 text-xs font-black uppercase tracking-widest text-white shadow-xl shadow-slate-200 transition-all hover:bg-indigo-600 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:shadow-none"
+                    >
+                        <Save size={16} />
+                        {isSavingSettings ? 'Saving...' : 'Save Now'}
+                    </button>
+                    {statusMessage && (
+                        <p className="max-w-xs text-left md:text-right text-[10px] font-bold uppercase tracking-widest text-slate-400">
+                            {statusMessage}
+                        </p>
+                    )}
                 </div>
             </div>
 

--- a/Frontend/src/utils/adminSettingsPersistence.js
+++ b/Frontend/src/utils/adminSettingsPersistence.js
@@ -1,0 +1,41 @@
+export const DEFAULT_ADMIN_SETTINGS = {
+    aiConfidenceThreshold: 0.8,
+    duplicateSensitivity: 0.85,
+    enableAutoResolve: false,
+    autoCloseDays: 7,
+    emailNotifications: false,
+    adminAlerts: false,
+};
+
+export const resolveCompanyId = (profile, user) => {
+    return (
+        profile?.company_id ||
+        profile?.companyId ||
+        user?.user_metadata?.company_id ||
+        user?.user_metadata?.companyId ||
+        null
+    );
+};
+
+export const settingsFromSystemSettingsRow = (row, fallback = DEFAULT_ADMIN_SETTINGS) => {
+    if (!row) return fallback;
+
+    return {
+        aiConfidenceThreshold: row.ai_confidence_threshold ?? fallback.aiConfidenceThreshold,
+        duplicateSensitivity: row.duplicate_sensitivity ?? fallback.duplicateSensitivity,
+        enableAutoResolve: row.enable_auto_resolve ?? fallback.enableAutoResolve,
+        autoCloseDays: row.auto_close_days ?? fallback.autoCloseDays,
+        emailNotifications: row.email_notifications ?? fallback.emailNotifications,
+        adminAlerts: row.admin_alerts ?? fallback.adminAlerts,
+    };
+};
+
+export const settingsToSystemSettingsRow = (settings, companyId) => ({
+    company_id: companyId,
+    ai_confidence_threshold: Number(settings.aiConfidenceThreshold),
+    duplicate_sensitivity: Number(settings.duplicateSensitivity),
+    enable_auto_resolve: Boolean(settings.enableAutoResolve),
+    auto_close_days: Number(settings.autoCloseDays),
+    email_notifications: Boolean(settings.emailNotifications),
+    admin_alerts: Boolean(settings.adminAlerts),
+});

--- a/Frontend/src/utils/adminSettingsPersistence.test.js
+++ b/Frontend/src/utils/adminSettingsPersistence.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    DEFAULT_ADMIN_SETTINGS,
+    resolveCompanyId,
+    settingsFromSystemSettingsRow,
+    settingsToSystemSettingsRow,
+} from './adminSettingsPersistence.js';
+
+test('maps a system_settings row into admin UI settings', () => {
+    const settings = settingsFromSystemSettingsRow({
+        ai_confidence_threshold: 0.7,
+        duplicate_sensitivity: 0.9,
+        enable_auto_resolve: true,
+        auto_close_days: 14,
+        email_notifications: true,
+        admin_alerts: false,
+    });
+
+    assert.deepEqual(settings, {
+        aiConfidenceThreshold: 0.7,
+        duplicateSensitivity: 0.9,
+        enableAutoResolve: true,
+        autoCloseDays: 14,
+        emailNotifications: true,
+        adminAlerts: false,
+    });
+});
+
+test('preserves fallback values when database columns are absent', () => {
+    const settings = settingsFromSystemSettingsRow({}, DEFAULT_ADMIN_SETTINGS);
+
+    assert.deepEqual(settings, DEFAULT_ADMIN_SETTINGS);
+});
+
+test('maps admin UI settings into an upsert payload', () => {
+    const row = settingsToSystemSettingsRow({
+        aiConfidenceThreshold: '0.75',
+        duplicateSensitivity: 0.8,
+        enableAutoResolve: 1,
+        autoCloseDays: '3',
+        emailNotifications: false,
+        adminAlerts: true,
+    }, 'company-123');
+
+    assert.deepEqual(row, {
+        company_id: 'company-123',
+        ai_confidence_threshold: 0.75,
+        duplicate_sensitivity: 0.8,
+        enable_auto_resolve: true,
+        auto_close_days: 3,
+        email_notifications: false,
+        admin_alerts: true,
+    });
+});
+
+test('resolves company id from profile before auth metadata', () => {
+    const companyId = resolveCompanyId(
+        { company_id: 'profile-company' },
+        { user_metadata: { company_id: 'metadata-company' } },
+    );
+
+    assert.equal(companyId, 'profile-company');
+});

--- a/supabase/migrations/20260531_add_company_settings.sql
+++ b/supabase/migrations/20260531_add_company_settings.sql
@@ -4,7 +4,7 @@
 -- `system_settings` per the unified schema; filename unchanged for migration ordering.
 
 CREATE TABLE IF NOT EXISTS system_settings (
-    company_id            UUID UNIQUE NOT NULL,
+    company_id            UUID PRIMARY KEY,
     ai_confidence_threshold FLOAT   DEFAULT 0.80,
     duplicate_sensitivity   FLOAT   DEFAULT 0.85,
     enable_auto_resolve     BOOLEAN DEFAULT FALSE,
@@ -12,7 +12,9 @@ CREATE TABLE IF NOT EXISTS system_settings (
     auto_close_days         INTEGER DEFAULT 7,
     email_notifications     BOOLEAN DEFAULT TRUE,
     admin_alerts            BOOLEAN DEFAULT TRUE,
-    digest_frequency        TEXT    DEFAULT 'daily'
+    digest_frequency        TEXT    DEFAULT 'daily',
+    created_at              TIMESTAMPTZ DEFAULT NOW(),
+    updated_at              TIMESTAMPTZ DEFAULT NOW()
 );
 
 -- Enable Row Level Security
@@ -29,6 +31,49 @@ CREATE POLICY "Users can view own company settings" ON system_settings
             SELECT company_id FROM user_companies WHERE user_id = auth.uid()
         )
     );
+
+CREATE POLICY "Admins can view own company settings" ON system_settings
+    FOR SELECT USING (
+        company_id IN (
+            SELECT company_id FROM profiles
+            WHERE id = auth.uid()
+              AND role IN ('admin', 'super_admin', 'master_admin')
+        )
+    );
+
+-- Admins can create and update settings for their own company from the dashboard.
+CREATE POLICY "Admins can insert own company settings" ON system_settings
+    FOR INSERT WITH CHECK (
+        company_id IN (
+            SELECT company_id FROM profiles
+            WHERE id = auth.uid()
+              AND role IN ('admin', 'super_admin', 'master_admin')
+        )
+    );
+
+CREATE POLICY "Admins can update own company settings" ON system_settings
+    FOR UPDATE USING (
+        company_id IN (
+            SELECT company_id FROM profiles
+            WHERE id = auth.uid()
+              AND role IN ('admin', 'super_admin', 'master_admin')
+        )
+    )
+    WITH CHECK (
+        company_id IN (
+            SELECT company_id FROM profiles
+            WHERE id = auth.uid()
+              AND role IN ('admin', 'super_admin', 'master_admin')
+        )
+    );
+
+CREATE OR REPLACE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
 -- Trigger to auto-update updated_at on modification
 CREATE TRIGGER update_system_settings_timestamp


### PR DESCRIPTION
## Summary
- load per-company admin settings from the `system_settings` table on the settings page
- save slider and toggle changes back to Supabase with a debounced upsert plus a manual save fallback
- tighten the `system_settings` migration with a primary key, timestamps, update trigger, and admin-scoped RLS policies
- add pure mapping helpers with Node tests for database/UI settings conversion

Fixes #39

## Validation
- `node --test Frontend/src/utils/adminSettingsPersistence.test.js`
- `git diff --check`

Note: full frontend build was not run in this local environment because `npm` is not available here.