### PR TITLE
feat(sla): Add SLA breach predictor with estimate endpoint and UI bad…

### DIFF
--- a/Frontend/src/admin/components/SLABadge.jsx
+++ b/Frontend/src/admin/components/SLABadge.jsx
@@ -19,36 +19,43 @@ function formatDuration(ms) {
 }
 
 /**
- * SLABadge — shows SLA status for a ticket based on its priority and creation time.
- * 
+ * SLABadge — shows SLA countdown for a ticket.
+ *
  * Props:
- *  - priority: string ('critical' | 'high' | 'medium' | 'low')
- *  - createdAt: string (ISO date string)
- *  - status: string — if ticket is resolved/closed, show "Met" without countdown
- *  - compact: bool — if true, shows just the badge with no label text
+ *  - priority:    string ('critical' | 'high' | 'medium' | 'low')
+ *  - createdAt:   string (ISO date) — used as fallback when slaBreachAt is absent
+ *  - slaBreachAt: string (ISO date) — preferred; exact deadline from backend
+ *  - slaStatus:   string ('ACTIVE' | 'WARNING' | 'BREACHED') — skip timer when BREACHED
+ *  - status:      string — if ticket is resolved/closed, show "Met" without countdown
+ *  - compact:     bool  — if true, shows just the badge with no label text
  */
-export default function SLABadge({ priority, createdAt, status, compact = false }) {
+export default function SLABadge({ priority, createdAt, slaBreachAt, slaStatus, status, compact = false }) {
     const [remaining, setRemaining] = useState(null);
 
     const isResolved = ['resolved', 'closed', 'auto-resolved'].includes(status?.toLowerCase());
+    const isAlreadyBreached = slaStatus?.toUpperCase() === 'BREACHED';
 
     useEffect(() => {
-        if (isResolved || !priority || !createdAt) return;
+        if (isResolved) return;
 
-        const priorityKey = priority.toLowerCase();
-        const limit = SLA_LIMITS[priorityKey] || SLA_LIMITS.medium;
-        const createdMs = new Date(createdAt).getTime();
-
-        const calculate = () => {
-            const elapsed = Date.now() - createdMs;
-            const rem = limit - elapsed;
-            setRemaining(rem);
+        // Prefer slaBreachAt (exact backend deadline) over priority + createdAt heuristic
+        const getDeadlineMs = () => {
+            if (slaBreachAt) return new Date(slaBreachAt).getTime();
+            if (!priority || !createdAt) return null;
+            const priorityKey = priority.toLowerCase();
+            const limit = SLA_LIMITS[priorityKey] || SLA_LIMITS.medium;
+            return new Date(createdAt).getTime() + limit;
         };
 
+        const deadlineMs = getDeadlineMs();
+        if (deadlineMs === null) return;
+
+        const calculate = () => setRemaining(deadlineMs - Date.now());
+
         calculate();
-        const timer = setInterval(calculate, 60 * 1000); // update every minute
+        const timer = setInterval(calculate, 60 * 1000);
         return () => clearInterval(timer);
-    }, [priority, createdAt, isResolved]);
+    }, [priority, createdAt, slaBreachAt, isResolved]);
 
     if (isResolved) {
         return (
@@ -59,9 +66,9 @@ export default function SLABadge({ priority, createdAt, status, compact = false 
         );
     }
 
-    if (remaining === null) return null;
+    if (remaining === null && !isAlreadyBreached) return null;
 
-    const isBreached = remaining <= 0;
+    const isBreached = isAlreadyBreached || (remaining !== null && remaining <= 0);
     const isCritical = remaining <= 30 * 60 * 1000 && remaining > 0; // < 30 min
     const isWarning = remaining <= 60 * 60 * 1000 && remaining > 30 * 60 * 1000; // 30–60 min
 

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -45,6 +45,7 @@ const AdminTickets = () => {
     const [categoryFilter, setCategoryFilter] = useState('All');
     const [priorityFilter, setPriorityFilter] = useState('All');
     const [teamFilter, setTeamFilter] = useState('All');
+    const [slaAtRisk, setSlaAtRisk] = useState(false);
     const [agents, setAgents] = useState([]); // All staff/admins in the company
 
     const ticketMatchesFilters = useCallback((ticket) => {
@@ -172,16 +173,24 @@ const AdminTickets = () => {
     const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
 
     const filteredTickets = useMemo(() => {
-        if (!searchQuery) return tickets;
-        const q = searchQuery.toLowerCase();
-        return tickets.filter(t =>
-            String(t.id).includes(q) ||
-            (t.subject || '').toLowerCase().includes(q) ||
-            (t.summary || '').toLowerCase().includes(q) ||
-            (t.description || '').toLowerCase().includes(q) ||
-            (t.profiles?.full_name || '').toLowerCase().includes(q)
-        );
-    }, [tickets, searchQuery]);
+        return tickets.filter(t => {
+            if (searchQuery) {
+                const q = searchQuery.toLowerCase();
+                const matchesSearch =
+                    String(t.id).includes(q) ||
+                    (t.subject || '').toLowerCase().includes(q) ||
+                    (t.summary || '').toLowerCase().includes(q) ||
+                    (t.description || '').toLowerCase().includes(q) ||
+                    (t.profiles?.full_name || '').toLowerCase().includes(q);
+                if (!matchesSearch) return false;
+            }
+            if (slaAtRisk) {
+                const s = (t.sla_status || '').toUpperCase();
+                if (s !== 'BREACHED' && s !== 'WARNING') return false;
+            }
+            return true;
+        });
+    }, [tickets, searchQuery, slaAtRisk]);
 
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();
@@ -256,6 +265,26 @@ const AdminTickets = () => {
                         options={teams.map(t => ({ value: t, label: t === 'All' ? 'All Teams' : t }))}
                     />
                 </div>
+
+                {/* SLA At-Risk Toggle */}
+                <div className="flex items-center gap-3">
+                    <button
+                        onClick={() => setSlaAtRisk(prev => !prev)}
+                        className={`flex items-center gap-2 px-4 py-2 rounded-2xl text-[11px] font-black uppercase tracking-widest border transition-all ${
+                            slaAtRisk
+                                ? 'bg-red-50 border-red-200 text-red-700 shadow-sm'
+                                : 'bg-slate-50 border-slate-200 text-slate-500 hover:border-red-200 hover:text-red-600'
+                        }`}
+                    >
+                        <ShieldAlert size={14} />
+                        SLA At Risk
+                        {slaAtRisk && (
+                            <span className="ml-1 w-4 h-4 rounded-full bg-red-500 text-white flex items-center justify-center text-[9px]">
+                                {filteredTickets.length}
+                            </span>
+                        )}
+                    </button>
+                </div>
             </div>
 
             {/* 3. High-Density Data Terminal */}
@@ -297,9 +326,13 @@ const AdminTickets = () => {
                         <tbody className="divide-y divide-slate-50">
                             {filteredTickets.map((ticket) => {
                                 const wasLiveChanged = String(lastChangedTicketId) === String(ticket.id);
+                                const slaState = (ticket.sla_status || '').toUpperCase();
+                                const slaRowClass =
+                                    slaState === 'BREACHED' ? 'bg-red-50/60 ring-1 ring-red-100' :
+                                    slaState === 'WARNING'  ? 'bg-amber-50/50 ring-1 ring-amber-100' : '';
 
                                 return (
-                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : ''} ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
+                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : slaRowClass} ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
                                     {/* Ticket ID */}
                                     <td className="px-6 py-6">
                                         <span className="font-mono text-xs font-black text-emerald-600">#{formatTicketId(ticket.id)}</span>

--- a/Frontend/src/user/components/RecentTickets.jsx
+++ b/Frontend/src/user/components/RecentTickets.jsx
@@ -4,6 +4,7 @@ import { Clock, ChevronRight, Inbox, Loader2, AlertCircle } from 'lucide-react';
 import useAuthStore from '../../store/authStore';
 import { supabase } from '../../lib/supabaseClient';
 import { formatTimelineDate } from '../../utils/dateUtils';
+import SLABadge from '../../admin/components/SLABadge';
 
 const RecentTickets = () => {
     const navigate = useNavigate();
@@ -113,6 +114,7 @@ const RecentTickets = () => {
                                     <th className="text-[11px] tracking-widest text-gray-400 dark:text-gray-500 font-bold uppercase px-7 py-3">ID</th>
                                     <th className="text-[11px] tracking-widest text-gray-400 dark:text-gray-500 font-bold uppercase px-7 py-3">Subject</th>
                                     <th className="text-[11px] tracking-widest text-gray-400 dark:text-gray-500 font-bold uppercase px-7 py-3">Status</th>
+                                    <th className="text-[11px] tracking-widest text-gray-400 dark:text-gray-500 font-bold uppercase px-7 py-3">Est. SLA</th>
                                     <th className="text-[11px] tracking-widest text-gray-400 dark:text-gray-500 font-bold uppercase px-7 py-3">Submitted</th>
                                 </tr>
                             </thead>
@@ -140,6 +142,16 @@ const RecentTickets = () => {
                                         </td>
                                         <td className="px-7 py-4">
                                             {getStatusBadge(ticket.status)}
+                                        </td>
+                                        <td className="px-7 py-4">
+                                            <SLABadge
+                                                priority={ticket.priority}
+                                                createdAt={ticket.created_at}
+                                                slaBreachAt={ticket.sla_breach_at}
+                                                slaStatus={ticket.sla_status}
+                                                status={ticket.status}
+                                                compact
+                                            />
                                         </td>
                                         <td className="px-7 py-4 whitespace-nowrap">
                                             <span className="text-gray-500 dark:text-gray-500 text-[12px] font-medium">

--- a/Frontend/src/user/pages/MyTickets.jsx
+++ b/Frontend/src/user/pages/MyTickets.jsx
@@ -11,6 +11,7 @@ import { Badge } from "../../components/ui/badge";
 import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import TicketStatusBadge from "../components/TicketStatusBadge";
+import SLABadge from "../../admin/components/SLABadge";
 import { formatTimelineDate, getTimeZoneAbbr } from "../../utils/dateUtils";
 import {
     Tooltip,
@@ -277,6 +278,7 @@ function MyTickets() {
                                     <th className="px-6 py-4 text-xs font-black text-gray-500 uppercase tracking-widest">Category</th>
                                     <th className="px-6 py-4 text-xs font-black text-gray-500 uppercase tracking-widest">Status</th>
                                     <th className="px-6 py-4 text-xs font-black text-gray-500 uppercase tracking-widest">Priority</th>
+                                    <th className="px-6 py-4 text-xs font-black text-gray-500 uppercase tracking-widest">Est. SLA</th>
                                     <th className="px-6 py-4 text-xs font-black text-gray-500 uppercase tracking-widest">Submitted</th>
                                 </tr>
                             </thead>
@@ -343,6 +345,15 @@ function MyTickets() {
                                                 <span className={`text-sm capitalize ${getPriorityColor(ticket.priority)}`}>
                                                     {ticket.priority || 'medium'}
                                                 </span>
+                                            </td>
+                                            <td className="px-6 py-4">
+                                                <SLABadge
+                                                    priority={ticket.priority}
+                                                    createdAt={ticket.created_at}
+                                                    slaBreachAt={ticket.sla_breach_at}
+                                                    slaStatus={ticket.sla_status}
+                                                    status={ticket.status}
+                                                />
                                             </td>
                                              <td className="px-6 py-4">
                                                  <div className="flex flex-col">

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,6 +75,7 @@ from backend.services.rag_service import RagService
 from backend.services.spam_service import SpamService
 from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sla_policy
 from backend.services.redis_cache import redis_cache
+from backend.sla_predictor import get_sla_estimate
 from backend.auth_cookie import router as auth_cookie_router, get_current_user  # noqa: F401
 
 
@@ -1263,6 +1264,29 @@ async def get_ticket_by_id(
     if company_scope and res.data.get("company_id") != company_scope:
         raise HTTPException(status_code=403, detail="User not authorized for this tenant")
     return res.data
+
+
+@app.get("/tickets/{ticket_id}/sla-estimate")
+async def get_ticket_sla_estimate(
+    ticket_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Estimate resolution time and SLA breach risk for a ticket."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile)
+
+    res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    ticket = res.data
+    if company_scope and ticket.get("company_id") != company_scope:
+        raise HTTPException(status_code=403, detail="User not authorized for this tenant")
+
+    return get_sla_estimate(ticket, supabase)
 
 
 @app.get("/tickets/{ticket_id}/audit_logs", response_model=list[AuditLogRecord])

--- a/backend/sla_predictor.py
+++ b/backend/sla_predictor.py
@@ -1,0 +1,156 @@
+"""
+SLA Breach Predictor — estimates resolution time and breach risk for a ticket.
+
+Uses a weighted heuristic with three factors:
+  1. Priority baseline   (matching main.py resolution deadlines)
+  2. Category adjustment (historical breach rate from Supabase — optional)
+  3. Workload multiplier (current open-ticket count for company — optional)
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Mirrors calculate_sla_breach_at() in main.py (hours → minutes)
+_BASELINE_MINUTES: dict[str, int] = {
+    "critical": 2 * 60,
+    "high": 8 * 60,
+    "medium": 24 * 60,
+    "low": 72 * 60,
+}
+
+_TERMINAL_STATUSES = frozenset({"resolved", "closed", "auto-resolved", "auto resolved"})
+
+
+def _priority_key(priority: str | None) -> str:
+    value = str(priority or "low").strip().lower()
+    return value if value in _BASELINE_MINUTES else "low"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _category_adjustment(category: str | None, company_id: str | None, supabase: Any) -> float:
+    """
+    Returns a multiplier based on the historical SLA breach rate for this category.
+
+      breach_rate > 0.5  → 1.3  (category tends to run over SLA)
+      breach_rate < 0.2  → 0.8  (category tends to resolve quickly)
+      < 5 resolved samples→ 1.0  (not enough data)
+    """
+    if supabase is None or not category:
+        return 1.0
+
+    try:
+        query = (
+            supabase.table("tickets")
+            .select("status, sla_status")
+            .eq("category", category)
+            .limit(100)
+        )
+        if company_id:
+            query = query.eq("company_id", company_id)
+
+        res = query.execute()
+        rows = res.data or []
+
+        terminal = [
+            r for r in rows
+            if str(r.get("status") or "").strip().lower() in _TERMINAL_STATUSES
+        ]
+        if len(terminal) < 5:
+            return 1.0
+
+        breached = sum(
+            1 for r in terminal
+            if str(r.get("sla_status") or "").upper() == "BREACHED"
+        )
+        breach_rate = breached / len(terminal)
+
+        if breach_rate > 0.5:
+            return 1.3
+        if breach_rate < 0.2:
+            return 0.8
+        return 1.0
+    except Exception as exc:
+        logger.warning("Category adjustment query failed: %s", exc)
+        return 1.0
+
+
+def _workload_multiplier(company_id: str | None, supabase: Any) -> float:
+    """
+    Returns a multiplier based on how many open tickets the company currently has.
+
+      > 20 open → 1.2  (high load, slower resolution expected)
+      < 5  open → 0.9  (low load, faster resolution expected)
+      otherwise → 1.0
+    """
+    if supabase is None or not company_id:
+        return 1.0
+
+    try:
+        res = (
+            supabase.table("tickets")
+            .select("id")
+            .eq("company_id", company_id)
+            .eq("status", "open")
+            .limit(50)
+            .execute()
+        )
+        count = len(res.data or [])
+
+        if count > 20:
+            return 1.2
+        if count < 5:
+            return 0.9
+        return 1.0
+    except Exception as exc:
+        logger.warning("Workload multiplier query failed: %s", exc)
+        return 1.0
+
+
+def get_sla_estimate(
+    ticket: dict,
+    supabase: Any = None,
+    _now_fn: Callable[[], datetime] | None = None,
+) -> dict:
+    """
+    Estimates resolution time and breach risk for a ticket.
+
+    Args:
+        ticket:   Ticket row dict — uses priority, category, company_id, sla_breach_at
+        supabase: Optional Supabase client for historical + workload context
+        _now_fn:  Injectable clock (for testing)
+
+    Returns:
+        {"estimated_minutes": int, "breach_risk": bool}
+    """
+    now_fn = _now_fn or _utc_now
+
+    priority = ticket.get("priority")
+    category = ticket.get("category")
+    company_id = ticket.get("company_id")
+    sla_breach_at = ticket.get("sla_breach_at")
+
+    baseline = _BASELINE_MINUTES[_priority_key(priority)]
+    category_factor = _category_adjustment(category, company_id, supabase)
+    workload_factor = _workload_multiplier(company_id, supabase)
+
+    estimated_minutes = int(round(baseline * category_factor * workload_factor))
+
+    breach_risk = False
+    if sla_breach_at:
+        try:
+            deadline = datetime.fromisoformat(str(sla_breach_at).replace("Z", "+00:00"))
+            if deadline.tzinfo is None:
+                deadline = deadline.replace(tzinfo=timezone.utc)
+            minutes_remaining = (deadline - now_fn()).total_seconds() / 60
+            breach_risk = estimated_minutes > minutes_remaining
+        except (ValueError, TypeError) as exc:
+            logger.warning("Could not parse sla_breach_at %r: %s", sla_breach_at, exc)
+
+    return {"estimated_minutes": estimated_minutes, "breach_risk": breach_risk}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -273,6 +273,8 @@ def mock_ai_services(request):
         "test_semantic_duplicates.py",
         "test_auth_cookie.py",
         "test_mobile_supabase_env.py",
+        "test_sla_service.py",
+        "test_sla_predictor.py",
     }:
         yield
         return

--- a/backend/tests/test_sla_predictor.py
+++ b/backend/tests/test_sla_predictor.py
@@ -1,0 +1,294 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from backend.sla_predictor import (
+    get_sla_estimate,
+    _category_adjustment,
+    _workload_multiplier,
+    _priority_key,
+)
+
+
+def _fixed_now(dt: datetime):
+    return lambda: dt
+
+
+def _future_iso(minutes: int, now: datetime) -> str:
+    return (now + timedelta(minutes=minutes)).isoformat().replace("+00:00", "Z")
+
+
+NOW = datetime(2026, 5, 27, 10, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake Supabase plumbing
+# ---------------------------------------------------------------------------
+
+class _FakeResult:
+    def __init__(self, data=None):
+        self.data = data or []
+
+
+class _FakeTable:
+    def __init__(self, db, name):
+        self.db = db
+        self.name = name
+        self.filters: dict = {}
+        self._limit: int | None = None
+
+    def select(self, *_args):
+        return self
+
+    def eq(self, field, value):
+        self.filters[field] = value
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def execute(self):
+        rows = list(self.db.get(self.name, []))
+        for k, v in self.filters.items():
+            rows = [r for r in rows if r.get(k) == v]
+        if self._limit is not None:
+            rows = rows[: self._limit]
+        return _FakeResult(rows)
+
+
+class _FakeSupabase:
+    def __init__(self, db: dict):
+        self.db = db
+
+    def table(self, name: str) -> _FakeTable:
+        return _FakeTable(self.db, name)
+
+
+# ---------------------------------------------------------------------------
+# Priority key normalisation
+# ---------------------------------------------------------------------------
+
+class TestPriorityKey(unittest.TestCase):
+    def test_known_priorities_pass_through(self):
+        for p in ("critical", "high", "medium", "low"):
+            self.assertEqual(_priority_key(p), p)
+
+    def test_unknown_priority_defaults_to_low(self):
+        self.assertEqual(_priority_key("urgent"), "low")
+        self.assertEqual(_priority_key(None), "low")
+        self.assertEqual(_priority_key(""), "low")
+
+    def test_case_insensitive(self):
+        self.assertEqual(_priority_key("HIGH"), "high")
+        self.assertEqual(_priority_key("Critical"), "critical")
+
+
+# ---------------------------------------------------------------------------
+# Baseline only (no Supabase)
+# ---------------------------------------------------------------------------
+
+class TestGetSlaEstimateBaseline(unittest.TestCase):
+    def test_critical_baseline(self):
+        result = get_sla_estimate({"priority": "critical"})
+        self.assertEqual(result["estimated_minutes"], 120)
+        self.assertFalse(result["breach_risk"])
+
+    def test_high_baseline(self):
+        result = get_sla_estimate({"priority": "high"})
+        self.assertEqual(result["estimated_minutes"], 480)
+
+    def test_medium_baseline(self):
+        result = get_sla_estimate({"priority": "medium"})
+        self.assertEqual(result["estimated_minutes"], 1440)
+
+    def test_low_baseline(self):
+        result = get_sla_estimate({"priority": "low"})
+        self.assertEqual(result["estimated_minutes"], 4320)
+
+    def test_unknown_priority_uses_low_baseline(self):
+        result = get_sla_estimate({"priority": "turbo"})
+        self.assertEqual(result["estimated_minutes"], 4320)
+
+    def test_missing_sla_breach_at_gives_no_breach_risk(self):
+        result = get_sla_estimate({"priority": "critical"})
+        self.assertFalse(result["breach_risk"])
+
+    def test_malformed_sla_breach_at_gives_no_breach_risk(self):
+        result = get_sla_estimate({"priority": "high", "sla_breach_at": "not-a-date"})
+        self.assertFalse(result["breach_risk"])
+
+
+# ---------------------------------------------------------------------------
+# Breach risk calculation
+# ---------------------------------------------------------------------------
+
+class TestBreachRisk(unittest.TestCase):
+    def test_breach_risk_true_when_estimate_exceeds_remaining_time(self):
+        # critical baseline = 120 min; only 60 min remain → breach risk
+        sla_breach_at = _future_iso(60, NOW)
+        result = get_sla_estimate(
+            {"priority": "critical", "sla_breach_at": sla_breach_at},
+            _now_fn=_fixed_now(NOW),
+        )
+        self.assertTrue(result["breach_risk"])
+
+    def test_breach_risk_false_when_plenty_of_time_remains(self):
+        # critical baseline = 120 min; 300 min remain → safe
+        sla_breach_at = _future_iso(300, NOW)
+        result = get_sla_estimate(
+            {"priority": "critical", "sla_breach_at": sla_breach_at},
+            _now_fn=_fixed_now(NOW),
+        )
+        self.assertFalse(result["breach_risk"])
+
+    def test_breach_risk_true_for_already_past_deadline(self):
+        # deadline already passed → minutes_remaining < 0 → breach risk
+        past_deadline = (NOW - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        result = get_sla_estimate(
+            {"priority": "low", "sla_breach_at": past_deadline},
+            _now_fn=_fixed_now(NOW),
+        )
+        self.assertTrue(result["breach_risk"])
+
+    def test_z_suffix_in_sla_breach_at_is_handled(self):
+        sla_breach_at = _future_iso(300, NOW)
+        result = get_sla_estimate(
+            {"priority": "critical", "sla_breach_at": sla_breach_at},
+            _now_fn=_fixed_now(NOW),
+        )
+        self.assertIsInstance(result["breach_risk"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Category adjustment
+# ---------------------------------------------------------------------------
+
+class TestCategoryAdjustment(unittest.TestCase):
+    def _make_db(self, resolved_count: int, breached_count: int) -> dict:
+        tickets = []
+        for i in range(resolved_count):
+            tickets.append({
+                "id": f"t{i}",
+                "category": "Software",
+                "company_id": "company_A",
+                "status": "resolved",
+                "sla_status": "BREACHED" if i < breached_count else "ACTIVE",
+            })
+        return {"tickets": tickets}
+
+    def test_high_breach_rate_gives_slow_multiplier(self):
+        # 8 out of 10 resolved tickets breached → factor 1.3
+        db = self._make_db(resolved_count=10, breached_count=8)
+        factor = _category_adjustment("Software", "company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 1.3)
+
+    def test_low_breach_rate_gives_fast_multiplier(self):
+        # 1 out of 10 resolved tickets breached → factor 0.8
+        db = self._make_db(resolved_count=10, breached_count=1)
+        factor = _category_adjustment("Software", "company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 0.8)
+
+    def test_moderate_breach_rate_gives_neutral_multiplier(self):
+        # 4 out of 10 breached (40%) → factor 1.0
+        db = self._make_db(resolved_count=10, breached_count=4)
+        factor = _category_adjustment("Software", "company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 1.0)
+
+    def test_fewer_than_5_resolved_returns_neutral(self):
+        db = self._make_db(resolved_count=3, breached_count=3)
+        factor = _category_adjustment("Software", "company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 1.0)
+
+    def test_no_supabase_returns_neutral(self):
+        self.assertAlmostEqual(_category_adjustment("Software", "company_A", None), 1.0)
+
+    def test_missing_category_returns_neutral(self):
+        db = self._make_db(10, 8)
+        self.assertAlmostEqual(_category_adjustment(None, "company_A", _FakeSupabase(db)), 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Workload multiplier
+# ---------------------------------------------------------------------------
+
+class TestWorkloadMultiplier(unittest.TestCase):
+    def _make_db(self, open_count: int) -> dict:
+        return {
+            "tickets": [
+                {"id": f"t{i}", "company_id": "company_A", "status": "open"}
+                for i in range(open_count)
+            ]
+        }
+
+    def test_high_workload_gives_slow_multiplier(self):
+        db = self._make_db(25)
+        factor = _workload_multiplier("company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 1.2)
+
+    def test_low_workload_gives_fast_multiplier(self):
+        db = self._make_db(3)
+        factor = _workload_multiplier("company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 0.9)
+
+    def test_medium_workload_gives_neutral_multiplier(self):
+        db = self._make_db(10)
+        factor = _workload_multiplier("company_A", _FakeSupabase(db))
+        self.assertAlmostEqual(factor, 1.0)
+
+    def test_no_supabase_returns_neutral(self):
+        self.assertAlmostEqual(_workload_multiplier("company_A", None), 1.0)
+
+    def test_missing_company_id_returns_neutral(self):
+        db = self._make_db(25)
+        self.assertAlmostEqual(_workload_multiplier(None, _FakeSupabase(db)), 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: combined factors
+# ---------------------------------------------------------------------------
+
+class TestGetSlaEstimateIntegration(unittest.TestCase):
+    def _make_supabase(self, open_count=3, resolved_count=10, breached_count=9) -> _FakeSupabase:
+        tickets = [
+            {"id": f"t{i}", "company_id": "company_A", "status": "open", "category": "Network", "sla_status": "ACTIVE"}
+            for i in range(open_count)
+        ] + [
+            {
+                "id": f"r{i}", "company_id": "company_A", "status": "resolved",
+                "category": "Network",
+                "sla_status": "BREACHED" if i < breached_count else "ACTIVE",
+            }
+            for i in range(resolved_count)
+        ]
+        return _FakeSupabase({"tickets": tickets})
+
+    def test_combined_factors_produce_adjusted_estimate(self):
+        # high breach rate (0.9) → factor 1.3; low workload (3) → factor 0.9
+        # critical baseline = 120 min; 120 * 1.3 * 0.9 = 140.4 → rounds to 140
+        supabase = self._make_supabase(open_count=3, resolved_count=10, breached_count=9)
+        result = get_sla_estimate(
+            {"priority": "critical", "category": "Network", "company_id": "company_A"},
+            supabase=supabase,
+            _now_fn=_fixed_now(NOW),
+        )
+        self.assertEqual(result["estimated_minutes"], 140)
+        self.assertFalse(result["breach_risk"])
+
+    def test_returns_breach_risk_when_estimate_exceeds_deadline(self):
+        supabase = self._make_supabase(open_count=3, resolved_count=10, breached_count=9)
+        sla_breach_at = _future_iso(100, NOW)  # only 100 min left, estimate is 140
+        result = get_sla_estimate(
+            {
+                "priority": "critical",
+                "category": "Network",
+                "company_id": "company_A",
+                "sla_breach_at": sla_breach_at,
+            },
+            supabase=supabase,
+            _now_fn=_fixed_now(NOW),
+        )
+        self.assertTrue(result["breach_risk"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- `backend/sla_predictor.py` — new SLA estimator utility
- `GET /tickets/{id}/sla-estimate` endpoint in main.py
- 27 unit tests in `test_sla_predictor.py`
- Est. SLA badge on RecentTickets + MyTickets
- SLA At Risk filter + row highlighting in AdminTickets
- SLABadge.jsx upgraded to use slaBreachAt from DB

## Why
Fixes #205 — agents had no visibility into resolution 
timelines or SLA breach risk before it happened.

## How to test
1. `cd backend && pytest tests/test_sla_predictor.py -v`
2. All 27 tests should pass
3. Frontend: SLA badges visible on ticket cards

## Screenshots
<img width="1119" height="672" alt="Screenshot 2026-05-27 234120" src="https://github.com/user-attachments/assets/66e8712b-3911-406d-a2f4-b4b6984add38" />


## Notes
- No DB migration needed (sla_breach_at + sla_status 
  columns already exist)
- No new packages added
- 27 unit tests covering all edge cases