### PR TITLE
fix: uncomment Resend API call for approval emails (#121)

### DIFF
--- a/supabase/functions/send-user-approval-email/index.ts
+++ b/supabase/functions/send-user-approval-email/index.ts
@@ -19,14 +19,16 @@ serve(async (req) => {
             throw new Error('Email is required');
         }
 
-        // Initialize Resend or another mail provider (Assuming user configures this later)
-        // const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
-        // Currently simulating a successfully sent email.
+        const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
+        const FROM_EMAIL = Deno.env.get('FROM_EMAIL') || 'HelpDesk.ai <noreply@yourdomain.com>';
+        const FRONTEND_URL = Deno.env.get('FRONTEND_URL') || 'https://your-frontend-url.com';
+
+        if (!RESEND_API_KEY) {
+            throw new Error('RESEND_API_KEY environment variable is not configured');
+        }
 
         console.log(`Sending approval email to ${email} for user ${name} in company ${company}...`);
 
-        // The email content could be sent via Resend:
-        /*
         const res = await fetch('https://api.resend.com/emails', {
             method: 'POST',
             headers: {
@@ -34,23 +36,30 @@ serve(async (req) => {
                 'Authorization': `Bearer ${RESEND_API_KEY}`,
             },
             body: JSON.stringify({
-                from: 'HelpDesk.ai <noreply@yourdomain.com>',
+                from: FROM_EMAIL,
                 to: [email],
                 subject: 'Account Approved! Welcome to HelpDesk.ai',
                 html: `
                     <h2>Hello ${name},</h2>
                     <p>Your account for <strong>${company}</strong> has been approved by your administrator!</p>
                     <p>You can now log in to the system and access your dashboard.</p>
-                    <a href="https://your-frontend-url.com/dashboard" style="background-color: #059669; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">Go to Dashboard</a>
+                    <a href="${FRONTEND_URL}/dashboard" style="background-color: #059669; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">Go to Dashboard</a>
                 `
             })
         });
-        */
+
+        if (!res.ok) {
+            const errorData = await res.text();
+            throw new Error(`Resend API error (${res.status}): ${errorData}`);
+        }
+
+        const data = await res.json();
 
         return new Response(
             JSON.stringify({
                 success: true,
-                message: `Approval email simulated for ${email}`
+                message: `Approval email sent to ${email}`,
+                emailId: data.id
             }),
             {
                 status: 200,
@@ -58,6 +67,7 @@ serve(async (req) => {
             }
         );
     } catch (error) {
+        console.error('Error sending approval email:', error.message);
         return new Response(
             JSON.stringify({ error: error.message }),
             {


### PR DESCRIPTION
## What
Uncomments the Resend API integration to actually send approval emails when users are approved.

## Problem
The `send-user-approval-email` edge function has the Resend API call wrapped in a `/* ... */` comment block. It only logs to console and returns `{ success: true, message: "Approval email simulated" }`. Users never receive email notifications.

## Solution
1. **Uncommented the Resend API call** — emails are now actually sent
2. **Added `RESEND_API_KEY` check** — throws clear error if not configured
3. **Made `FROM_EMAIL` configurable** — via `FROM_EMAIL` env var (defaults to `noreply@yourdomain.com`)
4. **Made `FRONTEND_URL` configurable** — via `FRONTEND_URL` env var for dashboard link
5. **Added error handling** — catches and logs Resend API errors
6. **Returns `emailId`** — for email tracking/delivery confirmation

## Required Environment Variables
```env
RESEND_API_KEY=re_xxxxxxxx
FROM_EMAIL=HelpDesk.ai <noreply@yourdomain.com>
FRONTEND_URL=https://your-frontend-url.com
```

## Testing
1. Set `RESEND_API_KEY` in Supabase edge function secrets
2. Approve a pending user
3. Check user's inbox for approval email

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User approval emails are now sent with proper delivery confirmation tracking and improved error handling to better report any delivery issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->