### PR TITLE
fix: [BUG] Missing .dockerignore causes bloated Docker builds — entire repo sent as build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,53 @@
+# Git
+.git/
+.gitattributes
+.github/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+.ipynb_checkpoints/
+venv/
+env/
+backend/venv/
+.env
+
+# Node / Frontend
+node_modules/
+Frontend/node_modules/
+Frontend/dist/
+dist/
+.vercel
+*.local
+package-lock.json
+
+# Mobile app (not needed for the backend image)
+MobileApp/
+
+# Model files and data (handled separately, not baked into the image)
+backend/models/
+backend/data/
+Model/
+
+# Docs, templates, scratch, and other dev-only artifacts
+docs/
+templates/
+scratch/
+*.md
+LICENSE
+
+# Editor / OS
+.vscode/
+.idea/
+.DS_Store
+
+# Logs
+*.log
+
+# CI / local caches
+.npm-cache/
+
+# Large data files
+*.xlsx


### PR DESCRIPTION
Closes #122.

Added `.dockerignore` at the project root listing everything the issue called out (`.git/`, `node_modules/`, `MobileApp/`, `backend/models/`, `backend/data/`, `docs/`, `templates/`, `scratch/`) plus the obvious adjacent noise (Python caches, Frontend build output, `.vscode/`, `*.xlsx`, etc.). The Dockerfile only copies `backend/requirements.txt` and `backend/`, so excluding everything else (and the two `backend/` subpaths) shrinks the build context dramatically without affecting the image contents.

Tests: no test suite detected

---
_Bounty attempt._