### PR TITLE
fix: docs: add CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `CHANGELOG.md` to track features, fixes, and breaking changes across releases.
+
+### Fixed
+- Duplicate detection now learns from saved tickets: after a ticket is inserted into Supabase, the `POST /tickets/save` endpoint in `backend/main.py` calls `duplicate_service.add_ticket(...)` so newly saved tickets are immediately available for future duplicate checks. Indexing failures return a non-breaking warning instead of failing the save.
+- Backfilled `company_id` for existing tickets to keep ticket-to-company associations consistent.
+
+[Unreleased]: https://github.com/ritesh-1918/HELPDESK.AI/commits/main


### PR DESCRIPTION
Closes #226.

Added `CHANGELOG.md` at the repo root following the Keep a Changelog 1.1.0 / SemVer convention with an `[Unreleased]` section. Seeded it from the only documented changes visible in the repo (`CHANGES.md` duplicate-detection fix and the recently merged ticket `company_id` backfill PR #68) so the file is meaningful rather than empty. No other files touched.

Tests: no test suite detected

---
_Bounty attempt._