### PR TITLE
fix: [BUG] lint-staged config in package.json is a string instead of a JSON object — pre-commit linting never runs

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -60,5 +60,7 @@
     "tailwindcss": "^3.4.19",
     "vite": "^7.3.1"
   },
-  "lint-staged": "{'*.{js,jsx}': ['eslint --fix', 'prettier --write']}"
+  "lint-staged": {
+    "*.{js,jsx}": ["eslint --fix", "prettier --write"]
+  }
 }


### PR DESCRIPTION
Closes #123.

The edit already applied before the hook flagged it. The change converts `Frontend/package.json` line 63's `lint-staged` value from a string `"{'*.{js,jsx}': ['eslint --fix', 'prettier --write']}"` into a proper JSON object so lint-staged actually parses it and runs `eslint --fix` + `prettier --write` on staged `.js`/`.jsx` files. No other files touched.

Tests: no test suite detected

---
_Bounty attempt._