### PR TITLE
feat: add Google OAuth support via Supabase (#216)

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -14,6 +14,7 @@ import ProtectedRoute from "./components/shared/ProtectedRoute";
 import useAuthStore from "./store/authStore";
 import NotApproved from "./pages/NotApproved";
 const Login = lazy(() => import("./pages/Login"));
+const AuthCallback = lazy(() => import("./pages/AuthCallback"));
 const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
 const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const Signup = lazy(() => import("./pages/Signup"));
@@ -222,6 +223,7 @@ function App() {
           {/* Public */}
           <Route path="/" element={<LandingPage />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
           <Route path="/forgot-password" element={<ForgotPassword />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/signup" element={<Signup />} />

--- a/Frontend/src/pages/AuthCallback.jsx
+++ b/Frontend/src/pages/AuthCallback.jsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import useAuthStore from "../store/authStore";
+import { supabase } from "../lib/supabaseClient";
+
+function AuthCallback() {
+  const navigate = useNavigate();
+  const { getProfile } = useAuthStore();
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      try {
+        // Retrieve the current session to ensure the user is logged in
+        const { data: { session }, error } = await supabase.auth.getSession();
+        if (error) throw error;
+        
+        const user = session?.user;
+        if (!user) {
+          throw new Error("No user session found");
+        }
+
+        // Fetch/sync user profile
+        const profile = await getProfile(user);
+        if (!profile) {
+          throw new Error("Failed to retrieve user profile");
+        }
+
+        // Redirect based on role and status
+        if (profile.status === "active") {
+          if (profile.role === "master_admin") {
+            navigate("/master-admin/dashboard", { replace: true });
+          } else if (profile.role === "admin" || profile.role === "super_admin") {
+            navigate("/admin/dashboard", { replace: true });
+          } else if (profile.role === "user") {
+            navigate("/dashboard", { replace: true });
+          } else {
+            navigate("/dashboard", { replace: true });
+          }
+        } else if (profile.status === "pending_approval") {
+          if (profile.role === "admin") {
+            navigate("/admin-lobby", { replace: true });
+          } else if (profile.role === "user") {
+            navigate("/user-lobby", { replace: true });
+          } else {
+            navigate("/user-lobby", { replace: true });
+          }
+        } else if (profile.status === "rejected") {
+          navigate("/not-approved", { replace: true });
+        } else {
+          navigate("/dashboard", { replace: true });
+        }
+      } catch (err) {
+        console.error("Error in OAuth callback processing:", err);
+        navigate("/login", { replace: true });
+      }
+    };
+
+    handleCallback();
+  }, [navigate, getProfile]);
+
+  return (
+    <div className="flex h-screen w-screen flex-col items-center justify-center bg-white dark:bg-gray-900 transition-colors duration-200">
+      <div className="h-12 w-12 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent"></div>
+      <p className="mt-4 text-lg font-medium text-gray-600 dark:text-gray-300">Signing you in...</p>
+    </div>
+  );
+}
+
+export default AuthCallback;

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -16,7 +16,7 @@ function Login() {
   const [magicLinkSent, setMagicLinkSent] = useState(false);
 
   const navigate = useNavigate();
-  const { login, signInWithMagicLink, loading, user, profile } = useAuthStore();
+  const { login, signInWithMagicLink, loginWithGoogle, loading, user, profile } = useAuthStore();
 
   // Auto-redirect if already logged in
   useEffect(() => {
@@ -96,6 +96,14 @@ function Login() {
         errMsg = "Network Error: Failed to fetch. This usually happens if your browser's ad-blocker (like Brave Shields, uBlock Origin, etc.) is blocking Supabase requests. Please try disabling your ad-blocker for this site and refresh!";
       }
       setError(errMsg);
+    }
+  };
+
+  const handleGoogleLogin = async () => {
+    try {
+      await loginWithGoogle();
+    } catch (err) {
+      console.error("Google login failed", err.message);
     }
   };
 
@@ -348,6 +356,45 @@ function Login() {
               >
                 {loading && <Loader2 className="w-5 h-5 animate-spin" />}
                 {!loading && (isMagicLink ? "Send Magic Link" : "Sign In")}
+              </button>
+
+              {/* Google Button */}
+              <button
+                type="button"
+                disabled={loading}
+                onClick={handleGoogleLogin}
+                className="w-full flex items-center justify-center gap-3 transition-all active:scale-[0.98] disabled:opacity-70 disabled:cursor-not-allowed"
+                style={{
+                  background: isDark ? '#1f2937' : '#ffffff',
+                  border: isDark ? '1.5px solid #374151' : '1.5px solid #e5e7eb',
+                  color: isDark ? '#f9fafb' : '#374151',
+                  borderRadius: '12px',
+                  padding: '13px',
+                  fontWeight: 500,
+                  fontSize: '15px',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                }}
+                onMouseEnter={(e) => {
+                  if (!loading) {
+                    e.currentTarget.style.background = isDark ? '#374151' : '#f9fafb';
+                    e.currentTarget.style.borderColor = isDark ? '#4b5563' : '#d1d5db';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!loading) {
+                    e.currentTarget.style.background = isDark ? '#1f2937' : '#ffffff';
+                    e.currentTarget.style.borderColor = isDark ? '#374151' : '#e5e7eb';
+                  }
+                }}
+              >
+                <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                  <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                  <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.06H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.94l2.85-2.22.81-.63z" fill="#FBBC05"/>
+                  <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.06l3.66 2.84c.87-2.6 3.3-4.52 6.16-4.52z" fill="#EA4335"/>
+                </svg>
+                <span>Continue with Google</span>
               </button>
 
               {/* Divider */}

--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -187,6 +187,26 @@ const useAuthStore = create(
                 }
             },
 
+            loginWithGoogle: async () => {
+                const { error } =
+                    await supabase.auth.signInWithOAuth({
+                        provider: 'google',
+                        options: {
+                            redirectTo:
+                                `${window.location.origin}/auth/callback`
+                        }
+                    });
+
+                if (error) {
+                    console.error(
+                        "Google OAuth error:",
+                        error.message
+                    );
+
+                    throw error;
+                }
+            },
+
             signInWithMagicLink: async (email) => {
                 set({ loading: true });
                 console.log("Attempting magic link / OTP login for:", email);


### PR DESCRIPTION
Implements Google OAuth login using Supabase native authentication, allowing users to sign in with Google directly from the login page while preserving existing authentication flows.

Key Changes
Auth Store: Added loginWithGoogle() in authStore.js using supabase.auth.signInWithOAuth().
Login UI: Added a responsive "Continue with Google" button with Google SVG icon and theme support.
Callback Handling: Created AuthCallback.jsx to synchronize session state, restore user profiles, and redirect users to the appropriate dashboard.
Routing: Added /auth/callback as a public route outside ProtectedRoute to prevent redirect loops.
Verification
✅ npm run build completed successfully
✅ npm run lint completed with 0 errors
✅ Existing authentication flows remain functional
✅ OAuth flow tested successfully