### PR TITLE
fix: [BOUNTY] [level:critical] Establish Distributed Redis Caching Layer for AI Categorization and Sentence Transformer Embeddings

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -58,6 +58,7 @@ from backend.services.classifier_v2 import classifier_v2
 from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
+from backend.services.redis_cache import redis_cache
 from backend.services.rag_service import RagService
 
 
@@ -200,6 +201,10 @@ except ImportError:
 async def lifespan(app: FastAPI):
     """Load all models at startup."""
     print("[Startup] Loading AI models ...")
+    try:
+        redis_cache.load()
+    except Exception as e:
+        print(f"[WARNING] Redis cache not loaded: {e}")
     try:
         classifier_service.load()
     except FileNotFoundError as e:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ easyocr
 slowapi>=0.1.9
 supabase==2.22.4
 storage3==2.22.4
+redis>=5.0.0

--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -10,6 +10,8 @@ import torch
 import torch.nn.functional as F
 from transformers import DistilBertTokenizerFast, DistilBertForSequenceClassification
 
+from backend.services.redis_cache import redis_cache, text_hash, CLASSIFIER_PREFIX
+
 SAVE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "models", "classifier")
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 MAX_LEN = 128
@@ -85,7 +87,13 @@ class ClassifierService:
     def predict(self, text: str) -> dict:
         """
         Predict category, subcategory, priority, auto_resolve, assigned_team, and confidence.
+        Cached in Redis (when USE_REDIS_CACHE=True) keyed by md5(text).
         """
+        cache_key = CLASSIFIER_PREFIX + text_hash(text)
+        cached = redis_cache.get_json(cache_key)
+        if cached is not None:
+            return cached
+
         self.load()
 
         encoding = self.tokenizer(
@@ -140,7 +148,7 @@ class ClassifierService:
                     confidence = max(confidence, 0.92) 
                     break
 
-        return {
+        result = {
             "category": category,
             "subcategory": subcategory,
             "priority": priority,
@@ -148,3 +156,5 @@ class ClassifierService:
             "assigned_team": assigned_team,
             "confidence": confidence,
         }
+        redis_cache.set_json(cache_key, result)
+        return result

--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -6,6 +6,8 @@ Uses sentence-transformers all-MiniLM-L6-v2 to detect similar tickets.
 import uuid
 from sentence_transformers import SentenceTransformer, util
 
+from backend.services.redis_cache import redis_cache, text_hash, EMBEDDING_PREFIX
+
 SIMILARITY_THRESHOLD = 0.70
 
 
@@ -20,15 +22,25 @@ class DuplicateService:
         self.storage_file = os.path.join(os.path.dirname(__file__), "..", "data", "case_history_cache.json")
         os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
 
+    def _encode(self, text: str):
+        """Encode text into an embedding, using Redis cache when available."""
+        cache_key = EMBEDDING_PREFIX + text_hash(text)
+        cached = redis_cache.get_pickle(cache_key)
+        if cached is not None:
+            return cached
+        embedding = self.model.encode(text, convert_to_tensor=True)
+        redis_cache.set_pickle(cache_key, embedding)
+        return embedding
+
     def load(self):
         """Load the sentence-transformer model and saved tickets."""
         if self._loaded:
             return
-        
+
         print("[DuplicateService] Loading model...")
         self.model = SentenceTransformer("all-MiniLM-L6-v2")
         self._loaded = True
-        
+
         if os.path.exists(self.storage_file):
             print(f"[DuplicateService] Syncing previous ticket history from {self.storage_file}...")
             import json
@@ -37,7 +49,7 @@ class DuplicateService:
                     data = json.load(f)
                     for item in data:
                         text = item["text"]
-                        embedding = self.model.encode(text, convert_to_tensor=True)
+                        embedding = self._encode(text)
                         self._tickets.append((item["ticket_id"], embedding, text))
                 print(f"[DuplicateService] Loaded {len(self._tickets)} tickets.")
             except Exception as e:
@@ -68,7 +80,7 @@ class DuplicateService:
     def add_ticket(self, ticket_id: str, text: str):
         """Add a ticket to the in-memory store and persist to disk."""
         self.load()
-        embedding = self.model.encode(text, convert_to_tensor=True)
+        embedding = self._encode(text)
         self._tickets.append((ticket_id, embedding, text))
         self.save_to_disk(ticket_id, text)
 
@@ -99,7 +111,7 @@ class DuplicateService:
                 "similarity": 0.0,
             }
 
-        query_embedding = self.model.encode(text, convert_to_tensor=True)
+        query_embedding = self._encode(text)
 
         best_score = 0.0
         best_id = None

--- a/backend/services/redis_cache.py
+++ b/backend/services/redis_cache.py
@@ -1,0 +1,108 @@
+"""
+Redis Cache Service — Distributed caching layer for AI inference and embeddings.
+
+Provides a thin wrapper around redis-py with graceful degradation when Redis is
+unavailable. Controlled by the ``USE_REDIS_CACHE`` env toggle. When disabled or
+unreachable, all operations become no-ops so the server keeps running (honors
+``ALLOW_DEGRADED_STARTUP``).
+"""
+
+import os
+import json
+import hashlib
+import pickle
+import base64
+
+DEFAULT_TTL = int(os.getenv("REDIS_CACHE_TTL", "3600"))  # 1 hour
+CLASSIFIER_PREFIX = "helpdesk:classifier:"
+EMBEDDING_PREFIX = "helpdesk:embedding:"
+
+
+def text_hash(text: str) -> str:
+    """MD5 hash of ticket text — used as the cache key."""
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+
+class RedisCacheService:
+    def __init__(self):
+        self.client = None
+        self.enabled = False
+        self._initialized = False
+
+    def load(self):
+        """Connect to Redis if USE_REDIS_CACHE=True. Never raises."""
+        if self._initialized:
+            return
+        self._initialized = True
+
+        if os.getenv("USE_REDIS_CACHE", "False").lower() not in ("true", "1", "yes"):
+            print("[RedisCache] Disabled (USE_REDIS_CACHE != True).")
+            return
+
+        try:
+            import redis  # type: ignore
+        except ImportError:
+            print("[RedisCache] redis-py not installed — caching disabled.")
+            return
+
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        try:
+            self.client = redis.Redis.from_url(url, socket_connect_timeout=2, socket_timeout=2)
+            self.client.ping()
+            self.enabled = True
+            print(f"[RedisCache] Connected to {url}.")
+        except Exception as e:
+            self.client = None
+            self.enabled = False
+            allow_degraded = os.getenv("ALLOW_DEGRADED_STARTUP", "True").lower() in ("true", "1", "yes")
+            msg = f"[RedisCache] Connection failed ({e}). Running without cache."
+            if not allow_degraded:
+                raise RuntimeError(msg)
+            print(msg)
+
+    # ---- JSON helpers (for classifier output) ----
+    def get_json(self, key: str):
+        if not self.enabled or self.client is None:
+            return None
+        try:
+            raw = self.client.get(key)
+            if raw is None:
+                return None
+            return json.loads(raw)
+        except Exception as e:
+            print(f"[RedisCache] get_json failed: {e}")
+            return None
+
+    def set_json(self, key: str, value, ttl: int = DEFAULT_TTL):
+        if not self.enabled or self.client is None:
+            return
+        try:
+            self.client.setex(key, ttl, json.dumps(value))
+        except Exception as e:
+            print(f"[RedisCache] set_json failed: {e}")
+
+    # ---- Pickle helpers (for tensor embeddings) ----
+    def get_pickle(self, key: str):
+        if not self.enabled or self.client is None:
+            return None
+        try:
+            raw = self.client.get(key)
+            if raw is None:
+                return None
+            return pickle.loads(base64.b64decode(raw))
+        except Exception as e:
+            print(f"[RedisCache] get_pickle failed: {e}")
+            return None
+
+    def set_pickle(self, key: str, value, ttl: int = DEFAULT_TTL):
+        if not self.enabled or self.client is None:
+            return
+        try:
+            payload = base64.b64encode(pickle.dumps(value))
+            self.client.setex(key, ttl, payload)
+        except Exception as e:
+            print(f"[RedisCache] set_pickle failed: {e}")
+
+
+# Module-level singleton
+redis_cache = RedisCacheService()


### PR DESCRIPTION
Closes #131.

Added a `backend/services/redis_cache.py` module providing a graceful Redis wrapper (gated by `USE_REDIS_CACHE` with `ALLOW_DEGRADED_STARTUP` fallback, MD5-keyed JSON/pickle helpers, 1h default TTL) and wired it into `classifier_service.predict` (cache DistilBERT outputs by md5(text)) and `duplicate_service` (new `_encode` wrapper caches sentence-transformer embeddings for both stored history and query lookups). Registered `redis_cache.load()` in `main.py`'s lifespan and added `redis>=5.0.0` to `backend/requirements.txt`. All operations no-op when Redis is disabled or unreachable, so the server still starts cleanly.

Tests: no test suite detected

---
_Bounty attempt._