### PR TITLE
fix(widget): prevent black screenshot in bug report on specific displays

### DIFF
--- a/Frontend/src/components/shared/BugReportWidget.jsx
+++ b/Frontend/src/components/shared/BugReportWidget.jsx
@@ -207,6 +207,8 @@ const BugReportWidget = ({ advanced = false, customTrigger = null }) => {
             // html2canvas options for partial capture
             const canvas = await html2canvas(document.body, {
                 useCORS: true,
+                allowTaint: false,
+                backgroundColor: null,
                 logging: false,
                 x: left + window.scrollX,
                 y: top + window.scrollY,


### PR DESCRIPTION
### Summary
This Pull Request resolves the issue where captured screenshots in the Bug Report Widget render as solid black images on specific displays (especially high-DPI or hardware-accelerated screens) or when rendering transparent canvas layers.

### Proposed Changes
* **File Modified**: [BugReportWidget.jsx](file:///Frontend/src/components/shared/BugReportWidget.jsx)
* **Fix Applied**: Updated the configuration options passed to `html2canvas` inside the regional snap handler:
  ```javascript
  const canvas = await html2canvas(document.body, {
      useCORS: true,
      allowTaint: false,   // Ensures cross-origin assets don't taint the canvas
      backgroundColor: null, // Resolves transparency conflicts rendering as black
      logging: false,
      x: left + window.scrollX,
      y: top + window.scrollY,
      width: width,
      height: height,
      scale: 2 // High quality
  });
  ```
  * Setting `backgroundColor: null` tells `html2canvas` to handle absolute and transparent layers natively rather than failing over to black pixels.
  * Setting `allowTaint: false` (alongside `useCORS: true`) guarantees standard CORS-compliant resource fetching without dirtying/blocking canvas reading.

### Verification Plan
* **Static Analysis**: Ran static lint analysis locally to ensure strict compliance:
  ```bash
  cd Frontend
  npm run lint
  ```
  * **Result**: Passed successfully with `0` errors and `0` warnings.
* **Testing Reference**: Aligns with automated QA Defect `D-003` and test case `TC-003` in `docs/testing_reports.md`.

---

### Related Issues
Resolves #272
