### PR TITLE
fix: prepend new tickets to show newest at top (fixes #179)

### DIFF
--- a/Frontend/src/store/ticketStore.js
+++ b/Frontend/src/store/ticketStore.js
@@ -32,7 +32,7 @@ const useTicketStore = create(
             })),
             addTicket: (ticket) => set((state) => {
                 return {
-                    tickets: [...state.tickets, ticket]
+                    tickets: [ticket, ...state.tickets]
                 };
             }),
             upsertTicket: (ticket) => set((state) => {


### PR DESCRIPTION
## Problem
`addTicket` was appending new tickets to the end of the array, causing newly created tickets to appear at the bottom of the dashboard instead of the top.

## Fix
Changed `addTicket` to prepend tickets so newest tickets appear at the top of the dashboard list.

## Changes
- `Frontend/src/store/ticketStore.js` — `addTicket` now uses `[ticket, ...state.tickets]` instead of `[...state.tickets, ticket]`

## Note
`updateTicket` already handles both `id` and `ticket_id` fields via `(t.id ?? t.ticket_id)` — no changes needed there.

Fixes #179

**Contributed under GSSoC'26**
This issue (#179) was officially assigned to me.