### PR TITLE
fix: move mobile Supabase config to env

### DIFF
--- a/MobileApp/.env.example
+++ b/MobileApp/.env.example
@@ -1,0 +1,2 @@
+EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/MobileApp/src/lib/supabase.js
+++ b/MobileApp/src/lib/supabase.js
@@ -2,8 +2,14 @@ import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const supabaseUrl = 'https://aejuenhqciagpntcqoir.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzIzODQwNzgsImV4cCI6MjA4Nzk2MDA3OH0.-OxgEW5t4alPGlzV_JZDRZcLsQbbMap6jiWjfAVkMMY';
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    'Missing Supabase mobile config. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY in MobileApp/.env or EAS secrets.'
+  );
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey, {
   auth: {

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -272,6 +272,7 @@ def mock_ai_services(request):
         "test_redis_cache.py",
         "test_semantic_duplicates.py",
         "test_auth_cookie.py",
+        "test_mobile_supabase_env.py",
     }:
         yield
         return

--- a/backend/tests/test_mobile_supabase_env.py
+++ b/backend/tests/test_mobile_supabase_env.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+def test_mobile_supabase_client_reads_expo_env_vars():
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "MobileApp"
+        / "src"
+        / "lib"
+        / "supabase.js"
+    ).read_text(encoding="utf-8")
+
+    assert "process.env.EXPO_PUBLIC_SUPABASE_URL" in source
+    assert "process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY" in source
+    assert "createClient(supabaseUrl, supabaseKey" in source
+
+
+def test_mobile_supabase_client_does_not_hardcode_project_credentials():
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "MobileApp"
+        / "src"
+        / "lib"
+        / "supabase.js"
+    ).read_text(encoding="utf-8")
+
+    assert "aejuenhqciagpntcqoir.supabase.co" not in source
+    assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in source
+
+
+def test_mobile_env_example_documents_required_keys():
+    source = (
+        Path(__file__).resolve().parents[2] / "MobileApp" / ".env.example"
+    ).read_text(encoding="utf-8")
+
+    assert "EXPO_PUBLIC_SUPABASE_URL=" in source
+    assert "EXPO_PUBLIC_SUPABASE_ANON_KEY=" in source


### PR DESCRIPTION
## Summary
- removes the hardcoded Supabase project URL and anon key from the Expo mobile app source
- reads mobile Supabase config from EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY
- adds MobileApp/.env.example plus regression coverage so hardcoded credentials do not return

## Testing
- python3 -m pytest backend/tests/test_mobile_supabase_env.py -q
- PYTHONPYCACHEPREFIX=/private/tmp/helpdesk-issue-151/.pycache python3 -m py_compile backend/tests/test_mobile_supabase_env.py backend/tests/conftest.py
- git diff --check