### PR TITLE
feat: add realtime ticket dashboard updates

### DIFF
--- a/Frontend/src/admin/pages/AdminDashboard.jsx
+++ b/Frontend/src/admin/pages/AdminDashboard.jsx
@@ -4,6 +4,7 @@ import { Activity, AlertTriangle, Clock, ShieldCheck } from 'lucide-react';
 
 import useAuthStore from "../../store/authStore";
 import { supabase } from "../../lib/supabaseClient";
+import useTicketsRealtime from "../../hooks/useTicketsRealtime";
 import StatCard from "../components/StatCard";
 import TicketTable from "../components/TicketTable";
 import { formatTimelineDate } from "../../utils/dateUtils";
@@ -107,6 +108,13 @@ const AdminDashboard = () => {
     const [isLoading, setIsLoading] = React.useState(true);
     const [nowMs, setNowMs] = React.useState(() => Date.now());
 
+    useTicketsRealtime({
+        company: profile?.company,
+        enabled: Boolean(profile),
+        onTicketsChange: setTickets,
+        channelName: 'admin_dashboard_tickets_realtime',
+    });
+
     React.useEffect(() => {
         if (profile) {
             const fetchStats = async () => {
@@ -135,8 +143,6 @@ const AdminDashboard = () => {
             };
 
             fetchStats();
-            const interval = setInterval(fetchStats, 30000);
-            return () => clearInterval(interval);
         }
     }, [profile]);
 

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useCallback, useState, useMemo, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import useAuthStore from "../../store/authStore";
 import useToastStore from "../../store/toastStore";
 import { supabase } from "../../lib/supabaseClient";
+import useTicketsRealtime from "../../hooks/useTicketsRealtime";
 import {
     Search,
     Filter,
@@ -29,7 +30,7 @@ import { formatTimelineDate } from "../../utils/dateUtils";
 const AdminTickets = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { user } = useAuthStore();
+    const { user, profile } = useAuthStore();
     const { showToast } = useToastStore();
 
     // Data State
@@ -45,6 +46,27 @@ const AdminTickets = () => {
     const [priorityFilter, setPriorityFilter] = useState('All');
     const [teamFilter, setTeamFilter] = useState('All');
     const [agents, setAgents] = useState([]); // All staff/admins in the company
+
+    const ticketMatchesFilters = useCallback((ticket) => {
+        if (statusFilter !== 'All' && String(ticket.status || '').toLowerCase() !== statusFilter.toLowerCase()) return false;
+        if (categoryFilter !== 'All' && ticket.category !== categoryFilter) return false;
+        if (priorityFilter !== 'All' && String(ticket.priority || '').toLowerCase() !== priorityFilter.toLowerCase()) return false;
+        if (teamFilter !== 'All' && ticket.assigned_team !== teamFilter) return false;
+        return true;
+    }, [categoryFilter, priorityFilter, statusFilter, teamFilter]);
+
+    const handleRealtimeInsert = useCallback((ticket) => {
+        showToast(`New Incident Reported: #${formatTicketId(ticket.id)}`, "success");
+    }, [showToast]);
+
+    const { lastChangedTicketId } = useTicketsRealtime({
+        company: profile?.company,
+        enabled: Boolean(profile),
+        onTicketsChange: setTickets,
+        onInsert: handleRealtimeInsert,
+        shouldInclude: ticketMatchesFilters,
+        channelName: 'admin_tickets_realtime',
+    });
 
     const fetchInitialData = async () => {
         setLoading(true);
@@ -113,38 +135,6 @@ const AdminTickets = () => {
 
     useEffect(() => {
         fetchInitialData();
-
-        // 4. Real-time subscription to ticket changes
-        const { profile } = useAuthStore.getState();
-        const channel = supabase
-            .channel('admin_tickets_realtime')
-            .on(
-                'postgres_changes',
-                {
-                    event: '*',
-                    schema: 'public',
-                    table: 'tickets',
-                    filter: profile?.company ? `company=eq.${profile.company}` : undefined
-                },
-                (payload) => {
-                    console.log("Admin tickets sync event:", payload.eventType, payload.new);
-                    if (payload.eventType === 'INSERT') {
-                        setTickets(prev => [payload.new, ...prev]);
-                        showToast(`New Incident Reported: #${payload.new.id}`, "success");
-                        // Play a subtle sound or visual cue if needed
-                    } else if (payload.eventType === 'UPDATE') {
-                        setTickets(prev => prev.map(t => t.id === payload.new.id ? { ...t, ...payload.new } : t));
-                    } else if (payload.eventType === 'DELETE') {
-                        setTickets(prev => prev.filter(t => t.id === payload.old.id));
-                    }
-                }
-            )
-            .subscribe();
-
-        return () => {
-            supabase.removeChannel(channel);
-        };
-     
     }, [statusFilter, categoryFilter, priorityFilter, teamFilter]);
 
     // Seed search from URL
@@ -305,8 +295,11 @@ const AdminTickets = () => {
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-slate-50">
-                            {filteredTickets.map((ticket) => (
-                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
+                            {filteredTickets.map((ticket) => {
+                                const wasLiveChanged = String(lastChangedTicketId) === String(ticket.id);
+
+                                return (
+                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : ''} ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
                                     {/* Ticket ID */}
                                     <td className="px-6 py-6">
                                         <span className="font-mono text-xs font-black text-emerald-600">#{formatTicketId(ticket.id)}</span>
@@ -456,7 +449,8 @@ const AdminTickets = () => {
                                         </div>
                                     </td>
                                 </tr>
-                            ))}
+                                );
+                            })}
                         </tbody>
                     </table>
                 </div>

--- a/Frontend/src/hooks/useTicketsRealtime.js
+++ b/Frontend/src/hooks/useTicketsRealtime.js
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { supabase } from '../lib/supabaseClient';
+import useTicketStore from '../store/ticketStore';
+import {
+    applyTicketRealtimePayload,
+    getTicketRecordId,
+} from '../utils/ticketRealtimeReducer';
+
+const makeChannelName = (baseName, company) => {
+    const safeCompany = company ? String(company).replace(/[^a-zA-Z0-9_-]/g, '_') : 'all';
+    return `${baseName}_${safeCompany}`;
+};
+
+const useTicketsRealtime = ({
+    company,
+    enabled = true,
+    onTicketsChange,
+    onInsert,
+    shouldInclude,
+    channelName = 'tickets_realtime',
+} = {}) => {
+    const [lastChangedTicketId, setLastChangedTicketId] = useState(null);
+
+    const realtimeFilter = useMemo(() => {
+        return company ? `company=eq.${company}` : undefined;
+    }, [company]);
+
+    useEffect(() => {
+        if (!enabled || !onTicketsChange) return undefined;
+
+        let clearHighlightTimer;
+        const channel = supabase
+            .channel(makeChannelName(channelName, company))
+            .on(
+                'postgres_changes',
+                {
+                    event: '*',
+                    schema: 'public',
+                    table: 'tickets',
+                    ...(realtimeFilter ? { filter: realtimeFilter } : {}),
+                },
+                (payload) => {
+                    const ticket = payload.new || payload.old;
+                    const ticketId = getTicketRecordId(ticket);
+
+                    onTicketsChange((currentTickets) => (
+                        applyTicketRealtimePayload(currentTickets, payload, { shouldInclude })
+                    ));
+
+                    const ticketStore = useTicketStore.getState();
+                    if (payload.eventType === 'DELETE') {
+                        ticketStore.removeTicket(ticketId);
+                    } else if (payload.new) {
+                        ticketStore.upsertTicket(payload.new);
+                    }
+
+                    if (payload.eventType === 'INSERT' && payload.new && onInsert) {
+                        onInsert(payload.new);
+                    }
+
+                    if (ticketId) {
+                        setLastChangedTicketId(ticketId);
+                        window.clearTimeout(clearHighlightTimer);
+                        clearHighlightTimer = window.setTimeout(() => {
+                            setLastChangedTicketId(null);
+                        }, 3500);
+                    }
+                },
+            )
+            .subscribe();
+
+        return () => {
+            window.clearTimeout(clearHighlightTimer);
+            supabase.removeChannel(channel);
+        };
+    }, [channelName, company, enabled, onInsert, onTicketsChange, realtimeFilter, shouldInclude]);
+
+    return { lastChangedTicketId };
+};
+
+export default useTicketsRealtime;

--- a/Frontend/src/store/ticketStore.js
+++ b/Frontend/src/store/ticketStore.js
@@ -30,6 +30,27 @@ const useTicketStore = create(
                     tickets: [...state.tickets, ticket]
                 };
             }),
+            upsertTicket: (ticket) => set((state) => {
+                const ticketId = ticket?.id ?? ticket?.ticket_id;
+                if (!ticketId) return state;
+
+                const exists = state.tickets.some(t => (t.id ?? t.ticket_id) === ticketId);
+                const tickets = exists
+                    ? state.tickets.map(t => (t.id ?? t.ticket_id) === ticketId ? { ...t, ...ticket } : t)
+                    : [ticket, ...state.tickets];
+                const shouldUpdateActive = (state.activeTicket?.id ?? state.activeTicket?.ticket_id) === ticketId;
+
+                return {
+                    tickets,
+                    activeTicket: shouldUpdateActive ? { ...state.activeTicket, ...ticket } : state.activeTicket
+                };
+            }),
+            removeTicket: (ticketId) => set((state) => ({
+                tickets: state.tickets.filter(t => (t.id ?? t.ticket_id) !== ticketId),
+                activeTicket: (state.activeTicket?.id ?? state.activeTicket?.ticket_id) === ticketId
+                    ? null
+                    : state.activeTicket
+            })),
             updateTicket: (ticketId, updates) => set((state) => {
 // eslint-disable-next-line no-unused-vars
                 const existingTicket = state.tickets.find(t => t.ticket_id === ticketId);

--- a/Frontend/src/utils/ticketRealtimeReducer.js
+++ b/Frontend/src/utils/ticketRealtimeReducer.js
@@ -1,0 +1,37 @@
+export const getTicketRecordId = (ticket) => ticket?.id ?? ticket?.ticket_id ?? null;
+
+const defaultShouldInclude = () => true;
+
+export const applyTicketRealtimePayload = (
+    tickets,
+    payload,
+    { shouldInclude = defaultShouldInclude } = {},
+) => {
+    const currentTickets = Array.isArray(tickets) ? tickets : [];
+    const eventType = payload?.eventType;
+    const nextTicket = payload?.new;
+    const oldTicket = payload?.old;
+    const targetTicket = nextTicket || oldTicket;
+    const targetId = getTicketRecordId(targetTicket);
+
+    if (!eventType || !targetId) return currentTickets;
+
+    if (eventType === 'DELETE') {
+        return currentTickets.filter((ticket) => getTicketRecordId(ticket) !== targetId);
+    }
+
+    if (!nextTicket || !shouldInclude(nextTicket)) {
+        return currentTickets.filter((ticket) => getTicketRecordId(ticket) !== targetId);
+    }
+
+    const exists = currentTickets.some((ticket) => getTicketRecordId(ticket) === targetId);
+    if (!exists) {
+        return [nextTicket, ...currentTickets];
+    }
+
+    return currentTickets.map((ticket) => (
+        getTicketRecordId(ticket) === targetId
+            ? { ...ticket, ...nextTicket }
+            : ticket
+    ));
+};

--- a/Frontend/src/utils/ticketRealtimeReducer.test.js
+++ b/Frontend/src/utils/ticketRealtimeReducer.test.js
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    applyTicketRealtimePayload,
+    getTicketRecordId,
+} from './ticketRealtimeReducer.js';
+
+test('resolves ticket ids from id and ticket_id fields', () => {
+    assert.equal(getTicketRecordId({ id: 42 }), 42);
+    assert.equal(getTicketRecordId({ ticket_id: 'T-7' }), 'T-7');
+    assert.equal(getTicketRecordId({}), null);
+});
+
+test('prepends new realtime inserts', () => {
+    const next = applyTicketRealtimePayload(
+        [{ id: 1, subject: 'Existing' }],
+        { eventType: 'INSERT', new: { id: 2, subject: 'New' } },
+    );
+
+    assert.deepEqual(next.map((ticket) => ticket.id), [2, 1]);
+});
+
+test('merges realtime updates into existing rows', () => {
+    const next = applyTicketRealtimePayload(
+        [{ id: 1, status: 'open', priority: 'low' }],
+        { eventType: 'UPDATE', new: { id: 1, status: 'resolved' } },
+    );
+
+    assert.deepEqual(next, [{ id: 1, status: 'resolved', priority: 'low' }]);
+});
+
+test('removes rows when updates no longer match current filters', () => {
+    const next = applyTicketRealtimePayload(
+        [{ id: 1, status: 'open' }],
+        { eventType: 'UPDATE', new: { id: 1, status: 'closed' } },
+        { shouldInclude: (ticket) => ticket.status === 'open' },
+    );
+
+    assert.deepEqual(next, []);
+});
+
+test('removes deleted tickets', () => {
+    const next = applyTicketRealtimePayload(
+        [{ id: 1 }, { id: 2 }],
+        { eventType: 'DELETE', old: { id: 1 } },
+    );
+
+    assert.deepEqual(next, [{ id: 2 }]);
+});

--- a/supabase/migrations/20260523010000_enable_ticket_realtime.sql
+++ b/supabase/migrations/20260523010000_enable_ticket_realtime.sql
@@ -1,0 +1,25 @@
+-- Enable Supabase realtime replication for ticket dashboard updates.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'tickets'
+    ) THEN
+        ALTER TABLE public.tickets REPLICA IDENTITY FULL;
+
+        IF EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime')
+           AND NOT EXISTS (
+                SELECT 1
+                FROM pg_publication_tables
+                WHERE pubname = 'supabase_realtime'
+                  AND schemaname = 'public'
+                  AND tablename = 'tickets'
+           ) THEN
+            ALTER PUBLICATION supabase_realtime ADD TABLE public.tickets;
+        END IF;
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- add a reusable `useTicketsRealtime` hook for company-scoped Supabase realtime ticket events
- keep the Zustand ticket store synchronized for insert/update/delete events
- wire the admin dashboard and ticket management table to live updates instead of relying on delayed refreshes
- add a safe realtime publication migration with `REPLICA IDENTITY FULL` for delete/update payloads
- highlight recently changed ticket rows so admins can see live activity immediately

Fixes #71

## Validation
- `node --test Frontend/src/utils/ticketRealtimeReducer.test.js`
- `node --check Frontend/src/hooks/useTicketsRealtime.js`
- `node --check Frontend/src/utils/ticketRealtimeReducer.js`
- `git diff --check`

Note: full frontend build/lint was not run in this local environment because `npm` and frontend `node_modules` are not available here.