### PR TITLE
feat(ui): add back to top button

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -72,6 +72,7 @@ const AboutUs = lazy(() => import("./pages/AboutUs"));
 const NotFoundPage = lazy(() => import("./components/ui/not-found-2").then((module) => ({ default: module.NotFound })));
 const Toaster = lazy(() => import("./components/shared/Toaster"));
 const BugReportWidget = lazy(() => import("./components/shared/BugReportWidget"));
+const BackToTop = lazy(() => import("./components/shared/BackToTop"));
 
 function RouteFallback() {
   return (
@@ -221,6 +222,7 @@ function App() {
       <Suspense fallback={<RouteFallback />}>
         <Toaster />
         <BugReportWidget />
+        <BackToTop />
         <Routes>
           {/* Public */}
           <Route path="/" element={<LandingPage />} />

--- a/Frontend/src/components/shared/BackToTop.jsx
+++ b/Frontend/src/components/shared/BackToTop.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { ArrowUp } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const BackToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button when page is scrolled down
+  const toggleVisibility = () => {
+    if (window.scrollY > 300) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  // Set the top cordinate to 0
+  // make scrolling smooth
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.button
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 20 }}
+          onClick={scrollToTop}
+          className="fixed bottom-8 right-8 z-50 p-3 bg-emerald-600 hover:bg-emerald-700 text-white rounded-full shadow-lg hover:shadow-xl transition-all duration-300"
+          aria-label="Back to top"
+        >
+          <ArrowUp className="w-6 h-6" />
+        </motion.button>
+      )}
+    </AnimatePresence>
+  );
+};
+
+export default BackToTop;


### PR DESCRIPTION
Fixes #196. Added a smooth-scrolling 'Back to Top' button using framer-motion that appears in the bottom right corner when the user scrolls down.