### PR TITLE
fix: remove global console.error monkey-patch from BugReportWidget

### DIFF
--- a/Frontend/src/components/shared/BugReportWidget.jsx
+++ b/Frontend/src/components/shared/BugReportWidget.jsx
@@ -23,23 +23,12 @@ function useDiagnostics() {
         const browserInfo = navigator.userAgent;
         const screenInfo = `${window.innerWidth}x${window.innerHeight}`;
 
-         
         setDiagnostics(prev => ({
             ...prev,
             url: window.location.href,
             browser: browserInfo,
             screen: screenInfo
         }));
-
-        // Intercept console.error
-        const originalConsoleError = console.error;
-        console.error = function (...args) {
-            setDiagnostics(prev => ({
-                ...prev,
-                consoleErrors: [...prev.consoleErrors, args.join(' ')].slice(-10) // keep last 10
-            }));
-            originalConsoleError.apply(console, args);
-        };
 
         // Global Error Listener
         const handleError = (e) => {
@@ -51,7 +40,6 @@ function useDiagnostics() {
         window.addEventListener('error', handleError);
 
         return () => {
-            console.error = originalConsoleError;
             window.removeEventListener('error', handleError);
         };
     }, []);


### PR DESCRIPTION
**Description:**
Fixes #97

## Problem

The `useDiagnostics` hook in `BugReportWidget.jsx` (line 34-42) was globally overriding `console.error` with a custom function that called `setDiagnostics()` on every error. This caused two serious issues:

1. **Cascading re-renders** — Every `console.error` call across the entire app (React warnings, library errors, even the widget's own error logging at lines 223, 304, 335, 357) triggered a React state update, re-rendering the component. If a re-render itself fired another error, it created a loop.

2. **Stack traces destroyed** — The code used `args.join(' ')` which converts Error objects to plain text strings. The rich stack traces that browsers provide for `console.error(new Error(...))` were completely lost.

Since the floating bug button stays mounted for the entire session, the override was effectively permanent — it never got cleaned up.

## Fix

Removed the `console.error` monkey-patch entirely (11 lines deleted). The `window.addEventListener('error', ...)` handler on line 45 already captures runtime errors properly without any global side effects.

### What was removed
- `const originalConsoleError = console.error;` — saved reference to original
- The entire `console.error = function(...) { ... }` block — the root cause
- `console.error = originalConsoleError;` in cleanup — no longer needed

### What was kept
- `window.addEventListener('error', handleError)` — continues capturing uncaught runtime errors
- `window.removeEventListener('error', handleError)` — clean cleanup on unmount

### Result
- `console.error()` now works natively — stack traces preserved ✅
- No unwanted React re-renders on every error ✅
- Runtime errors still captured for diagnostics ✅
- Backward compatible — mock/testing behavior unchanged ✅
### Checklist
- [x] Branch targets `gssoc`
- [x] Atomic commit with descriptive message
- [x] Backward compatible — error listener still captures runtime errors
- [x] No leftover references to removed variables