### PR TITLE
fix(ui): show scrollbar on landing page

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -93,14 +93,8 @@
   }
 }
 
-html{
+html {
   overflow-y: scroll;
-  scrollbar-width: none; /* Firefox */
-}
-
-html::-webkit-scrollbar{
-  width: 0;
-  height: 0;
 }
 
 body{


### PR DESCRIPTION
Fixes #202. Removed the CSS in \Frontend/src/index.css\ that was explicitly hiding the scrollbar with \scrollbar-width: none\ and \::-webkit-scrollbar { width: 0 }\.