### PR TITLE
fix: add .dockerignore to reduce build context (#122)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# Version control
+.git
+.gitignore
+
+# Dependencies (will be installed in container)
+node_modules
+Frontend/node_modules
+backend/node_modules
+MobileApp/node_modules
+
+# Mobile app (not needed for web backend)
+MobileApp
+
+# Documentation
+docs
+*.md
+!README.md
+
+# Development files
+.vscode
+.idea
+*.log
+npm-debug.log*
+scratch
+
+# Build artifacts
+Frontend/build
+Frontend/dist
+backend/dist
+
+# Data and models (should be mounted, not baked in)
+backend/data
+backend/models
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker files (no need to include in context)
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# CI/CD
+.github
+
+# Test files
+**/*.test.js
+**/*.test.jsx
+**/*.spec.js
+**/*.spec.jsx
+__tests__


### PR DESCRIPTION
## What
Adds a `.dockerignore` file to exclude unnecessary files from Docker build context.

## Problem
No `.dockerignore` exists, so every Docker build sends the entire repo (including `.git/`, `node_modules/`, `MobileApp/`) to the daemon — hundreds of MB of unnecessary data.

## Solution
Created `.dockerignore` that excludes:
- `.git/` (version control history)
- `node_modules/` (will be installed in container)
- `MobileApp/` (not needed for web backend)
- `docs/`, `*.md` (documentation)
- `.vscode/`, `.idea/` (IDE files)
- `backend/data/`, `backend/models/` (should be mounted)
- Build artifacts, test files, OS files

## Impact
- Faster Docker builds
- Smaller build context
- Less bandwidth usage
- CI/CD pipeline improvement

Closes #122