### PR TITLE
fix: enforce tenant auth on ticket reads

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -735,15 +735,62 @@ async def log_correction(raw_request: Request):
 # ---------------------------------------------------------------------------
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
+MASTER_TICKET_ROLES = {"master_admin", "super_admin", "superadmin", "owner"}
+
+
+def _get_auth_user_id(user: dict) -> str:
+    user_id = user.get("id") or user.get("sub") or user.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid authenticated user")
+    return str(user_id)
+
+
+def _get_authenticated_profile(user: dict) -> dict:
+    user_id = _get_auth_user_id(user)
+    res = (
+        supabase.table("profiles")
+        .select("id, company_id, company, role")
+        .eq("id", user_id)
+        .single()
+        .execute()
+    )
+    if not res.data:
+        raise HTTPException(status_code=403, detail="User profile not found")
+    return res.data
+
+
+def _is_master_ticket_reader(profile: dict) -> bool:
+    role = str(profile.get("role") or "").lower()
+    return role in MASTER_TICKET_ROLES
+
+
+def _ticket_company_scope(profile: dict, requested_company_id: str | None = None) -> str | None:
+    if _is_master_ticket_reader(profile):
+        return requested_company_id
+
+    company_id = profile.get("company_id")
+    if not company_id:
+        raise HTTPException(status_code=403, detail="User tenant is not configured")
+    if requested_company_id and requested_company_id != company_id:
+        raise HTTPException(status_code=403, detail="User not authorized for this tenant")
+    return str(company_id)
+
+
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
+async def get_tickets(
+    company_id: str | None = None,
+    current_user: dict = Depends(get_current_user),
+):
     """Fetch persistent tickets from Supabase."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile, company_id)
     
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
-    if company_id:
-        query = query.eq("company_id", company_id)
+    if company_scope:
+        query = query.eq("company_id", company_scope)
         
     res = query.execute()
     return res.data
@@ -968,6 +1015,7 @@ async def save_ticket(request_body: TicketSaveRequest):
 async def get_ticket_by_id(
     request: Request,
     ticket_id: str,
+    current_user: dict = Depends(get_current_user),
 ):
     """Fetch single persistent ticket."""
     if not supabase:
@@ -978,11 +1026,16 @@ async def get_ticket_by_id(
         return await search_tickets(
             q=request.query_params.get("q", ""),
             company_id=request.query_params.get("company_id"),
+            current_user=current_user,
         )
 
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile)
     res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
+    if company_scope and res.data.get("company_id") != company_scope:
+        raise HTTPException(status_code=403, detail="User not authorized for this tenant")
     return res.data
 
 
@@ -1000,7 +1053,11 @@ async def get_ticket_audit_logs(ticket_id: str, company_id: str):
 
 
 @app.get("/tickets/search")
-async def search_tickets(q: str, company_id: str | None = None):
+async def search_tickets(
+    q: str,
+    company_id: str | None = None,
+    current_user: dict = Depends(get_current_user),
+):
     """Search tickets by query text, optionally scoped by company_id."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
@@ -1008,10 +1065,13 @@ async def search_tickets(q: str, company_id: str | None = None):
     if not query_text:
         raise HTTPException(status_code=400, detail="Query text is required")
 
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile, company_id)
+
     try:
         rpc_res = supabase.rpc(
             "search_tickets",
-            {"query_text": query_text, "company_id": company_id},
+            {"query_text": query_text, "company_id": company_scope},
         ).execute()
         return rpc_res.data or []
     except Exception:
@@ -1024,8 +1084,8 @@ async def search_tickets(q: str, company_id: str | None = None):
             if lowered in str(row.get("subject", "")).lower()
             or lowered in str(row.get("description", "")).lower()
         ]
-        if company_id:
-            filtered = [row for row in filtered if row.get("company_id") == company_id]
+        if company_scope:
+            filtered = [row for row in filtered if row.get("company_id") == company_scope]
         return filtered
 
 

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,5 +1,14 @@
 import pytest
 from unittest.mock import patch, MagicMock
+from backend.auth_cookie import get_current_user
+
+
+def authenticate_as(test_client, user_id):
+    test_client.app.dependency_overrides[get_current_user] = lambda: {"id": user_id}
+
+
+def clear_authentication(test_client):
+    test_client.app.dependency_overrides.pop(get_current_user, None)
 
 def test_route_registration(test_client):
     """
@@ -92,6 +101,7 @@ def test_multi_tenant_data_isolation_on_read(test_client, fake_db):
         {"id": 1, "company_id": "company_A", "subject": "Ticket A", "created_at": "2026-05-23T10:00:00Z"},
         {"id": 2, "company_id": "company_B", "subject": "Ticket B", "created_at": "2026-05-23T11:00:00Z"},
     ]
+    authenticate_as(test_client, "user_A")
     
     # Query for company A
     res_a = test_client.get("/tickets?company_id=company_A")
@@ -100,12 +110,44 @@ def test_multi_tenant_data_isolation_on_read(test_client, fake_db):
     assert len(tickets_a) == 1
     assert tickets_a[0]["company_id"] == "company_A"
     
-    # Query for company B
+    # Query for company B as company A user
     res_b = test_client.get("/tickets?company_id=company_B")
-    assert res_b.status_code == 200
-    tickets_b = res_b.json()
-    assert len(tickets_b) == 1
-    assert tickets_b[0]["company_id"] == "company_B"
+    assert res_b.status_code == 403
+    clear_authentication(test_client)
+
+
+def test_ticket_reads_require_authentication(test_client, fake_db):
+    fake_db["tickets"] = [
+        {"id": 1, "company_id": "company_A", "subject": "Ticket A", "created_at": "2026-05-23T10:00:00Z"},
+    ]
+
+    assert test_client.get("/tickets").status_code == 401
+    assert test_client.get("/tickets/search?q=Ticket").status_code == 401
+    assert test_client.get("/tickets/1").status_code == 401
+
+
+def test_ticket_reads_scope_to_authenticated_tenant(test_client, fake_db):
+    fake_db["tickets"] = [
+        {"id": 1, "company_id": "company_A", "subject": "VPN issue", "description": "A", "created_at": "2026-05-23T10:00:00Z"},
+        {"id": 2, "company_id": "company_B", "subject": "VPN issue", "description": "B", "created_at": "2026-05-23T11:00:00Z"},
+    ]
+    authenticate_as(test_client, "user_A")
+
+    all_tickets = test_client.get("/tickets")
+    assert all_tickets.status_code == 200
+    assert [ticket["company_id"] for ticket in all_tickets.json()] == ["company_A"]
+
+    search_results = test_client.get("/tickets/search?q=VPN")
+    assert search_results.status_code == 200
+    assert [ticket["company_id"] for ticket in search_results.json()] == ["company_A"]
+
+    own_ticket = test_client.get("/tickets/1")
+    assert own_ticket.status_code == 200
+    assert own_ticket.json()["company_id"] == "company_A"
+
+    other_ticket = test_client.get("/tickets/2")
+    assert other_ticket.status_code == 403
+    clear_authentication(test_client)
 
 
 def test_analyze_ticket_mock_model_prediction(test_client):


### PR DESCRIPTION
## Summary
- requires authenticated user context for ticket list, search, and detail reads
- derives ticket tenant scope from the caller profile instead of trusting client company_id
- rejects cross-tenant list/search/detail access for normal users
- adds regression coverage for unauthenticated reads, scoped tenant reads, and cross-tenant denial

## Testing
- PYTHONPYCACHEPREFIX=/private/tmp/helpdesk-issue-117/.pycache python3 -m py_compile backend/main.py backend/tests/test_integration.py
- git diff --check

Note: local pytest for backend/tests/test_integration.py is blocked in this shell because the local interpreter is missing the repo dependency slowapi. GitHub Actions has the backend dependency install and will be the full integration verifier.