### PR TITLE
[BOUNTY] [level:critical] Implement AES-256-GCM Encryption for PII Fields in Ticket Database

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,33 @@
 # Changes Made
 
-This file summarizes the code change made to address the duplicate-detection issue reported in the backend.
+This file summarizes the code changes made to address issues reported in the backend.
+
+## Added: AES-256-GCM Encryption for PII Fields (Issue #166)
+
+### What changed
+- Created `backend/auth/crypto.py` — a cryptographic helper module using AES-256 in GCM mode (via the `cryptography` library).
+- The module reads `DB_ENCRYPTION_SECRET_KEY` from the environment (expects a 64-character hex-encoded 256-bit key).
+- Provides `encrypt_field()` / `decrypt_field()` functions with a `crypto_available` flag for graceful degradation.
+- Integrated encryption hooks in `backend/main.py`:
+  - On `POST /tickets/save`: `description`, `contact_email`, and `raw_text` fields are encrypted before being inserted into Supabase.
+  - On `GET /tickets` and `GET /tickets/{ticket_id}`: PII fields are automatically decrypted after fetch via a `_decrypt_ticket_pii()` helper.
+- Added `contact_email` and `raw_text` fields to `TicketSaveRequest` model and `VALID_TICKET_COLUMNS`.
+- Added `cryptography>=44.0.0` to `backend/requirements.txt`.
+- Added `DB_ENCRYPTION_SECRET_KEY` reference to `backend/.env.example`.
+- Created `backend/tests/test_crypto.py` with 14 unit tests covering encrypt/decrypt round-trip, key validation, degraded mode, and edge cases.
+
+### Why this was needed
+To meet enterprise-grade compliance (GDPR/HIPAA), sensitive PII fields (email addresses, ticket descriptions, raw text) must be encrypted at rest in the database. Previously these fields were stored in plaintext, making the database a liability in case of a breach.
+
+### Result
+- PII fields are transparently encrypted with AES-256-GCM before persisting to Supabase and decrypted on read.
+- Each encryption produces a unique ciphertext (random nonce per GCM operation) — same plaintext never looks the same.
+- If `DB_ENCRYPTION_SECRET_KEY` is unset, the server starts gracefully with a warning log and stores fields in plaintext (safe for local dev).
+- Invalid keys or tampered ciphertexts raise clear errors.
+
+### Validation
+- `python -m unittest backend.tests.test_crypto -v` — all 14 tests pass (5 round-trip/edge-case tests, 3 degraded-mode tests, 3 key-validation tests, 3 error-handling tests).
+
 
 ## Fixed: Duplicate detection now learns from saved tickets
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -104,3 +104,16 @@ ENV=production
 USE_REDIS_CACHE=false
 REDIS_URL=redis://127.0.0.1:6379/0
 REDIS_CACHE_TTL_SECONDS=3600
+
+# -----------------------------------------------------------------------------
+# PII Field Encryption at Rest (Issue #166)
+# -----------------------------------------------------------------------------
+# AES-256-GCM encryption key for encrypting sensitive PII fields
+# (description, contact_email, raw_text) in the tickets table before they are
+# stored in Supabase.  Generate a 64-character hex string with:
+#
+#     python -c "import secrets; print(secrets.token_hex(32))"
+#
+# If unset, the server will still start but will log a warning and store PII
+# fields in PLAINTEXT — not suitable for production.
+DB_ENCRYPTION_SECRET_KEY=

--- a/backend/auth/__init__.py
+++ b/backend/auth/__init__.py
@@ -1,0 +1,1 @@
+# Auth package — cryptographic helpers for PII protection

--- a/backend/auth/crypto.py
+++ b/backend/auth/crypto.py
@@ -1,0 +1,171 @@
+"""
+AES-256-GCM cryptographic helper for PII field encryption at rest.
+
+Usage:
+    from backend.auth.crypto import encrypt_field, decrypt_field, crypto_available
+
+    # Encrypt before DB insert
+    encrypted = encrypt_field("user@example.com")
+
+    # Decrypt after DB read
+    plaintext = decrypt_field(encrypted)
+
+    # Check if encryption is active
+    if crypto_available:
+        ...
+    else:
+        # Log warning, skip encryption
+        ...
+
+Key:
+    Read from ``DB_ENCRYPTION_SECRET_KEY`` environment variable.
+    Must be a hex-encoded 64-character string (32 bytes = 256 bits).
+    If unset, the module operates in degraded mode — all operations
+    return the original value with a warning log.
+"""
+
+import os
+import base64
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_KEY: Optional[bytes] = None
+"""Derived 32-byte AES key, or ``None`` in degraded mode."""
+
+_NONCE_BYTES = 12
+"""GCM standard nonce length (96 bits)."""
+_TAG_BYTES = 16
+"""GCM authentication tag (128 bits)."""
+
+
+def _load_key() -> Optional[bytes]:
+    """Read and validate the encryption key from the environment.
+
+    Returns:
+        A 32-byte key or ``None`` if the env var is missing or invalid.
+    """
+    raw = os.environ.get("DB_ENCRYPTION_SECRET_KEY", "").strip()
+    if not raw:
+        logger.warning(
+            "[CRYPTO] DB_ENCRYPTION_SECRET_KEY is not set — PII encryption "
+            "is DISABLED. Set a 64-char hex-encoded 256-bit key to enable."
+        )
+        return None
+
+    try:
+        key = bytes.fromhex(raw)
+    except ValueError:
+        logger.error(
+            "[CRYPTO] DB_ENCRYPTION_SECRET_KEY is not valid hex — "
+            "PII encryption DISABLED."
+        )
+        return None
+
+    if len(key) != 32:
+        logger.error(
+            f"[CRYPTO] DB_ENCRYPTION_SECRET_KEY must be 32 bytes "
+            f"(64 hex chars), got {len(key)} bytes — "
+            f"PII encryption DISABLED."
+        )
+        return None
+
+    return key
+
+
+crypto_available: bool
+"""``True`` when a valid encryption key is configured and AES is ready."""
+
+
+def init() -> None:
+    """(Re)load the encryption key.
+
+    Called automatically at import time.  Idempotent — call again
+    after changing ``DB_ENCRYPTION_SECRET_KEY`` at runtime if needed.
+    """
+    global _KEY, crypto_available
+    _KEY = _load_key()
+    crypto_available = _KEY is not None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def encrypt_field(plaintext: Optional[str]) -> Optional[str]:
+    """Encrypt a single PII field value.
+
+    Args:
+        plaintext: The raw string to encrypt.  ``None`` and empty strings
+            are passed through unchanged.
+
+    Returns:
+        Base64-encoded ciphertext (nonce + ciphertext + tag) when a key
+        is configured, or the original value when running in degraded mode.
+    """
+    if not plaintext:
+        return plaintext
+    if _KEY is None:
+        return plaintext
+
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    nonce = os.urandom(_NONCE_BYTES)
+    aesgcm = AESGCM(_KEY)
+    ciphertext = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+
+    # Pack: nonce (12) || ciphertext || tag (16) → base64
+    payload = nonce + ciphertext
+    return base64.b64encode(payload).decode("ascii")
+
+
+def decrypt_field(ciphertext_b64: Optional[str]) -> Optional[str]:
+    """Decrypt a single PII field value.
+
+    Args:
+        ciphertext_b64: Base64-encoded payload produced by :func:`encrypt_field`.
+
+    Returns:
+        The original plaintext string, or the original value when running
+        in degraded mode.  Returns ``None`` for ``None`` inputs.
+
+    Raises:
+        ValueError: If the payload cannot be decoded or the authentication
+            tag is invalid (tampered data or wrong key).
+    """
+    if not ciphertext_b64:
+        return ciphertext_b64
+    if _KEY is None:
+        return ciphertext_b64
+
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    try:
+        payload = base64.b64decode(ciphertext_b64)
+    except Exception as exc:
+        raise ValueError("Failed to decode ciphertext payload") from exc
+
+    if len(payload) < _NONCE_BYTES + _TAG_BYTES:
+        raise ValueError(
+            f"Ciphertext payload too short ({len(payload)} bytes). "
+            f"Expected at least {_NONCE_BYTES + _TAG_BYTES} bytes."
+        )
+
+    nonce = payload[:_NONCE_BYTES]
+    ciphertext = payload[_NONCE_BYTES:]
+
+    aesgcm = AESGCM(_KEY)
+    plaintext = aesgcm.decrypt(nonce, ciphertext, None)
+    return plaintext.decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Module initialisation
+# ---------------------------------------------------------------------------
+init()

--- a/backend/main.py
+++ b/backend/main.py
@@ -73,6 +73,32 @@ from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sl
 from backend.services.redis_cache import redis_cache
 from backend.auth_cookie import router as auth_cookie_router, get_current_user  # noqa: F401
 
+# Cryptographic helper for PII field encryption at rest
+from backend.auth.crypto import encrypt_field, decrypt_field, crypto_available
+
+# Fields in the tickets table that contain PII and must be encrypted at rest
+PII_FIELDS = ("description", "contact_email", "raw_text")
+
+
+def _decrypt_ticket_pii(ticket: dict) -> dict:
+    """Decrypt PII fields on a single ticket dict **in-place**.
+
+    If the crypto key is missing or decryption fails, the original
+    (potentially encrypted) value is preserved and a warning is logged.
+    """
+    if not ticket:
+        return ticket
+    for field in PII_FIELDS:
+        raw = ticket.get(field)
+        if not raw:
+            continue
+        try:
+            ticket[field] = decrypt_field(raw) or raw
+        except Exception as exc:
+            logger = logging.getLogger(__name__)
+            logger.warning(f"[PII] Failed to decrypt '{field}' on ticket {ticket.get('id', '?')}: {exc}")
+    return ticket
+
 
 # ---------------------------------------------------------------------------
 # Request / Response models
@@ -184,6 +210,8 @@ class TicketSaveRequest(BaseModel):
     user_id: str
     subject: str
     description: str
+    contact_email: str | None = None
+    raw_text: str | None = None
     category: str
     subcategory: str
     priority: str
@@ -743,6 +771,11 @@ async def get_tickets(company_id: str | None = None):
         query = query.eq("company_id", company_id)
         
     res = query.execute()
+
+    # Decrypt PII fields on all returned tickets
+    if res.data:
+        for ticket in res.data:
+            _decrypt_ticket_pii(ticket)
     return res.data
 
 @app.post("/tickets/save")
@@ -881,7 +914,8 @@ async def save_ticket(request_body: TicketSaveRequest):
         # Extra AI telemetry and non-existent schema fields are merged into the metadata JSONB column
         # to avoid 400/500 errors from unknown column names in the insert call.
         VALID_TICKET_COLUMNS = {
-            "user_id", "subject", "description", "category", "subcategory",
+            "user_id", "subject", "description", "contact_email", "raw_text",
+            "category", "subcategory",
             "priority", "assigned_team", "status", "auto_resolve", "is_duplicate",
             "confidence", "image_url", "company", "company_id",
             "sla_breach_at", "sla_response_due_at", "sla_status", "escalation_level", "metadata",
@@ -899,6 +933,16 @@ async def save_ticket(request_body: TicketSaveRequest):
 
         # Strip keys not accepted by the DB schema
         insert_data = {k: v for k, v in final_data.items() if k in VALID_TICKET_COLUMNS}
+
+        # Encrypt PII fields at rest before persisting to database
+        for pii_field in ("description", "contact_email", "raw_text"):
+            if pii_field in insert_data and insert_data[pii_field]:
+                insert_data[pii_field] = encrypt_field(insert_data[pii_field])
+                if not crypto_available:
+                    logger.warning(
+                        f"[PII] Storing '{pii_field}' in plaintext — "
+                        "set DB_ENCRYPTION_SECRET_KEY to enable AES-256-GCM encryption."
+                    )
 
         res = supabase.table("tickets").insert(insert_data).execute()
         
@@ -980,7 +1024,7 @@ async def get_ticket_by_id(
     res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
-    return res.data
+    return _decrypt_ticket_pii(dict(res.data))
 
 
 @app.get("/tickets/{ticket_id}/audit_logs", response_model=list[AuditLogRecord])

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ easyocr
 slowapi>=0.1.9
 supabase==2.22.4
 storage3==2.22.4
+cryptography>=44.0.0
 redis>=5.0.0
 pytest
 pytest-asyncio

--- a/backend/tests/test_crypto.py
+++ b/backend/tests/test_crypto.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for the AES-256-GCM PII encryption helper module.
+
+Run with:
+    python -m pytest backend/tests/test_crypto.py -v
+    python -m unittest backend.tests.test_crypto -v
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestCryptoHelpers(unittest.TestCase):
+    """Test encrypt_field / decrypt_field round-trip and edge cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set a valid encryption key in the environment once for this class."""
+        # A 32-byte (64 hex char) test key — never use this in production!
+        cls.test_key = "5f6b0a491c0356b49974c3ab199edf611c39eeb477581b2754c9086af3196df6"
+        cls.patcher = patch.dict(os.environ, {"DB_ENCRYPTION_SECRET_KEY": cls.test_key})
+        cls.patcher.start()
+        # Re-import / re-init so the module picks up the test key
+        import backend.auth.crypto as crypto_mod
+        crypto_mod.init()
+        cls.crypto = crypto_mod
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.patcher.stop()
+
+    def test_round_trip_encrypt_decrypt(self):
+        """A plaintext value should survive a full encrypt → decrypt cycle."""
+        plaintext = "user@example.com"
+        encrypted = self.crypto.encrypt_field(plaintext)
+        self.assertIsNotNone(encrypted)
+        self.assertNotEqual(encrypted, plaintext)
+
+        decrypted = self.crypto.decrypt_field(encrypted)
+        self.assertEqual(decrypted, plaintext)
+
+    def test_round_trip_long_text(self):
+        """Long multi-line descriptions should encrypt and decrypt correctly."""
+        plaintext = (
+            "Dear support team,\n\n"
+            "My laptop model ABC-123 is overheating after the latest BIOS update. "
+            "I've tried restarting multiple times. Please help!\n\n"
+            "Regards,\nJohn Doe\ncontact: john.doe@company.com"
+        )
+        encrypted = self.crypto.encrypt_field(plaintext)
+        decrypted = self.crypto.decrypt_field(encrypted)
+        self.assertEqual(decrypted, plaintext)
+
+    def test_encrypt_different_each_time(self):
+        """GCM mode uses a random nonce so the same plaintext should produce
+        different ciphertext on each call."""
+        plaintext = "always-the-same@example.com"
+        c1 = self.crypto.encrypt_field(plaintext)
+        c2 = self.crypto.encrypt_field(plaintext)
+        self.assertNotEqual(c1, c2)
+
+    def test_none_passthrough(self):
+        """None values should pass through unchanged (no error)."""
+        self.assertIsNone(self.crypto.encrypt_field(None))
+        self.assertIsNone(self.crypto.decrypt_field(None))
+
+    def test_empty_string_passthrough(self):
+        """Empty strings should pass through unchanged."""
+        self.assertEqual(self.crypto.encrypt_field(""), "")
+        self.assertEqual(self.crypto.decrypt_field(""), "")
+
+    def test_decrypt_invalid_base64_raises(self):
+        """Tampered ciphertext should raise ValueError."""
+        with self.assertRaises(ValueError):
+            self.crypto.decrypt_field("this-is-not-valid-base64!!")
+
+    def test_decrypt_wrong_key_raises(self):
+        """Decrypting with a different key should raise an auth error."""
+        plaintext = "secret-pii-data"
+        encrypted = self.crypto.encrypt_field(plaintext)
+
+        # Temporarily swap to a different key
+        wrong_key = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        with patch.dict(os.environ, {"DB_ENCRYPTION_SECRET_KEY": wrong_key}):
+            import backend.auth.crypto as crypto_mod
+            crypto_mod.init()
+            with self.assertRaises(Exception):
+                crypto_mod.decrypt_field(encrypted)
+
+    def test_crypto_available_flag(self):
+        """crypto_available should be True when key is set."""
+        self.assertTrue(self.crypto.crypto_available)
+
+
+class TestCryptoDegradedMode(unittest.TestCase):
+    """Behaviour when no encryption key is configured."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.patcher = patch.dict(os.environ, {"DB_ENCRYPTION_SECRET_KEY": ""})
+        cls.patcher.start()
+        import backend.auth.crypto as crypto_mod
+        crypto_mod.init()
+        cls.crypto = crypto_mod
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.patcher.stop()
+
+    def test_crypto_available_false(self):
+        """crypto_available should be False without a key."""
+        self.assertFalse(self.crypto.crypto_available)
+
+    def test_encrypt_passthrough_degraded(self):
+        """Without a key, encrypt_field should return the original value."""
+        val = "user@example.com"
+        self.assertEqual(self.crypto.encrypt_field(val), val)
+
+    def test_decrypt_passthrough_degraded(self):
+        """Without a key, decrypt_field should return the original value."""
+        val = "some-encrypted-looking-value"
+        self.assertEqual(self.crypto.decrypt_field(val), val)
+
+
+class TestCryptoKeyValidation(unittest.TestCase):
+    """Key validation edge cases on init()."""
+
+    def test_invalid_hex_key_logs_error(self):
+        """A key that is not valid hex should disable crypto."""
+        with patch.dict(os.environ, {"DB_ENCRYPTION_SECRET_KEY": "not-hex-key!!"}):
+            import backend.auth.crypto as crypto_mod
+            crypto_mod.init()
+            self.assertFalse(crypto_mod.crypto_available)
+
+    def test_short_key_logs_error(self):
+        """A hex key shorter than 32 bytes should disable crypto."""
+        with patch.dict(os.environ, {"DB_ENCRYPTION_SECRET_KEY": "aabb"}):
+            import backend.auth.crypto as crypto_mod
+            crypto_mod.init()
+            self.assertFalse(crypto_mod.crypto_available)
+
+    def test_long_key_logs_error(self):
+        """A hex key longer than 32 bytes should disable crypto."""
+        with patch.dict(os.environ, {"DB_ENCRYPTION_SECRET_KEY": "aa" * 33}):
+            import backend.auth.crypto as crypto_mod
+            crypto_mod.init()
+            self.assertFalse(crypto_mod.crypto_available)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
Implements AES-256-GCM encryption/decryption hooks for PII fields in the tickets table to meet enterprise-grade compliance (GDPR/HIPAA).

Fixes #166

## Changes

### New files
- **`backend/auth/crypto.py`** — Cryptographic helper module using AES-256-GCM mode (via the `cryptography` library). Reads `DB_ENCRYPTION_SECRET_KEY` from environment (64-char hex = 32 bytes). Provides `encrypt_field()` / `decrypt_field()` with a `crypto_available` flag.
- **`backend/auth/__init__.py`** — Package init
- **`backend/tests/test_crypto.py`** — 14 unit tests covering encrypt/decrypt round-trip, degraded mode, key validation, and error handling

### Modified files
- **`backend/main.py`**
  - Added `contact_email` and `raw_text` to `TicketSaveRequest` and `VALID_TICKET_COLUMNS`
  - On `POST /tickets/save`: encrypts `description`, `contact_email`, `raw_text` before Supabase insert
  - On `GET /tickets` and `GET /tickets/{id}`: decrypts PII fields on read via `_decrypt_ticket_pii()`
  - Logs warning if `DB_ENCRYPTION_SECRET_KEY` is unset (graceful degrade)
- **`backend/requirements.txt`** — Added `cryptography>=44.0.0`
- **`backend/.env.example`** — Added `DB_ENCRYPTION_SECRET_KEY` documentation
- **`CHANGES.md`** — Documented the feature

## Key Design Decisions
| Decision | Rationale |
|----------|-----------|
| AES-256-GCM | NIST-standard AEAD — built-in authentication, random nonce per operation |
| Lazy import of `cryptography` | Imported inside encrypt/decrypt functions so degraded mode doesn't require the library |
| Nonce \|\| ciphertext packed as base64 | Compact single-column storage (`TEXT` type) |
| Graceful degrade | No key → warning log + plaintext passthrough; server starts without error |
| `init()` function | Allows re-initialization at runtime if env changes |

## Validation
python -m unittest backend.tests.test_crypto -v
----------------------------------------------------------------------
Ran 14 tests in 0.019s OK

## Checklist
- [x] Branch targets `gssoc` (not `main`)
- [x] Atomic commit with descriptive message (fixes #166)
- [x] All 14 tests pass
- [x] PEP 8 style, type hints
- [x] Graceful degrade if env var unset
- [x] `CHANGES.md` updated