### PR TITLE
fix: chore: add .eslintrc.json for static analysis and linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,39 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2022": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "rules": {
+    "no-unused-vars": ["warn", { "varsIgnorePattern": "^[A-Z_]", "args": "none", "caughtErrorsIgnorePattern": "^_" }],
+    "no-console": "off",
+    "no-undef": "error",
+    "semi": ["error", "always"],
+    "quotes": ["warn", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
+    "eqeqeq": ["error", "always"],
+    "no-var": "error",
+    "prefer-const": "warn"
+  },
+  "ignorePatterns": [
+    "node_modules/",
+    "dist/",
+    "build/",
+    "Frontend/",
+    "MobileApp/",
+    "backend/",
+    "Model/",
+    "supabase/",
+    "docs/"
+  ]
+}


### PR DESCRIPTION
Closes #227.

Added `.eslintrc.json` at the repository root with `eslint:recommended` plus sensible defaults (semi, quotes, eqeqeq, no-var, prefer-const, no-unused-vars matching the pattern already used in `Frontend/eslint.config.js`). The config is scoped to root-level JS via `ignorePatterns` so it doesn't conflict with the existing flat config in `Frontend/` or interfere with the Python backend, Expo MobileApp, and other subprojects that own their own tooling.

Tests: no test suite detected

---
_Bounty attempt._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added code quality linting configuration to enforce consistent code standards and improve development practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->