### PR TITLE
Fix auth profile cache authorization bypass

### DIFF
--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -37,6 +37,19 @@ const mirrorBackendAuth = async (path, payload) => {
 
 let currentUserPromise = null;
 
+const getProfileCache = (profile) => {
+    if (!profile?.id) return null;
+
+    return {
+        id: profile.id,
+        email: profile.email,
+        full_name: profile.full_name,
+        company: profile.company,
+        company_id: profile.company_id,
+        profile_picture: profile.profile_picture,
+    };
+};
+
 const useAuthStore = create(
     persist(
         (set, get) => ({
@@ -53,38 +66,25 @@ const useAuthStore = create(
                 if (!user) return null;
 
                 const metadata = user.user_metadata || {};
-                const currentProfile = get().profile;
+                set({ profile: null });
 
-                // 1. Resolve FROM METADATA or PERSISTED state
-                // Priority 1: If we have a persisted session for THIS user and it's active, keep it 
-                // to prevent temporary lobbies during refresh/tab switching.
-                if (currentProfile && currentProfile.id === user.id && currentProfile.status === 'active') {
-                    console.log("Active profile retained from state.");
-                    // Background fetch to ensure session is still valid/synced
-                    get()._syncProfile(user.id);
-                    return currentProfile;
-                }
-
-                // Priority 2: Use Auth Metadata (Instant fallback)
-                const isMasterAdmin = user.email === 'masteradmin@helpdesk.ai';
-
-                const instantProfile = {
-                    id: user.id,
-                    email: user.email,
-                    full_name: isMasterAdmin ? 'Master Admin' : (metadata.full_name || 'User'),
-                    role: isMasterAdmin ? 'master_admin' : (metadata.role || 'user'),
-                    status: isMasterAdmin ? 'active' : 'pending_email_verification',
-                    company: metadata.company || ''
-                };
-
-                // 2. Sync with Database First before setting a fallback
-                // This prevents flashes of 'pending_email_verification' when returning from magic links
+                // Always resolve authorization fields from the database. Local storage and
+                // user_metadata are client-controlled surfaces and must not grant roles.
                 const dbProfile = await get()._syncProfile(user.id);
                 if (dbProfile) {
                     return dbProfile;
                 }
 
-                console.log("Falling back to instant profile resolved from metadata:", instantProfile.role);
+                const instantProfile = {
+                    id: user.id,
+                    email: user.email,
+                    full_name: metadata.full_name || 'User',
+                    role: 'user',
+                    status: 'pending_email_verification',
+                    company: metadata.company || ''
+                };
+
+                console.log("Falling back to non-authoritative profile:", instantProfile.role);
                 set({ profile: instantProfile });
                 return instantProfile;
             },
@@ -124,7 +124,7 @@ const useAuthStore = create(
                         const cookieUser = await verifyServerCookieSession();
                         if (cookieUser) {
                             set({ user: cookieUser });
-                            get().getProfile(cookieUser);
+                            await get().getProfile(cookieUser);
                             return cookieUser;
                         }
 
@@ -133,8 +133,7 @@ const useAuthStore = create(
 
                         if (user) {
                             set({ user });
-                            // Don't 'await' here because we want 'loading: false' ASAP
-                            get().getProfile(user);
+                            await get().getProfile(user);
                         } else {
                             set({ user: null, profile: null });
                         }
@@ -351,8 +350,8 @@ const useAuthStore = create(
                 supabase.auth.onAuthStateChange(async (event, session) => {
                     console.log("Auth state change:", event);
                     if (session?.user) {
-                        set({ user: session.user });
-                        get().getProfile(session.user);
+                        set({ user: session.user, loading: true, isCheckingSession: true });
+                        await get().getProfile(session.user);
                     } else {
                         set({ user: null, profile: null });
                     }
@@ -363,8 +362,8 @@ const useAuthStore = create(
         {
             name: 'auth-storage',
             partialize: (state) => ({
-                // Profile only — JWT session lives in HttpOnly cookies (issue #130)
-                profile: state.profile
+                // Cache display-only profile fields. Role/status must come from the DB.
+                profile: getProfileCache(state.profile)
             }),
         }
     )

--- a/Frontend/src/store/authStore.test.js
+++ b/Frontend/src/store/authStore.test.js
@@ -1,0 +1,143 @@
+import useAuthStore from './authStore';
+import { supabase } from '../lib/supabaseClient';
+
+jest.mock('../config', () => ({
+    API_CONFIG: {
+        BACKEND_URL: 'http://localhost:5000',
+    },
+}));
+
+jest.mock('./ticketStore', () => ({
+    __esModule: true,
+    default: {
+        getState: jest.fn(() => ({ clearTicket: jest.fn() })),
+        setState: jest.fn(),
+    },
+}));
+
+jest.mock('../lib/supabaseClient', () => ({
+    supabase: {
+        from: jest.fn(),
+        auth: {
+            getUser: jest.fn(),
+            signOut: jest.fn(),
+            signInWithPassword: jest.fn(),
+            signInWithOtp: jest.fn(),
+            verifyOtp: jest.fn(),
+            signUp: jest.fn(),
+            onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
+        },
+    },
+}));
+
+const mockProfileQuery = (result) => {
+    const single = jest.fn().mockResolvedValue(result);
+    const eq = jest.fn(() => ({ single }));
+    const select = jest.fn(() => ({ eq }));
+
+    supabase.from.mockReturnValue({ select });
+
+    return { select, eq, single };
+};
+
+describe('authStore profile authorization cache handling', () => {
+    const user = {
+        id: 'user-123',
+        email: 'user@example.com',
+        user_metadata: {
+            full_name: 'Regular User',
+            role: 'admin',
+            company: 'Acme',
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        localStorage.clear();
+        useAuthStore.setState({
+            user: null,
+            profile: null,
+            loading: false,
+            isCheckingSession: true,
+            _initialized: false,
+        });
+    });
+
+    test('does not return a tampered persisted admin profile before the database profile resolves', async () => {
+        const dbProfile = {
+            id: user.id,
+            email: user.email,
+            full_name: 'Regular User',
+            role: 'user',
+            status: 'active',
+            company: 'Acme',
+        };
+        mockProfileQuery({ data: dbProfile, error: null });
+
+        useAuthStore.setState({
+            profile: {
+                id: user.id,
+                email: user.email,
+                full_name: 'Regular User',
+                role: 'admin',
+                status: 'active',
+                company: 'Acme',
+            },
+        });
+
+        const profile = await useAuthStore.getState().getProfile(user);
+
+        expect(profile).toEqual(dbProfile);
+        expect(useAuthStore.getState().profile).toEqual(dbProfile);
+        expect(supabase.from).toHaveBeenCalledWith('profiles');
+    });
+
+    test('clears hydrated profile while the authoritative profile lookup is pending', () => {
+        let resolveSingle;
+        const pendingLookup = new Promise((resolve) => {
+            resolveSingle = resolve;
+        });
+        const single = jest.fn(() => pendingLookup);
+        const eq = jest.fn(() => ({ single }));
+        const select = jest.fn(() => ({ eq }));
+        supabase.from.mockReturnValue({ select });
+
+        useAuthStore.setState({
+            profile: {
+                id: user.id,
+                role: 'master_admin',
+                status: 'active',
+            },
+        });
+
+        const profilePromise = useAuthStore.getState().getProfile(user);
+
+        expect(useAuthStore.getState().profile).toBeNull();
+
+        resolveSingle({
+            data: {
+                id: user.id,
+                role: 'user',
+                status: 'active',
+            },
+            error: null,
+        });
+
+        return expect(profilePromise).resolves.toMatchObject({ role: 'user' });
+    });
+
+    test('metadata fallback cannot grant privileged roles when no database profile exists', async () => {
+        mockProfileQuery({
+            data: null,
+            error: { code: 'PGRST116', message: 'No rows found' },
+        });
+
+        const profile = await useAuthStore.getState().getProfile(user);
+
+        expect(profile).toMatchObject({
+            id: user.id,
+            role: 'user',
+            status: 'pending_email_verification',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- stop trusting persisted auth profile role/status before the database profile resolves
- clear hydrated profile while fetching the authoritative Supabase profile
- persist only display-safe profile fields and add regression tests for tampered role/status cache

## Validation
- `node /Users/saurabhkumarbajpaiai/Documents/Codex/2026-05-08/build-a-high-end-web-application/.tools/package/bin/npm-cli.js test -- --runTestsByPath src/store/authStore.test.js`
- `node /Users/saurabhkumarbajpaiai/Documents/Codex/2026-05-08/build-a-high-end-web-application/.tools/package/bin/npm-cli.js run lint`
- `node --check src/store/authStore.js`
- `node --check src/store/authStore.test.js`

## Notes
- Full `npm test -- --runInBand` still fails on existing Jest configuration issues: `import.meta.env` in `src/lib/supabaseClient.js` is not transformed for `AdminSettings.test.jsx`, and Jest also treats existing `node:test` utility tests as empty Jest suites. The Node test runner output for those utility tests passes.
- `npm run build` reaches Vite/Rollup but fails in this macOS Codex environment because Rollup's native optional binary is rejected by the app-translocated Node process code signature check (`ERR_DLOPEN_FAILED`).
