### PR TITLE
feat: Redis caching for AI categorization and embeddings (#131)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,12 @@ NOTIFICATION_ROUTING_LOG_LEVEL=info
 # -----------------------------------------------------------------------------
 # Set to `development` to enable extra debug logging in some services.
 ENV=production
+
+
+# -----------------------------------------------------------------------------
+# Redis Inference Cache (Issue #131)
+# -----------------------------------------------------------------------------
+# When true, cache DistilBERT classifications and sentence-transformer embeddings.
+USE_REDIS_CACHE=false
+REDIS_URL=redis://127.0.0.1:6379/0
+REDIS_CACHE_TTL_SECONDS=3600

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,6 +64,7 @@ from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
 from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sla_policy
 from backend.services.semantic_duplicate_service import SemanticDuplicateService
+from backend.services.redis_cache import redis_cache
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +117,16 @@ def detect_semantic_duplicate(text: str, *, company_id: str | None, threshold: f
 
 def classify_ticket_text(text: str) -> dict:
     """Run the local classifier cascade with ONNX as the offline fallback path."""
+    cached = redis_cache.get_classification(text)
+    if cached:
+        return cached
+
+    result = _classify_ticket_text_uncached(text)
+    redis_cache.set_classification(text, result)
+    return result
+
+
+def _classify_ticket_text_uncached(text: str) -> dict:
     try:
         classification_v3_res = classifier_v3.predict(text)
         if "error" not in classification_v3_res:
@@ -388,6 +399,10 @@ def detect_and_translate_ticket_text(text: str) -> dict:
 async def lifespan(app: FastAPI):
     """Load all models at startup."""
     print("[Startup] Loading AI models ...")
+    try:
+        redis_cache.connect()
+    except Exception as e:
+        print(f"[WARNING] Redis cache not available: {e}")
     try:
         classifier_service.load()
     except FileNotFoundError as e:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ easyocr
 slowapi>=0.1.9
 supabase==2.22.4
 storage3==2.22.4
+redis>=5.0.0
 pytest
 pytest-asyncio
 httpx

--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -101,12 +101,20 @@ class DuplicateService:
 
     def generate_embedding(self, text: str) -> list[float] | None:
         """Generate a 384-d embedding for the provided ticket text."""
+        from backend.services.redis_cache import redis_cache
+
+        cached = redis_cache.get_embedding(text)
+        if cached is not None:
+            return cached
+
         self.load()
         if not self.is_available():
             return None
 
         embedding = self.model.encode(text, convert_to_tensor=False, normalize_embeddings=True)
-        return [float(value) for value in embedding.tolist()]
+        values = [float(value) for value in embedding.tolist()]
+        redis_cache.set_embedding(text, values)
+        return values
 
     def _build_result(
         self,

--- a/backend/services/redis_cache.py
+++ b/backend/services/redis_cache.py
@@ -1,0 +1,108 @@
+"""Redis cache for AI inference (classification + embeddings)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CLASSIFICATION_PREFIX = "helpdesk:cls:"
+EMBEDDING_PREFIX = "helpdesk:emb:"
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _text_key(prefix: str, text: str) -> str:
+    digest = hashlib.md5(text.strip().lower().encode("utf-8")).hexdigest()
+    return f"{prefix}{digest}"
+
+
+class RedisInferenceCache:
+    """Optional Redis layer for DistilBERT classifications and ST embeddings."""
+
+    def __init__(self) -> None:
+        self._client: Any | None = None
+        self.enabled = _truthy(os.getenv("USE_REDIS_CACHE"))
+        self.allow_degraded = _truthy(os.getenv("ALLOW_DEGRADED_STARTUP"))
+        self.ttl_seconds = int(os.getenv("REDIS_CACHE_TTL_SECONDS", "3600"))
+
+    @property
+    def available(self) -> bool:
+        return self.enabled and self._client is not None
+
+    def connect(self) -> None:
+        if not self.enabled:
+            logger.info("[RedisCache] Disabled (USE_REDIS_CACHE=false)")
+            return
+
+        try:
+            import redis
+
+            url = os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0")
+            client = redis.from_url(url, decode_responses=True, socket_connect_timeout=2)
+            client.ping()
+            self._client = client
+            logger.info("[RedisCache] Connected")
+        except Exception as error:
+            self._client = None
+            message = f"[RedisCache] Unavailable: {error}"
+            if self.allow_degraded:
+                logger.warning("%s — bypassing cache", message)
+            else:
+                raise RuntimeError(message) from error
+
+    def get_classification(self, text: str) -> dict | None:
+        if not self.available:
+            return None
+        try:
+            raw = self._client.get(_text_key(CLASSIFICATION_PREFIX, text))
+            return json.loads(raw) if raw else None
+        except Exception as error:
+            logger.warning("[RedisCache] classification get failed: %s", error)
+            return None
+
+    def set_classification(self, text: str, payload: dict) -> None:
+        if not self.available:
+            return
+        try:
+            self._client.setex(
+                _text_key(CLASSIFICATION_PREFIX, text),
+                self.ttl_seconds,
+                json.dumps(payload),
+            )
+        except Exception as error:
+            logger.warning("[RedisCache] classification set failed: %s", error)
+
+    def get_embedding(self, text: str) -> list[float] | None:
+        if not self.available:
+            return None
+        try:
+            raw = self._client.get(_text_key(EMBEDDING_PREFIX, text))
+            if not raw:
+                return None
+            values = json.loads(raw)
+            return [float(v) for v in values]
+        except Exception as error:
+            logger.warning("[RedisCache] embedding get failed: %s", error)
+            return None
+
+    def set_embedding(self, text: str, embedding: list[float]) -> None:
+        if not self.available:
+            return
+        try:
+            self._client.setex(
+                _text_key(EMBEDDING_PREFIX, text),
+                self.ttl_seconds,
+                json.dumps(embedding),
+            )
+        except Exception as error:
+            logger.warning("[RedisCache] embedding set failed: %s", error)
+
+
+redis_cache = RedisInferenceCache()

--- a/backend/services/semantic_duplicate_service.py
+++ b/backend/services/semantic_duplicate_service.py
@@ -66,10 +66,18 @@ class SemanticDuplicateService:
         Generate a 384-dimensional embedding vector for the given text.
         Returns None if the model isn't loaded.
         """
+        from backend.services.redis_cache import redis_cache
+
+        cached = redis_cache.get_embedding(text)
+        if cached is not None:
+            return cached
+
         if not self.model:
             return None
         try:
-            return self.model.encode(text).tolist()
+            embedding = self.model.encode(text).tolist()
+            redis_cache.set_embedding(text, embedding)
+            return embedding
         except Exception as e:
             logger.error(f"[SemanticDuplicate] Embedding error: {e}")
             return None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -266,7 +266,15 @@ def fake_supabase(fake_db):
 
 
 @pytest.fixture(autouse=True)
-def mock_ai_services():
+def mock_ai_services(request):
+    if request.node.fspath.basename in {
+        "test_redis_cache.py",
+        "test_semantic_duplicates.py",
+        "test_auth_cookie.py",
+    }:
+        yield
+        return
+
     import backend.main as main
 
     with patch.object(main.classifier_service, "predict") as mock_v1_predict, \

--- a/backend/tests/test_redis_cache.py
+++ b/backend/tests/test_redis_cache.py
@@ -1,0 +1,79 @@
+"""Tests for Redis inference cache (issue #131)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.services.redis_cache import RedisInferenceCache, _text_key, CLASSIFICATION_PREFIX, EMBEDDING_PREFIX
+
+
+@pytest.fixture(autouse=True)
+def reset_env(monkeypatch):
+    monkeypatch.delenv("USE_REDIS_CACHE", raising=False)
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("ALLOW_DEGRADED_STARTUP", raising=False)
+    monkeypatch.delenv("REDIS_CACHE_TTL_SECONDS", raising=False)
+
+
+def test_text_key_is_stable():
+    assert _text_key(CLASSIFICATION_PREFIX, "Hello") == _text_key(CLASSIFICATION_PREFIX, " hello ")
+    assert _text_key(CLASSIFICATION_PREFIX, "A") != _text_key(EMBEDDING_PREFIX, "A")
+
+
+def test_cache_disabled_by_default():
+    cache = RedisInferenceCache()
+    cache.connect()
+    assert cache.available is False
+    assert cache.get_classification("ticket") is None
+
+
+def test_classification_roundtrip(monkeypatch):
+    monkeypatch.setenv("USE_REDIS_CACHE", "true")
+    client = MagicMock()
+    client.ping.return_value = True
+    store = {}
+
+    def setex(key, ttl, value):
+        store[key] = value
+
+    client.get.side_effect = lambda key: store.get(key)
+    client.setex.side_effect = setex
+
+    cache = RedisInferenceCache()
+    with patch("redis.from_url", return_value=client):
+        cache.connect()
+
+    payload = {"category": "Billing", "priority": "High"}
+    assert cache.get_classification("payment failed") is None
+    cache.set_classification("payment failed", payload)
+    assert cache.get_classification("payment failed") == payload
+
+
+def test_embedding_roundtrip(monkeypatch):
+    monkeypatch.setenv("USE_REDIS_CACHE", "true")
+    client = MagicMock()
+    client.ping.return_value = True
+    store = {}
+
+    client.get.side_effect = lambda key: store.get(key)
+    client.setex.side_effect = lambda key, ttl, value: store.update({key: value})
+
+    cache = RedisInferenceCache()
+    with patch("redis.from_url", return_value=client):
+        cache.connect()
+
+    vector = [0.1, 0.2, 0.3]
+    cache.set_embedding("duplicate ticket", vector)
+    assert cache.get_embedding("duplicate ticket") == vector
+
+
+def test_degraded_startup_bypasses_redis(monkeypatch):
+    monkeypatch.setenv("USE_REDIS_CACHE", "true")
+    monkeypatch.setenv("ALLOW_DEGRADED_STARTUP", "1")
+
+    cache = RedisInferenceCache()
+    with patch("redis.from_url", side_effect=ConnectionError("down")):
+        cache.connect()
+
+    assert cache.available is False
+    assert cache.get_embedding("x") is None


### PR DESCRIPTION
## Summary
- Adds optional Redis cache for DistilBERT/classifier outputs and sentence-transformer embeddings
- MD5 text keys, 1h TTL (configurable), USE_REDIS_CACHE + REDIS_URL env toggles
- Graceful bypass when Redis is offline and ALLOW_DEGRADED_STARTUP=1
- 5 unit tests

Closes #131

Made with [Cursor](https://cursor.com)