### PR TITLE
Fix USE_MOCK backend integration and add API fallback handling

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 import { MOCK_TICKETS } from './mockData';
-import { API_CONFIG } from '../config';
+import { API_CONFIG, USE_MOCK } from './config';
 
-const USE_MOCK = true;
 const API_BASE_URL = API_CONFIG.BACKEND_URL;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -48,10 +47,59 @@ export const api = {
       await delay(500);
       return getStorage('tickets', MOCK_TICKETS);
     }
+
+    // When not using mock, call real backend with fallback to mock on failure
+    try {
+      const response = await axios.get(`${API_BASE_URL}/tickets`);
+      const data = response?.data;
+
+      // Normalize to the mock shape: an array of tickets
+      if (Array.isArray(data)) return data;
+      if (data && Array.isArray(data.data)) return data.data;
+      if (data && Array.isArray(data.tickets)) return data.tickets;
+
+      // Best-effort: if the backend returned an object that's not an array,
+      // return that object so callers can inspect fields. This preserves
+      // the fallback behavior but attempts to match the mock when possible.
+      return data;
+    } catch (error) {
+      console.warn('Failed to fetch tickets from backend, falling back to mock:', error);
+      await delay(500);
+      return getStorage('tickets', MOCK_TICKETS);
+    }
   },
 
   createTicket: async (ticketData) => {
     if (USE_MOCK) {
+      await delay(800);
+      const tickets = getStorage('tickets', MOCK_TICKETS);
+      const newTicket = {
+        ticket_id: "TCKT-" + Math.floor(Math.random() * 10000),
+        status: 'Open',
+        createdAt: new Date().toISOString(),
+        ...ticketData,
+        messages: [
+          {
+            sender: 'user',
+            message: ticketData.description || ticketData.summary || '',
+            timestamp: new Date().toISOString()
+          }
+        ]
+      };
+      tickets.unshift(newTicket); // Add to beginning
+      setStorage('tickets', tickets);
+      return { data: newTicket };
+    }
+
+    // When not using mock, call backend to create ticket and fallback to mock on failure
+    try {
+      const response = await axios.post(`${API_BASE_URL}/tickets`, ticketData);
+      const created = response?.data;
+
+      // Normalize to mock shape: { data: <createdTicket> }
+      return { data: created };
+    } catch (error) {
+      console.warn('Failed to create ticket in backend, falling back to mock:', error);
       await delay(800);
       const tickets = getStorage('tickets', MOCK_TICKETS);
       const newTicket = {

--- a/Frontend/src/services/config.js
+++ b/Frontend/src/services/config.js
@@ -1,0 +1,13 @@
+// Centralized frontend config. Reads VITE_USE_MOCK from environment.
+// Vite exposes env vars via import.meta.env
+const raw = typeof import.meta !== 'undefined' ? import.meta.env?.VITE_USE_MOCK : undefined;
+
+// Default to true when missing. Treat the string "false" (case-insensitive) as false.
+export const USE_MOCK = raw === undefined || raw === null
+  ? true
+  : String(raw).toLowerCase() !== 'false';
+
+// Export other config placeholders if needed by other modules
+export const API_CONFIG = {
+  BACKEND_URL: typeof import.meta !== 'undefined' ? (import.meta.env?.VITE_BACKEND_URL || '') : ''
+};


### PR DESCRIPTION
Fixes #98

## Overview

This PR fixes the hardcoded `USE_MOCK` configuration which prevented `getTickets()` and `createTicket()` from calling the real backend API.

## Changes Made

* Added `config.js` for centralized API configuration
* Added environment-based `VITE_USE_MOCK` toggle
* Updated `getTickets()` to:

  * use mock data when enabled
  * call the real backend when disabled
  * gracefully fallback to mock data on API failure
* Updated `createTicket()` with the same backend + fallback pattern
* Normalized backend responses to match existing mock response shapes
* Preserved the fallback behavior pattern already used in `predictTicket()`

## Verification

* Build completed successfully
* Lint checked successfully except unrelated legacy warnings/errors
* No unrelated changes included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable backend selection for flexible API switching
  * Implemented automatic fallback to cached data when the backend is unavailable, improving app reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->