### PR TITLE
feat(i1feat(i18n): Add Multi-Language Auto-Translation Pipeline with HuggingFace - Fixes #206

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -26,6 +26,7 @@ import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
 import { formatTimelineDate } from "../../utils/dateUtils";
+import LanguageBadge from "../../components/shared/LanguageBadge";
 
 const AdminTickets = () => {
     const navigate = useNavigate();
@@ -45,6 +46,7 @@ const AdminTickets = () => {
     const [categoryFilter, setCategoryFilter] = useState('All');
     const [priorityFilter, setPriorityFilter] = useState('All');
     const [teamFilter, setTeamFilter] = useState('All');
+    const [languageFilter, setLanguageFilter] = useState('All');
     const [agents, setAgents] = useState([]); // All staff/admins in the company
 
     const ticketMatchesFilters = useCallback((ticket) => {
@@ -52,8 +54,13 @@ const AdminTickets = () => {
         if (categoryFilter !== 'All' && ticket.category !== categoryFilter) return false;
         if (priorityFilter !== 'All' && String(ticket.priority || '').toLowerCase() !== priorityFilter.toLowerCase()) return false;
         if (teamFilter !== 'All' && ticket.assigned_team !== teamFilter) return false;
+        if (languageFilter !== 'All') {
+            const translated = ticket?.metadata?.translation?.translated;
+            if (languageFilter === 'Translated' && !translated) return false;
+            if (languageFilter === 'English' && translated) return false;
+        }
         return true;
-    }, [categoryFilter, priorityFilter, statusFilter, teamFilter]);
+    }, [categoryFilter, priorityFilter, statusFilter, teamFilter, languageFilter]);
 
     const handleRealtimeInsert = useCallback((ticket) => {
         showToast(`New Incident Reported: #${formatTicketId(ticket.id)}`, "success");
@@ -172,16 +179,25 @@ const AdminTickets = () => {
     const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
 
     const filteredTickets = useMemo(() => {
-        if (!searchQuery) return tickets;
-        const q = searchQuery.toLowerCase();
-        return tickets.filter(t =>
-            String(t.id).includes(q) ||
-            (t.subject || '').toLowerCase().includes(q) ||
-            (t.summary || '').toLowerCase().includes(q) ||
-            (t.description || '').toLowerCase().includes(q) ||
-            (t.profiles?.full_name || '').toLowerCase().includes(q)
-        );
-    }, [tickets, searchQuery]);
+        let result = tickets;
+        if (searchQuery) {
+            const q = searchQuery.toLowerCase();
+            result = result.filter(t =>
+                String(t.id).includes(q) ||
+                (t.subject || '').toLowerCase().includes(q) ||
+                (t.summary || '').toLowerCase().includes(q) ||
+                (t.description || '').toLowerCase().includes(q) ||
+                (t.profiles?.full_name || '').toLowerCase().includes(q)
+            );
+        }
+        if (languageFilter !== 'All') {
+            result = result.filter(t => {
+                const translated = t?.metadata?.translation?.translated;
+                return languageFilter === 'Translated' ? translated : !translated;
+            });
+        }
+        return result;
+    }, [tickets, searchQuery, languageFilter]);
 
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();
@@ -254,6 +270,19 @@ const AdminTickets = () => {
                         onChange={(e) => setTeamFilter(e.target.value)}
                         buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
                         options={teams.map(t => ({ value: t, label: t === 'All' ? 'All Teams' : t }))}
+                    />
+                </div>
+                {/* Language Filter */}
+                <div className="flex items-center gap-3">
+                    <Select
+                        value={languageFilter}
+                        onChange={(e) => setLanguageFilter(e.target.value)}
+                        buttonClassName="bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-sky-500/5 transition-all text-left flex justify-between items-center"
+                        options={[
+                            { value: 'All', label: '🌐 All Languages' },
+                            { value: 'English', label: 'English Only' },
+                            { value: 'Translated', label: 'Translated Only' },
+                        ]}
                     />
                 </div>
             </div>
@@ -340,11 +369,7 @@ const AdminTickets = () => {
                                                 {ticket.category} 
                                                 <span className="text-[9px] font-medium text-slate-300">• {formatTimelineDate(ticket.created_at)}</span>
                                             </span>
-                                            {ticket?.metadata?.translation?.translated && (
-                                                <span className="text-[10px] text-sky-700 mt-1">
-                                                    Translated from {ticket.metadata.translation.source_language_name || ticket.metadata.translation.source_language || 'Unknown'}
-                                                </span>
-                                            )}
+                                            <LanguageBadge translation={ticket?.metadata?.translation} compact />
                                         </div>
                                     </td>
 

--- a/Frontend/src/components/shared/LanguageBadge.jsx
+++ b/Frontend/src/components/shared/LanguageBadge.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Globe } from 'lucide-react';
+
+/**
+ * Compact badge shown on ticket cards when the ticket was originally
+ * submitted in a non-English language and auto-translated.
+ *
+ * Props:
+ *   translation  – ticket.metadata?.translation  (object)
+ *   compact      – boolean, renders icon-only variant when true (default false)
+ */
+const LanguageBadge = ({ translation, compact = false }) => {
+    if (!translation?.translated) return null;
+
+    const langName = translation.source_language_name
+        || translation.source_language?.toUpperCase()
+        || 'Unknown';
+
+    if (compact) {
+        return (
+            <span
+                title={`Translated from ${langName}`}
+                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-bold
+                           bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400
+                           border border-sky-200 dark:border-sky-800/30 whitespace-nowrap"
+            >
+                <Globe size={10} className="shrink-0" />
+                {langName}
+            </span>
+        );
+    }
+
+    return (
+        <span
+            className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-bold
+                       bg-sky-50 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400
+                       border border-sky-200 dark:border-sky-800/30 whitespace-nowrap"
+        >
+            <Globe size={12} className="shrink-0" />
+            {langName}
+        </span>
+    );
+};
+
+export default LanguageBadge;

--- a/Frontend/src/user/components/RecentTickets.jsx
+++ b/Frontend/src/user/components/RecentTickets.jsx
@@ -4,6 +4,7 @@ import { Clock, ChevronRight, Inbox, Loader2, AlertCircle } from 'lucide-react';
 import useAuthStore from '../../store/authStore';
 import { supabase } from '../../lib/supabaseClient';
 import { formatTimelineDate } from '../../utils/dateUtils';
+import LanguageBadge from '../../components/shared/LanguageBadge';
 
 const RecentTickets = () => {
     const navigate = useNavigate();
@@ -132,11 +133,9 @@ const RecentTickets = () => {
                                             <p className="text-sm font-semibold text-slate-900 dark:text-white truncate max-w-[320px]">
                                                 {ticket.summary || ticket.subject || ticket.description || "No description provided"}
                                             </p>
-                                            {ticket?.metadata?.translation?.translated && (
-                                                <p className="text-[11px] text-sky-600 dark:text-sky-400 mt-1">
-                                                    Translated from {ticket.metadata.translation.source_language_name || ticket.metadata.translation.source_language || 'Unknown'}
-                                                </p>
-                                            )}
+                                            <div className="mt-1">
+                                                <LanguageBadge translation={ticket?.metadata?.translation} compact />
+                                            </div>
                                         </td>
                                         <td className="px-7 py-4">
                                             {getStatusBadge(ticket.status)}

--- a/Frontend/src/user/pages/MyTickets.jsx
+++ b/Frontend/src/user/pages/MyTickets.jsx
@@ -121,13 +121,6 @@ function MyTickets() {
         return 'text-gray-600';
     };
 
-    const getTranslationInfo = (ticket) => {
-        const t = ticket?.metadata?.translation;
-        if (!t?.translated) return null;
-        return {
-            sourceLanguageName: t.source_language_name || t.source_language || 'Unknown',
-        };
-    };
 
     return (
         <main className="flex-1 max-w-[1200px] w-full mx-auto px-6 py-10 flex flex-col gap-8">

--- a/Frontend/src/user/pages/MyTickets.jsx
+++ b/Frontend/src/user/pages/MyTickets.jsx
@@ -12,6 +12,7 @@ import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import TicketStatusBadge from "../components/TicketStatusBadge";
 import { formatTimelineDate, getTimeZoneAbbr } from "../../utils/dateUtils";
+import LanguageBadge from "../../components/shared/LanguageBadge";
 import {
     Tooltip,
     TooltipContent,
@@ -325,11 +326,9 @@ function MyTickets() {
                                                  <p className="text-sm font-semibold text-gray-900 truncate group-hover:text-emerald-700 transition-colors">
                                                      {ticket.summary || ticket.subject || ticket.description || "No subject"}
                                                  </p>
-                                                 {getTranslationInfo(ticket) && (
-                                                     <p className="text-[10px] text-slate-500 mt-1">
-                                                         Translated from {getTranslationInfo(ticket).sourceLanguageName}
-                                                     </p>
-                                                 )}
+                                                 <div className="mt-1">
+                                                     <LanguageBadge translation={ticket?.metadata?.translation} compact />
+                                                 </div>
                                             </td>
                                             <td className="px-6 py-4">
                                                 <span className="text-sm font-medium text-gray-600 bg-gray-100 px-2.5 py-1 rounded-md">

--- a/backend/language_pipeline.py
+++ b/backend/language_pipeline.py
@@ -1,0 +1,144 @@
+"""
+Multi-Language Auto-Translation Pipeline.
+
+Provides:
+  detect_language(text: str) -> str          – ISO-639-1 code (e.g. 'hi')
+  translate_to_english(text, source_lang)    – Helsinki-NLP/opus-mt-{src}-en
+  translate_from_english(text, target_lang)  – Helsinki-NLP/opus-mt-en-{tgt}
+
+Language detection uses `langdetect` (offline, fast).
+Translation uses Helsinki-NLP MarianMT models loaded lazily via `transformers`.
+Both functions degrade gracefully: on any error the original text is returned.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+LANGUAGE_NAMES: dict[str, str] = {
+    "hi": "Hindi",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "ar": "Arabic",
+    "pt": "Portuguese",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "ko": "Korean",
+    "it": "Italian",
+    "ru": "Russian",
+    "en": "English",
+}
+
+# In-memory model cache: model_name -> (tokenizer, model)
+_MODEL_CACHE: dict[str, tuple] = {}
+
+
+def detect_language(text: str) -> str:
+    """Detect the ISO-639-1 language code of *text*.
+
+    Uses langdetect as the primary engine; falls back to 'en' when the
+    package is absent, the text is too short, or detection throws.
+    """
+    text = (text or "").strip()
+    if not text or len(text) < 5:
+        return "en"
+
+    try:
+        from langdetect import detect as _detect
+        code = _detect(text)
+        # Normalise: langdetect may return 'zh-cn', 'pt-br', etc.
+        return str(code).lower().split("-")[0][:2]
+    except Exception as exc:
+        logger.warning("langdetect unavailable or failed (%s) – defaulting to 'en'", exc)
+        # Last-resort heuristic: high non-ASCII density → definitely not English
+        ascii_ratio = sum(1 for c in text if ord(c) < 128) / len(text)
+        return "en" if ascii_ratio > 0.80 else "unknown"
+
+
+def _load_model(model_name: str) -> tuple:
+    """Lazy-load a Helsinki-NLP MarianMT model and cache it in memory."""
+    if model_name in _MODEL_CACHE:
+        return _MODEL_CACHE[model_name]
+
+    try:
+        from transformers import MarianMTModel, MarianTokenizer
+    except ImportError as exc:
+        raise ImportError(
+            "transformers is required for translation. "
+            "Install it with: pip install transformers"
+        ) from exc
+
+    logger.info("Loading translation model '%s' (first call – will cache)…", model_name)
+    tokenizer = MarianTokenizer.from_pretrained(model_name)
+    model = MarianMTModel.from_pretrained(model_name)
+    _MODEL_CACHE[model_name] = (tokenizer, model)
+    logger.info("Model '%s' cached.", model_name)
+    return tokenizer, model
+
+
+def _run_translation(text: str, model_name: str) -> str:
+    """Run a single translation using the named Marian model."""
+    tokenizer, model = _load_model(model_name)
+    inputs = tokenizer(
+        [text],
+        return_tensors="pt",
+        padding=True,
+        truncation=True,
+        max_length=512,
+    )
+    translated_ids = model.generate(**inputs)
+    return tokenizer.batch_decode(translated_ids, skip_special_tokens=True)[0]
+
+
+def translate_to_english(text: str, source_lang: str) -> str:
+    """Translate *text* from *source_lang* to English.
+
+    Uses Helsinki-NLP/opus-mt-{source_lang}-en.
+    Returns the original text unchanged if *source_lang* is 'en',
+    or if the translation model is unavailable / fails.
+    """
+    text = (text or "").strip()
+    if not text:
+        return text
+
+    lang = str(source_lang or "en").lower().split("-")[0][:2]
+    if lang in ("en", ""):
+        return text
+
+    model_name = f"Helsinki-NLP/opus-mt-{lang}-en"
+    try:
+        return _run_translation(text, model_name)
+    except Exception as exc:
+        logger.warning(
+            "translate_to_english failed (model=%s): %s – returning original text",
+            model_name, exc,
+        )
+        return text
+
+
+def translate_from_english(text: str, target_lang: str) -> str:
+    """Back-translate *text* from English into *target_lang*.
+
+    Uses Helsinki-NLP/opus-mt-en-{target_lang}.
+    Returns the original text unchanged if *target_lang* is 'en',
+    or if the translation model is unavailable / fails.
+    """
+    text = (text or "").strip()
+    if not text:
+        return text
+
+    lang = str(target_lang or "en").lower().split("-")[0][:2]
+    if lang in ("en", ""):
+        return text
+
+    model_name = f"Helsinki-NLP/opus-mt-en-{lang}"
+    try:
+        return _run_translation(text, model_name)
+    except Exception as exc:
+        logger.warning(
+            "translate_from_english failed (model=%s): %s – returning original text",
+            model_name, exc,
+        )
+        return text

--- a/backend/main.py
+++ b/backend/main.py
@@ -509,6 +509,19 @@ LANGUAGE_NAMES = {
     "ru": "Russian",
 }
 
+try:
+    from backend.language_pipeline import (
+        detect_language as _lp_detect_language,
+        translate_to_english as _lp_translate_to_english,
+        translate_from_english as _lp_translate_from_english,
+        LANGUAGE_NAMES as _LP_LANGUAGE_NAMES,
+    )
+    LANGUAGE_NAMES.update(_LP_LANGUAGE_NAMES)
+    _LANGUAGE_PIPELINE_AVAILABLE = True
+except ImportError:
+    _LANGUAGE_PIPELINE_AVAILABLE = False
+
+
 def _heuristic_language_detection(text: str) -> dict:
     sample = (text or "").strip()
     if not sample:
@@ -531,13 +544,27 @@ def detect_and_translate_ticket_text(text: str) -> dict:
             "metadata":{},
         }
 
-    detected = _heuristic_language_detection(original_text)
-    if gemini_service and getattr(gemini_service, "_initialized", False):
-        detected = gemini_service.detect_language(original_text)
+    # --- Step 1: Language detection ---
+    # Primary: language_pipeline (langdetect); secondary: Gemini; fallback: heuristic
+    if _LANGUAGE_PIPELINE_AVAILABLE:
+        source_code = _lp_detect_language(original_text)
+        source_name = LANGUAGE_NAMES.get(source_code, source_code.upper())
+    else:
+        detected = _heuristic_language_detection(original_text)
+        if gemini_service and getattr(gemini_service, "_initialized", False):
+            detected = gemini_service.detect_language(original_text)
+        source_code = str(detected.get("code", "en")).lower()
+        source_name = detected.get("name") or LANGUAGE_NAMES.get(source_code, source_code.upper())
 
-    source_code = str(detected.get("code", "en")).lower()
-    source_name = detected.get("name") or LANGUAGE_NAMES.get(source_code, source_code.upper())
-    if source_code in ("en", "eng"):
+    # If langdetect returned "en" / "unknown", try Gemini for confirmation
+    if source_code in ("en", "unknown") and gemini_service and getattr(gemini_service, "_initialized", False):
+        gemini_detected = gemini_service.detect_language(original_text)
+        gemini_code = str(gemini_detected.get("code", "en")).lower()
+        if gemini_code not in ("en", "eng", "unknown"):
+            source_code = gemini_code
+            source_name = gemini_detected.get("name") or LANGUAGE_NAMES.get(gemini_code, gemini_code.upper())
+
+    if source_code in ("en", "eng", "unknown"):
         return {
             "text_for_analysis": original_text,
             "source_language": "en",
@@ -547,8 +574,14 @@ def detect_and_translate_ticket_text(text: str) -> dict:
             "metadata":{},
         }
 
+    # --- Step 2: Translation to English ---
+    # Primary: language_pipeline (Helsinki-NLP); fallback: Gemini
     translated_text = original_text
-    if gemini_service and getattr(gemini_service, "_initialized", False):
+    if _LANGUAGE_PIPELINE_AVAILABLE:
+        translated_text = _lp_translate_to_english(original_text, source_code)
+
+    # Fall back to Gemini if Helsinki-NLP returned the same text (model unavailable)
+    if translated_text == original_text and gemini_service and getattr(gemini_service, "_initialized", False):
         translated_text = gemini_service.translate_to_english(original_text, source_name)
 
     if not translated_text or translated_text.strip() == original_text:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 torch>=2.0.0
+langdetect>=1.2.0
 transformers>=4.35.0
 datasets>=2.14.0
 pandas>=2.0.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -273,6 +273,9 @@ def mock_ai_services(request):
         "test_semantic_duplicates.py",
         "test_auth_cookie.py",
         "test_mobile_supabase_env.py",
+        "test_sla_service.py",
+        "test_sla_predictor.py",
+        "test_language_pipeline.py",
     }:
         yield
         return

--- a/backend/tests/test_language_pipeline.py
+++ b/backend/tests/test_language_pipeline.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for backend.language_pipeline.
+
+All tests are self-contained: langdetect and transformers are mocked via
+sys.modules injection so the suite runs without optional ML packages installed.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_langdetect_stub(return_value: str):
+    """Return a fake langdetect module whose detect() always returns return_value."""
+    mod = types.ModuleType("langdetect")
+    mod.detect = lambda text: return_value
+    mod.LangDetectException = Exception
+    return mod
+
+
+def _make_langdetect_raises():
+    """Return a fake langdetect module whose detect() raises LangDetectException."""
+    mod = types.ModuleType("langdetect")
+    exc_cls = type("LangDetectException", (Exception,), {})
+    mod.LangDetectException = exc_cls
+
+    def _detect(text):
+        raise exc_cls("no features in text")
+
+    mod.detect = _detect
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# detect_language
+# ---------------------------------------------------------------------------
+
+class TestDetectLanguage(unittest.TestCase):
+
+    def _call(self, text, langdetect_stub=None):
+        # Inject stub before calling; remove cached module so the in-function
+        # `from langdetect import detect` picks up our stub.
+        if langdetect_stub is not None:
+            sys.modules["langdetect"] = langdetect_stub
+        else:
+            sys.modules.pop("langdetect", None)
+        from backend.language_pipeline import detect_language
+        return detect_language(text)
+
+    def tearDown(self):
+        sys.modules.pop("langdetect", None)
+
+    def test_empty_string_returns_english(self):
+        self.assertEqual(self._call(""), "en")
+
+    def test_whitespace_returns_english(self):
+        self.assertEqual(self._call("   "), "en")
+
+    def test_very_short_text_returns_english(self):
+        self.assertEqual(self._call("hi"), "en")
+
+    def test_hindi_detected(self):
+        result = self._call(
+            "मेरा इंटरनेट काम नहीं कर रहा है",
+            _make_langdetect_stub("hi"),
+        )
+        self.assertEqual(result, "hi")
+
+    def test_spanish_detected(self):
+        result = self._call(
+            "Mi computadora no enciende y necesito ayuda urgente",
+            _make_langdetect_stub("es"),
+        )
+        self.assertEqual(result, "es")
+
+    def test_french_detected(self):
+        result = self._call(
+            "Mon ordinateur ne démarre pas après la mise à jour",
+            _make_langdetect_stub("fr"),
+        )
+        self.assertEqual(result, "fr")
+
+    def test_german_detected(self):
+        result = self._call(
+            "Mein Computer startet nicht mehr nach dem Update",
+            _make_langdetect_stub("de"),
+        )
+        self.assertEqual(result, "de")
+
+    def test_arabic_detected(self):
+        result = self._call(
+            "جهاز الكمبيوتر الخاص بي لا يعمل بعد التحديث",
+            _make_langdetect_stub("ar"),
+        )
+        self.assertEqual(result, "ar")
+
+    def test_portuguese_detected(self):
+        result = self._call(
+            "Meu computador não liga após a atualização do sistema",
+            _make_langdetect_stub("pt"),
+        )
+        self.assertEqual(result, "pt")
+
+    def test_japanese_detected(self):
+        result = self._call(
+            "コンピューターが起動しない問題があります",
+            _make_langdetect_stub("ja"),
+        )
+        self.assertEqual(result, "ja")
+
+    def test_code_normalised_to_two_chars(self):
+        # langdetect may return 'zh-cn' – we must strip to 'zh'
+        result = self._call("我的电脑无法启动，请帮帮我", _make_langdetect_stub("zh-cn"))
+        self.assertEqual(result, "zh")
+
+    def test_langdetect_exception_falls_back_to_english_for_ascii(self):
+        # ASCII-dominant text + broken langdetect → 'en'
+        result = self._call(
+            "My laptop is not working properly",
+            _make_langdetect_raises(),
+        )
+        self.assertEqual(result, "en")
+
+    def test_langdetect_missing_falls_back(self):
+        # No langdetect in sys.modules at all
+        sys.modules.pop("langdetect", None)
+        from backend.language_pipeline import detect_language
+        result = detect_language("My laptop screen is flickering")
+        # ASCII text → heuristic returns 'en'
+        self.assertEqual(result, "en")
+
+
+# ---------------------------------------------------------------------------
+# translate_to_english
+# ---------------------------------------------------------------------------
+
+class TestTranslateToEnglish(unittest.TestCase):
+
+    def setUp(self):
+        import backend.language_pipeline as lp
+        lp._MODEL_CACHE.clear()
+
+    def test_english_input_unchanged(self):
+        from backend.language_pipeline import translate_to_english
+        text = "My printer is not working"
+        self.assertEqual(translate_to_english(text, "en"), text)
+
+    def test_empty_text_returns_empty(self):
+        from backend.language_pipeline import translate_to_english
+        self.assertEqual(translate_to_english("", "hi"), "")
+
+    def test_hindi_uses_correct_model(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("मेरा इंटरनेट काम नहीं कर रहा", "hi")
+            m.assert_called_once_with(
+                "मेरा इंटरनेट काम नहीं कर रहा",
+                "Helsinki-NLP/opus-mt-hi-en",
+            )
+
+    def test_spanish_uses_correct_model(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("Mi computadora no enciende", "es")
+            m.assert_called_once_with(
+                "Mi computadora no enciende",
+                "Helsinki-NLP/opus-mt-es-en",
+            )
+
+    def test_french_uses_correct_model(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("Mon ordinateur ne démarre pas", "fr")
+            m.assert_called_once_with(
+                "Mon ordinateur ne démarre pas",
+                "Helsinki-NLP/opus-mt-fr-en",
+            )
+
+    def test_german_uses_correct_model(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("Mein Computer startet nicht", "de")
+            m.assert_called_once_with(
+                "Mein Computer startet nicht",
+                "Helsinki-NLP/opus-mt-de-en",
+            )
+
+    def test_arabic_uses_correct_model(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("الكمبيوتر لا يعمل", "ar")
+            m.assert_called_once_with(
+                "الكمبيوتر لا يعمل",
+                "Helsinki-NLP/opus-mt-ar-en",
+            )
+
+    def test_portuguese_uses_correct_model(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("Meu computador não liga", "pt")
+            m.assert_called_once_with(
+                "Meu computador não liga",
+                "Helsinki-NLP/opus-mt-pt-en",
+            )
+
+    def test_failure_returns_original_text(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", side_effect=OSError("model not found")):
+            result = translate_to_english("बोलो", "hi")
+            self.assertEqual(result, "बोलो")
+
+    def test_returns_translation_result(self):
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="My computer does not start"):
+            result = translate_to_english("Mi computadora no enciende", "es")
+            self.assertEqual(result, "My computer does not start")
+
+    def test_lang_code_normalised(self):
+        """zh-cn should produce Helsinki-NLP/opus-mt-zh-en (not zh-cn-en)."""
+        from backend.language_pipeline import translate_to_english
+        with patch("backend.language_pipeline._run_translation", return_value="translated") as m:
+            translate_to_english("你好世界", "zh-cn")
+            m.assert_called_once_with("你好世界", "Helsinki-NLP/opus-mt-zh-en")
+
+
+# ---------------------------------------------------------------------------
+# translate_from_english
+# ---------------------------------------------------------------------------
+
+class TestTranslateFromEnglish(unittest.TestCase):
+
+    def setUp(self):
+        import backend.language_pipeline as lp
+        lp._MODEL_CACHE.clear()
+
+    def test_english_target_unchanged(self):
+        from backend.language_pipeline import translate_from_english
+        text = "Your ticket has been resolved."
+        self.assertEqual(translate_from_english(text, "en"), text)
+
+    def test_empty_text_returns_empty(self):
+        from backend.language_pipeline import translate_from_english
+        self.assertEqual(translate_from_english("", "hi"), "")
+
+    def test_hindi_uses_correct_model(self):
+        from backend.language_pipeline import translate_from_english
+        with patch("backend.language_pipeline._run_translation", return_value="आपका टिकट हल हो गया") as m:
+            translate_from_english("Your ticket has been resolved", "hi")
+            m.assert_called_once_with(
+                "Your ticket has been resolved",
+                "Helsinki-NLP/opus-mt-en-hi",
+            )
+
+    def test_spanish_uses_correct_model(self):
+        from backend.language_pipeline import translate_from_english
+        with patch("backend.language_pipeline._run_translation", return_value="Su ticket ha sido resuelto") as m:
+            translate_from_english("Your ticket has been resolved", "es")
+            m.assert_called_once_with(
+                "Your ticket has been resolved",
+                "Helsinki-NLP/opus-mt-en-es",
+            )
+
+    def test_failure_returns_original_text(self):
+        from backend.language_pipeline import translate_from_english
+        with patch("backend.language_pipeline._run_translation", side_effect=Exception("no model")):
+            result = translate_from_english("Ticket resolved", "fr")
+            self.assertEqual(result, "Ticket resolved")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- `backend/language_pipeline.py` — new translation module
- `detect_language()` via langdetect (offline, no API key)
- `translate_to_english()` + `translate_from_english()` 
  via Helsinki-NLP/opus-mt HuggingFace models
- Integrated into existing ticket creation pipeline
- 29 unit tests covering 7 languages
- LanguageBadge.jsx component on ticket cards
- Language filter dropdown in AdminTickets

## Why
Fixes #206 — pipeline was English-only, breaking for 
non-English enterprise users.

## How to test
1. `pytest backend\tests\test_language_pipeline.py -v`
2. All 29 tests pass

## Screenshots
<img width="1150" height="729" alt="Screenshot 2026-05-28 001726" src="https://github.com/user-attachments/assets/d450322f-95d1-4686-bfc4-d18ece3a09ff" />


## Notes
- Only new package: `langdetect>=1.0.7`
- Helsinki-NLP models load lazily, cached in memory
- Graceful fallback if translation fails