### PR TITLE
fix: make USE_MOCK toggleable via VITE_USE_MOCK env var

### DIFF
--- a/Frontend/src/config.js
+++ b/Frontend/src/config.js
@@ -13,5 +13,6 @@ const getBackendUrl = () => {
 export const API_CONFIG = {
     BACKEND_URL: getBackendUrl(),
     FRONTEND_URL: window.location.origin,
-    IS_PROD: import.meta.env.PROD
+    IS_PROD: import.meta.env.PROD,
+    USE_MOCK: import.meta.env.VITE_USE_MOCK !== 'false'  // default true
 };

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { MOCK_TICKETS } from './mockData';
 import { API_CONFIG } from '../config';
 
-const USE_MOCK = true;
+const USE_MOCK = API_CONFIG.USE_MOCK;
 const API_BASE_URL = API_CONFIG.BACKEND_URL;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -38,13 +38,41 @@ const setStorage = (key, data) => {
   }
 };
 
+// Shared mock logic for createTicket
+const createTicketMock = (ticketData) => {
+  const tickets = getStorage('tickets', MOCK_TICKETS);
+  const newTicket = {
+    ticket_id: "TCKT-" + Math.floor(Math.random() * 10000),
+    status: 'Open',
+    createdAt: new Date().toISOString(),
+    ...ticketData,
+    messages: [
+      {
+        sender: 'user',
+        message: ticketData.description || ticketData.summary || '',
+        timestamp: new Date().toISOString()
+      }
+    ]
+  };
+  tickets.unshift(newTicket); // Add to beginning
+  setStorage('tickets', tickets);
+  return { data: newTicket };
+};
+
 export const api = {
   // Login and Signup have been fully migrated to Supabase via authStore.js
   // Ensure that no component tries to use api.login or api.signup anymore.
 
-
   getTickets: async () => {
     if (USE_MOCK) {
+      await delay(500);
+      return getStorage('tickets', MOCK_TICKETS);
+    }
+    try {
+      const response = await axios.get(`${API_BASE_URL}/tickets`);
+      return response.data;
+    } catch (error) {
+      console.error("Backend unavailable, falling back to mock:", error);
       await delay(500);
       return getStorage('tickets', MOCK_TICKETS);
     }
@@ -53,23 +81,15 @@ export const api = {
   createTicket: async (ticketData) => {
     if (USE_MOCK) {
       await delay(800);
-      const tickets = getStorage('tickets', MOCK_TICKETS);
-      const newTicket = {
-        ticket_id: "TCKT-" + Math.floor(Math.random() * 10000),
-        status: 'Open',
-        createdAt: new Date().toISOString(),
-        ...ticketData,
-        messages: [
-          {
-            sender: 'user',
-            message: ticketData.description || ticketData.summary || '',
-            timestamp: new Date().toISOString()
-          }
-        ]
-      };
-      tickets.unshift(newTicket); // Add to beginning
-      setStorage('tickets', tickets);
-      return { data: newTicket };
+      return createTicketMock(ticketData);
+    }
+    try {
+      const response = await axios.post(`${API_BASE_URL}/tickets/save`, ticketData);
+      return response.data;
+    } catch (error) {
+      console.error("Backend unavailable, falling back to mock:", error);
+      await delay(800);
+      return createTicketMock(ticketData);
     }
   },
 


### PR DESCRIPTION
**Description:**
Fixes #98

### Changes

**Frontend/src/config.js**
- Added `USE_MOCK` property to `API_CONFIG`, controlled by `VITE_USE_MOCK` env var (defaults to `true` for backward compatibility)

**Frontend/src/services/api.js**
- Replaced hardcoded `const USE_MOCK = true` with `const USE_MOCK = API_CONFIG.USE_MOCK`
- Extracted `createTicketMock()` helper to avoid code duplication between mock-only mode and error fallback
- Added real backend calls with try-catch fallback to mock for:
  - `getTickets()` → `GET /tickets`
  - `createTicket()` → `POST /tickets/save`

### How to use
- `VITE_USE_MOCK=false` → calls real backend (falls back to mock on error)
- `VITE_USE_MOCK=true` or not set → uses mock data (existing behavior)

### Checklist
- [x] Branch targets `gssoc`
- [x] Atomic commit with descriptive message
- [x] Backward compatible — mock mode unchanged by default
- [x] Error fallback matches `predictTicket` pattern