### PR TITLE
fix(auth): Add Google OAuth loginWithGoogle - Fixes #216

### DIFF
--- a/Frontend/src/lib/supabaseClient.js
+++ b/Frontend/src/lib/supabaseClient.js
@@ -73,6 +73,7 @@ const createDisabledSupabaseClient = () => ({
 				},
 			},
 		}),
+		signInWithOAuth: async () => ({ data: null, error: makeDisabledError() }),
 		signInWithPassword: async () => ({ data: { user: null, session: null }, error: makeDisabledError() }),
 		signUp: async () => ({ data: { user: null, session: null }, error: makeDisabledError() }),
 		signOut: async () => ({ error: null }),

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -17,7 +17,7 @@ function Login() {
   const [magicLinkSent, setMagicLinkSent] = useState(false);
 
   const navigate = useNavigate();
-  const { login, signInWithMagicLink, user, profile } = useAuthStore();
+  const { login, signInWithMagicLink, loginWithGoogle, loading, user, profile } = useAuthStore();
 
   // Auto-redirect if already logged in
   useEffect(() => {


### PR DESCRIPTION
What changed
- Added `loginWithGoogle` and `loading` to `useAuthStore` 
  destructuring in `Login.jsx`
- Added `signInWithOAuth` to supabaseClient.js stub to 
  prevent TypeError when env vars not configured

Why
Fixes #216 — "Continue with Google" button already existed 
in UI but `loginWithGoogle` was never imported from 
`useAuthStore`, causing silent crash on click.

How to test
1. `cd Frontend && npm install && npm run dev`
2. Navigate to `/login`
3. Click "Continue with Google"
4. Verify redirect to Google OAuth flow
5. After login → verify redirect to correct dashboard

Screenshots
<img width="1919" height="967" alt="Screenshot 2026-05-27 223406" src="https://github.com/user-attachments/assets/e73817ca-7b06-42c5-927e-46159c95ec71" />

Notes
- No new packages added
- Uses existing `@supabase/supabase-js` OAuth support
- Follows existing auth pattern in authStore