### PR TITLE
feat: add Google OAuth login (#216)

### DIFF
--- a/Frontend/src/lib/supabaseClient.js
+++ b/Frontend/src/lib/supabaseClient.js
@@ -74,6 +74,7 @@ const createDisabledSupabaseClient = () => ({
 			},
 		}),
 		signInWithPassword: async () => ({ data: { user: null, session: null }, error: makeDisabledError() }),
+		signInWithOAuth: async () => ({ data: { provider: null, url: null }, error: makeDisabledError() }),
 		signUp: async () => ({ data: { user: null, session: null }, error: makeDisabledError() }),
 		signOut: async () => ({ error: null }),
 		resetPasswordForEmail: async () => ({ data: null, error: makeDisabledError() }),

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -15,7 +15,7 @@ function Login() {
   const [magicLinkSent, setMagicLinkSent] = useState(false);
 
   const navigate = useNavigate();
-  const { login, signInWithMagicLink, loading, user, profile } = useAuthStore();
+  const { login, signInWithMagicLink, signInWithGoogle, loading, user, profile } = useAuthStore();
 
   // Auto-redirect if already logged in
   useEffect(() => {
@@ -99,6 +99,20 @@ function Login() {
   };
 
   const currentSubmitHandler = isMagicLink ? handleMagicLink : handleLogin;
+
+  const handleGoogleSignIn = async () => {
+    setError("");
+    try {
+      await signInWithGoogle();
+    } catch (err) {
+      console.error("Google sign-in error:", err);
+      let errMsg = err.message || "Failed to sign in with Google. Please try again.";
+      if (errMsg.toLowerCase().includes("failed to fetch")) {
+        errMsg = "Network Error: Failed to fetch. This usually happens if your browser's ad-blocker (like Brave Shields, uBlock Origin, etc.) is blocking Supabase requests. Please try disabling your ad-blocker for this site and refresh!";
+      }
+      setError(errMsg);
+    }
+  };
 
   return (
     <div className="min-h-screen flex" style={{ fontFamily: "'Inter', sans-serif" }}>
@@ -353,6 +367,37 @@ function Login() {
                 <span className="flex-shrink-0 mx-4" style={{ color: '#9ca3af', fontSize: '13px', fontWeight: 500 }}>Or</span>
                 <div className="flex-grow" style={{ borderTop: '1px solid #e5e7eb' }}></div>
               </div>
+
+              {/* Google Sign-In Button */}
+              {!isMagicLink && (
+                <button
+                  type="button"
+                  onClick={handleGoogleSignIn}
+                  disabled={loading}
+                  className="w-full flex items-center justify-center gap-3 transition-all disabled:opacity-70 disabled:cursor-not-allowed"
+                  style={{
+                    background: '#ffffff',
+                    border: '1.5px solid #e5e7eb',
+                    color: '#374151',
+                    borderRadius: '12px',
+                    padding: '13px',
+                    fontWeight: 500,
+                    fontSize: '15px',
+                    cursor: 'pointer',
+                    transition: 'background 0.2s, box-shadow 0.2s',
+                  }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = '#f9fafb'; e.currentTarget.style.boxShadow = '0 2px 8px rgba(0,0,0,0.06)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = '#ffffff'; e.currentTarget.style.boxShadow = 'none'; }}
+                >
+                  <svg width="18" height="18" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+                    <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                    <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                    <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+                    <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+                  </svg>
+                  Continue with Google
+                </button>
+              )}
 
               {/* Magic Link Toggle */}
               <button

--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -134,6 +134,27 @@ const useAuthStore = create(
                 }
             },
 
+            signInWithGoogle: async () => {
+                set({ loading: true });
+                console.log("Attempting Google OAuth login...");
+                try {
+                    const { data, error } = await supabase.auth.signInWithOAuth({
+                        provider: 'google',
+                        options: {
+                            redirectTo: `${window.location.origin}/login`,
+                        },
+                    });
+
+                    if (error) throw error;
+                    return data;
+                } catch (error) {
+                    console.error("Google OAuth login failed:", error.message);
+                    throw error;
+                } finally {
+                    set({ loading: false });
+                }
+            },
+
             signInWithMagicLink: async (email) => {
                 set({ loading: true });
                 console.log("Attempting magic link / OTP login for:", email);

--- a/GOOGLE_OAUTH_SETUP.md
+++ b/GOOGLE_OAUTH_SETUP.md
@@ -1,0 +1,64 @@
+# Google OAuth Setup Guide for HELPDESK.AI
+
+This guide explains how to configure Google OAuth login for HELPDESK.AI using Supabase.
+
+## Prerequisites
+
+- A Supabase project with Auth enabled
+- A Google Cloud Console project
+
+## Step 1: Configure Google Cloud Console
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select an existing one
+3. Navigate to **APIs & Services** > **Credentials**
+4. Click **Create Credentials** > **OAuth client ID**
+5. Select **Web application** as the application type
+6. Add the following **Authorized redirect URIs**:
+   ```
+   https://<your-supabase-project-ref>.supabase.co/auth/v1/callback
+   ```
+7. Note down the **Client ID** and **Client Secret**
+
+## Step 2: Enable Google Provider in Supabase
+
+1. Go to your [Supabase Dashboard](https://supabase.com/dashboard)
+2. Select your project
+3. Navigate to **Authentication** > **Providers**
+4. Find **Google** and enable it
+5. Enter the **Client ID** and **Client Secret** from Step 1
+6. Click **Save**
+
+## Step 3: Configure Redirect URLs in Supabase
+
+1. In Supabase Dashboard, go to **Authentication** > **URL Configuration**
+2. Add your site URL to **Site URL** (e.g., `http://localhost:5173` for development)
+3. Add the following to **Redirect URLs**:
+   ```
+   http://localhost:5173/login
+   https://your-production-domain.com/login
+   ```
+
+## Environment Variables
+
+No additional environment variables are needed beyond the existing Supabase configuration:
+
+```env
+VITE_SUPABASE_URL=https://<your-project-ref>.supabase.co
+VITE_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
+## How It Works
+
+1. User clicks "Continue with Google" on the login page
+2. The app calls `supabase.auth.signInWithOAuth({ provider: 'google' })`
+3. User is redirected to Google's consent screen
+4. After authorization, Google redirects back to the app
+5. Supabase handles the OAuth callback and creates/retrieves the user session
+6. The existing `onAuthStateChange` listener picks up the session and resolves the user profile
+
+## Notes
+
+- Google OAuth users will have their profile automatically created with the default `user` role
+- The `full_name` and `email` are populated from the Google account metadata
+- Email verification is automatically handled by Google (Google-verified emails are trusted)


### PR DESCRIPTION
## Changes

Implements Google OAuth login for HELPDESK.AI.

### What was done:

1. **`Frontend/src/store/authStore.js`** - Added `signInWithGoogle()` method that uses `supabase.auth.signInWithOAuth({ provider: 'google' })` to initiate the Google OAuth flow

2. **`Frontend/src/pages/Login.jsx`** - Added "Continue with Google" button with the official Google logo SVG, positioned between the login form and the magic link toggle. The button is only shown in password login mode (hidden when magic link mode is active)

3. **`Frontend/src/lib/supabaseClient.js`** - Added `signInWithOAuth` stub to the disabled Supabase client for graceful degradation when env vars are missing

4. **`GOOGLE_OAUTH_SETUP.md`** - Added comprehensive setup guide covering Google Cloud Console configuration, Supabase provider setup, and redirect URL configuration

### How it works:
- User clicks "Continue with Google" on the login page
- App redirects to Google consent screen via Supabase OAuth
- After authorization, Google redirects back to `/login`
- Existing `onAuthStateChange` listener picks up the session and resolves the user profile
- User is redirected to their appropriate dashboard based on role/status

### Setup required:
- Enable Google provider in Supabase Dashboard > Authentication > Providers
- Add Google OAuth Client ID and Secret from Google Cloud Console
- Configure redirect URLs in Supabase URL Configuration

See `GOOGLE_OAUTH_SETUP.md` for detailed instructions.

Closes #216

Wallet: 0x96e04aC80b9b18ddbfB7e921800feF673BC1CA26