### PR TITLE
fix: change lint-staged config from string to proper JSON object so pre-commit linting actually runs (#123)

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -72,5 +72,7 @@
     "tailwindcss": "^3.4.19",
     "vite": "^7.3.1"
   },
-  "lint-staged": "{'*.{js,jsx}': ['eslint --fix', 'prettier --write']}"
+  "lint-staged": {
+    "*.{js,jsx}": ["eslint --fix", "prettier --write"]
+  }
 }


### PR DESCRIPTION
## Description

Fixes #123

The `lint-staged` config in `Frontend/package.json` was a **string** containing JavaScript-style single quotes and curly braces — not a valid JSON object. lint-staged silently ignored this invalid config and exited without running any linters. Pre-commit code quality checks (`eslint --fix` and `prettier --write`) never ran.

### Root Cause

Line 75 of `Frontend/package.json`:

`"lint-staged": "{'*.{js,jsx}': ['eslint --fix', 'prettier --write']}"`

This is a string with single quotes — invalid JSON. lint-staged expects a proper JSON object.

### Changes Made

**File:** `Frontend/package.json` (+2 / -1)

Changed the `lint-staged` config from a string to a proper JSON object:

```json
"lint-staged": {
  "*.{js,jsx}": ["eslint --fix", "prettier --write"]
}
```
### Verification
- ✅ `JSON.parse()` succeeds — valid JSON
- ✅ `typeof lint-staged = object` — correct type, not a string
- ✅ Pattern `*.{js,jsx}` targets all staged JS/JSX files
- ✅ `eslint --fix` configured as first command
- ✅ `prettier --write` configured as second command
- ✅ Both `eslint` and `prettier` already in `devDependencies` — no new dependencies needed