### PR TITLE
feat(ui): make navbar fully responsive

### DIFF
--- a/Frontend/src/pages/LandingPage.jsx
+++ b/Frontend/src/pages/LandingPage.jsx
@@ -381,7 +381,7 @@ export default function LandingPage() {
 
   {/* Mobile Menu */}
   {isMenuOpen && (
-    <div className="lg:hidden border-t border-gray-100 bg-white">
+    <div className="lg:hidden absolute top-full left-0 w-full border-t border-gray-100 bg-white shadow-xl dark:bg-gray-900 dark:border-gray-800">
       <div className="flex flex-col px-4 py-5 gap-4">
 
         <a


### PR DESCRIPTION
Fixes #199. Updated the mobile menu in the landing page navbar to be absolutely positioned with \bsolute top-full left-0 w-full\, preventing it from breaking the page flow and ensuring it renders correctly over the hero section.