### PR TITLE
feat(digest): Add Weekly AI Digest Email with APScheduler and Admin Toggle - Fixes #208

### DIFF
--- a/Frontend/src/admin/pages/AdminSettings.jsx
+++ b/Frontend/src/admin/pages/AdminSettings.jsx
@@ -7,7 +7,9 @@ import {
     Inbox,
     Bell,
     Save,
-    ShieldCheck
+    ShieldCheck,
+    Mail,
+    Send,
 } from 'lucide-react';
 import useAdminStore from '../store/adminStore';
 import useAuthStore from '../../store/authStore';
@@ -32,6 +34,8 @@ const AdminSettings = () => {
     const [isSavingSettings, setIsSavingSettings] = useState(false);
     const [statusMessage, setStatusMessage] = useState('');
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+    const [isSendingDigest, setIsSendingDigest] = useState(false);
+    const [digestStatus, setDigestStatus] = useState('');
 
     const companyId = useMemo(() => resolveCompanyId(profile, user), [profile, user]);
 
@@ -49,7 +53,7 @@ const AdminSettings = () => {
 
             const { data, error } = await supabase
                 .from('system_settings')
-                .select('ai_confidence_threshold, duplicate_sensitivity, enable_auto_resolve, auto_close_days, email_notifications, admin_alerts')
+                .select('ai_confidence_threshold, duplicate_sensitivity, enable_auto_resolve, auto_close_days, email_notifications, admin_alerts, digest_enabled, last_digest_sent')
                 .eq('company_id', companyId)
                 .maybeSingle();
 
@@ -117,6 +121,34 @@ const AdminSettings = () => {
 
         return () => window.clearTimeout(saveTimer);
     }, [hasUnsavedChanges, isLoadingSettings, isSavingSettings, saveCompanySettings, settings]);
+
+    const handleSendDigestNow = useCallback(async () => {
+        if (!companyId || !user?.email) {
+            setDigestStatus('Company ID and admin email are required.');
+            return;
+        }
+        setIsSendingDigest(true);
+        setDigestStatus('Sending digest...');
+        try {
+            const res = await fetch(`${import.meta.env.VITE_API_URL || ''}/api/digest/send-now`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ company_id: companyId, admin_email: user.email }),
+            });
+            if (res.ok) {
+                setDigestStatus(`Digest sent to ${user.email}`);
+                updateSettings({ lastDigestSent: new Date().toISOString() });
+            } else {
+                const err = await res.json().catch(() => ({}));
+                setDigestStatus(`Failed: ${err.detail || res.statusText}`);
+            }
+        } catch (e) {
+            setDigestStatus(`Error: ${e.message}`);
+        } finally {
+            setIsSendingDigest(false);
+        }
+    }, [companyId, user, updateSettings]);
 
     return (
         <div className="max-w-4xl mx-auto py-6 space-y-10 pb-20 animate-in fade-in duration-700">
@@ -290,6 +322,58 @@ const AdminSettings = () => {
                     </div>
                     <CardContent className="p-8">
                         <WebhookSettings />
+                    </CardContent>
+                </Card>
+
+                {/* 6. Weekly AI Digest */}
+                <Card className="border-none shadow-2xl shadow-slate-200/40 rounded-[2rem] overflow-hidden bg-white">
+                    <div className="px-8 py-6 bg-slate-900 text-white flex items-center justify-between border-b border-slate-800">
+                        <h3 className="text-sm font-black uppercase italic tracking-tight flex items-center gap-3">
+                            <Mail size={18} className="text-indigo-400" /> Weekly AI Digest
+                        </h3>
+                    </div>
+                    <CardContent className="p-8 space-y-6">
+                        {/* Toggle */}
+                        <div className="flex items-center justify-between pb-4 border-b border-slate-100">
+                            <div>
+                                <h4 className="text-xs font-black text-slate-700 uppercase tracking-widest">Weekly Digest Email</h4>
+                                <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest mt-1">
+                                    Receive an AI-generated performance summary every Monday at 8:00 AM UTC.
+                                </p>
+                            </div>
+                            <button
+                                onClick={() => handleChange('digestEnabled', !settings.digestEnabled)}
+                                className={`w-14 h-8 rounded-full relative transition-all duration-300 shadow-inner shrink-0 ${settings.digestEnabled ? 'bg-indigo-600' : 'bg-slate-200'}`}
+                            >
+                                <div className={`absolute top-1 w-6 h-6 bg-white rounded-full transition-all duration-300 shadow-md ${settings.digestEnabled ? 'right-1' : 'left-1'}`}></div>
+                            </button>
+                        </div>
+
+                        {/* Last sent + Send Now */}
+                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                            <div>
+                                <p className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">
+                                    Last digest sent:&nbsp;
+                                    <span className="text-slate-600">
+                                        {settings.lastDigestSent
+                                            ? new Date(settings.lastDigestSent).toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })
+                                            : 'Never'}
+                                    </span>
+                                </p>
+                                {digestStatus && (
+                                    <p className="text-[10px] font-bold uppercase tracking-widest mt-1 text-indigo-600">{digestStatus}</p>
+                                )}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={handleSendDigestNow}
+                                disabled={isSendingDigest || !companyId}
+                                className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-5 py-3 text-xs font-black uppercase tracking-widest text-white shadow-lg shadow-indigo-200 transition-all hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:shadow-none shrink-0"
+                            >
+                                <Send size={14} />
+                                {isSendingDigest ? 'Sending...' : 'Send Now'}
+                            </button>
+                        </div>
                     </CardContent>
                 </Card>
 

--- a/Frontend/src/admin/store/adminStore.js
+++ b/Frontend/src/admin/store/adminStore.js
@@ -11,7 +11,9 @@ const useAdminStore = create(
                 enableAutoResolve: false,
                 autoCloseDays: 7,
                 emailNotifications: false,
-                adminAlerts: false
+                adminAlerts: false,
+                digestEnabled: false,
+                lastDigestSent: null,
             },
 
             setUsers: (users) => set({ users }),

--- a/Frontend/src/utils/adminSettingsPersistence.js
+++ b/Frontend/src/utils/adminSettingsPersistence.js
@@ -5,6 +5,8 @@ export const DEFAULT_ADMIN_SETTINGS = {
     autoCloseDays: 7,
     emailNotifications: false,
     adminAlerts: false,
+    digestEnabled: false,
+    lastDigestSent: null,
 };
 
 export const resolveCompanyId = (profile, user) => {
@@ -27,6 +29,8 @@ export const settingsFromSystemSettingsRow = (row, fallback = DEFAULT_ADMIN_SETT
         autoCloseDays: row.auto_close_days ?? fallback.autoCloseDays,
         emailNotifications: row.email_notifications ?? fallback.emailNotifications,
         adminAlerts: row.admin_alerts ?? fallback.adminAlerts,
+        digestEnabled: row.digest_enabled ?? fallback.digestEnabled,
+        lastDigestSent: row.last_digest_sent ?? fallback.lastDigestSent,
     };
 };
 
@@ -38,4 +42,5 @@ export const settingsToSystemSettingsRow = (settings, companyId) => ({
     auto_close_days: Number(settings.autoCloseDays),
     email_notifications: Boolean(settings.emailNotifications),
     admin_alerts: Boolean(settings.adminAlerts),
+    digest_enabled: Boolean(settings.digestEnabled),
 });

--- a/backend/digest_service.py
+++ b/backend/digest_service.py
@@ -1,0 +1,320 @@
+"""
+Weekly AI Digest Email Service — Issue #208
+
+Queries last 7 days of ticket data from Supabase, generates a Gemini AI summary,
+and sends a formatted HTML digest email via Resend to company admins.
+"""
+
+import os
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Resend — lazy import so the app still starts without the SDK installed
+# ---------------------------------------------------------------------------
+try:
+    import resend as _resend_sdk
+    _HAS_RESEND = True
+except ImportError:
+    _resend_sdk = None
+    _HAS_RESEND = False
+
+
+def _resend_api_key() -> Optional[str]:
+    return os.environ.get("RESEND_API_KEY")
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+def get_weekly_stats(supabase_client, company_id: Optional[str] = None) -> dict:
+    """
+    Query Supabase for ticket statistics over the past 7 days.
+
+    Returns a dict with totals, resolution rate, SLA breach count,
+    top 3 categories, and a comparison % change vs the prior 7-day window.
+    """
+    if supabase_client is None:
+        raise RuntimeError("Supabase client is not available")
+
+    now = datetime.now(timezone.utc)
+    week_start = now - timedelta(days=7)
+    prev_week_start = now - timedelta(days=14)
+
+    week_iso = week_start.isoformat()
+    prev_iso = prev_week_start.isoformat()
+    now_iso = now.isoformat()
+
+    def _query(from_ts: str, to_ts: str):
+        q = supabase_client.table("tickets").select(
+            "id, status, category, sla_status, created_at"
+        ).gte("created_at", from_ts).lt("created_at", to_ts)
+        if company_id:
+            q = q.eq("company_id", company_id)
+        return q.execute().data or []
+
+    this_week = _query(week_iso, now_iso)
+    last_week = _query(prev_iso, week_iso)
+
+    def _is_resolved(t: dict) -> bool:
+        status = (t.get("status") or "").lower()
+        return any(s in status for s in ["resolv", "closed", "auto-resolv"])
+
+    def _is_breached(t: dict) -> bool:
+        return (t.get("sla_status") or "").lower() == "breached"
+
+    total_this = len(this_week)
+    total_last = len(last_week)
+    resolved_this = sum(1 for t in this_week if _is_resolved(t))
+    breached_this = sum(1 for t in this_week if _is_breached(t))
+
+    resolution_rate = round(resolved_this / total_this * 100, 1) if total_this else 0.0
+
+    if total_last > 0:
+        pct_change = round((total_this - total_last) / total_last * 100, 1)
+    else:
+        pct_change = 0.0
+
+    # Top 3 categories by ticket count this week
+    category_counts: dict[str, int] = {}
+    for t in this_week:
+        cat = (t.get("category") or "Uncategorized").strip()
+        category_counts[cat] = category_counts.get(cat, 0) + 1
+    top_categories = sorted(category_counts.items(), key=lambda x: x[1], reverse=True)[:3]
+
+    return {
+        "total_tickets": total_this,
+        "total_tickets_last_week": total_last,
+        "pct_change": pct_change,
+        "resolved_count": resolved_this,
+        "resolution_rate": resolution_rate,
+        "sla_breaches": breached_this,
+        "top_categories": top_categories,
+        "period_start": week_iso,
+        "period_end": now_iso,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AI Summary
+# ---------------------------------------------------------------------------
+
+def generate_ai_summary(stats: dict, gemini_service=None) -> str:
+    """
+    Use Gemini to produce a 3-sentence plain-English summary of the week's stats.
+    Falls back to a template summary when Gemini is unavailable.
+    """
+    if gemini_service is None or not getattr(gemini_service, "_initialized", False):
+        return _fallback_summary(stats)
+
+    top_cats = ", ".join(c for c, _ in stats["top_categories"]) or "N/A"
+    prompt = (
+        "You are an IT manager assistant. Summarize this week's helpdesk performance "
+        "in exactly 3 concise sentences. Be factual and professional.\n\n"
+        f"- Total tickets this week: {stats['total_tickets']} "
+        f"({stats['pct_change']:+.1f}% vs last week)\n"
+        f"- Resolution rate: {stats['resolution_rate']}%\n"
+        f"- SLA breaches: {stats['sla_breaches']}\n"
+        f"- Top categories: {top_cats}\n"
+    )
+
+    try:
+        response = gemini_service.client.models.generate_content(
+            model=gemini_service.model_name,
+            contents=prompt,
+        )
+        text = (response.text or "").strip()
+        return text if text else _fallback_summary(stats)
+    except Exception as exc:
+        logger.warning("Gemini summary failed: %s", exc)
+        return _fallback_summary(stats)
+
+
+def _fallback_summary(stats: dict) -> str:
+    top_cats = ", ".join(c for c, _ in stats["top_categories"]) or "N/A"
+    trend = "up" if stats["pct_change"] >= 0 else "down"
+    return (
+        f"This week your helpdesk handled {stats['total_tickets']} tickets, "
+        f"{trend} {abs(stats['pct_change']):.1f}% compared to last week. "
+        f"The resolution rate stood at {stats['resolution_rate']}% with "
+        f"{stats['sla_breaches']} SLA breach(es) recorded. "
+        f"The most common ticket categories were: {top_cats}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+def _build_html(stats: dict, summary: str, app_url: str) -> str:
+    top_cat_rows = "".join(
+        f"<tr><td style='padding:6px 12px;border-bottom:1px solid #f0f0f0'>{cat}</td>"
+        f"<td style='padding:6px 12px;border-bottom:1px solid #f0f0f0;text-align:right;font-weight:700'>{count}</td></tr>"
+        for cat, count in stats["top_categories"]
+    )
+    trend_arrow = "&#9650;" if stats["pct_change"] >= 0 else "&#9660;"
+    trend_color = "#e53e3e" if stats["pct_change"] >= 0 else "#38a169"
+
+    period_start = stats["period_start"][:10]
+    period_end = stats["period_end"][:10]
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Weekly Helpdesk Digest</title>
+</head>
+<body style="margin:0;padding:0;background:#f7f8fa;font-family:'Segoe UI',Arial,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f7f8fa;padding:32px 0">
+  <tr><td align="center">
+    <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 2px 16px rgba(0,0,0,0.07)">
+
+      <!-- Header -->
+      <tr><td style="background:#1e1e2e;padding:32px 40px">
+        <h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:900;letter-spacing:-0.5px">
+          &#128202; Weekly Helpdesk Digest
+        </h1>
+        <p style="margin:6px 0 0;color:#a0aec0;font-size:13px">{period_start} &rarr; {period_end}</p>
+      </td></tr>
+
+      <!-- Stats grid -->
+      <tr><td style="padding:32px 40px 16px">
+        <table width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td width="25%" style="text-align:center;padding:16px;background:#f7f8fa;border-radius:12px;margin:4px">
+              <p style="margin:0;font-size:28px;font-weight:900;color:#1e1e2e">{stats['total_tickets']}</p>
+              <p style="margin:4px 0 0;font-size:11px;color:#718096;text-transform:uppercase;letter-spacing:0.05em">Total Tickets</p>
+              <p style="margin:4px 0 0;font-size:12px;font-weight:700;color:{trend_color}">{trend_arrow} {abs(stats['pct_change']):.1f}%</p>
+            </td>
+            <td width="4%"></td>
+            <td width="25%" style="text-align:center;padding:16px;background:#f0fff4;border-radius:12px">
+              <p style="margin:0;font-size:28px;font-weight:900;color:#276749">{stats['resolution_rate']}%</p>
+              <p style="margin:4px 0 0;font-size:11px;color:#718096;text-transform:uppercase;letter-spacing:0.05em">&#9989; Resolution Rate</p>
+            </td>
+            <td width="4%"></td>
+            <td width="25%" style="text-align:center;padding:16px;background:#fff5f5;border-radius:12px">
+              <p style="margin:0;font-size:28px;font-weight:900;color:#c53030">{stats['sla_breaches']}</p>
+              <p style="margin:4px 0 0;font-size:11px;color:#718096;text-transform:uppercase;letter-spacing:0.05em">&#9888; SLA Breaches</p>
+            </td>
+            <td width="4%"></td>
+            <td width="13%"></td>
+          </tr>
+        </table>
+      </td></tr>
+
+      <!-- Top categories -->
+      <tr><td style="padding:8px 40px 24px">
+        <h2 style="margin:0 0 12px;font-size:14px;font-weight:900;color:#1e1e2e;text-transform:uppercase;letter-spacing:0.08em">
+          &#127942; Top Ticket Categories
+        </h2>
+        <table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e2e8f0;border-radius:8px;overflow:hidden">
+          <tr style="background:#f7f8fa">
+            <th style="padding:8px 12px;text-align:left;font-size:11px;color:#718096;text-transform:uppercase">Category</th>
+            <th style="padding:8px 12px;text-align:right;font-size:11px;color:#718096;text-transform:uppercase">Tickets</th>
+          </tr>
+          {top_cat_rows if top_cat_rows else "<tr><td colspan='2' style='padding:12px;text-align:center;color:#a0aec0'>No data</td></tr>"}
+        </table>
+      </td></tr>
+
+      <!-- AI Summary -->
+      <tr><td style="padding:0 40px 32px">
+        <div style="background:#f0f4ff;border-left:4px solid #5a67d8;border-radius:8px;padding:20px 24px">
+          <p style="margin:0 0 8px;font-size:12px;font-weight:900;color:#5a67d8;text-transform:uppercase;letter-spacing:0.08em">
+            &#129504; AI Performance Summary
+          </p>
+          <p style="margin:0;font-size:14px;color:#2d3748;line-height:1.7">{summary}</p>
+        </div>
+      </td></tr>
+
+      <!-- CTA -->
+      <tr><td style="padding:0 40px 40px;text-align:center">
+        <a href="{app_url}" style="display:inline-block;background:#5a67d8;color:#ffffff;text-decoration:none;padding:14px 32px;border-radius:10px;font-size:14px;font-weight:900;letter-spacing:0.05em">
+          &#128279; View Full Dashboard
+        </a>
+      </td></tr>
+
+      <!-- Footer -->
+      <tr><td style="background:#f7f8fa;padding:20px 40px;border-top:1px solid #e2e8f0;text-align:center">
+        <p style="margin:0;font-size:11px;color:#a0aec0">
+          Helpdesk.AI &mdash; Automated weekly digest &bull; To disable, visit your Admin Settings.
+        </p>
+      </td></tr>
+
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>"""
+
+
+def send_digest_email(
+    admin_email: str,
+    stats: dict,
+    summary: str,
+    app_url: str = "https://helpdeskaiv1.vercel.app",
+    from_email: str = "digest@helpdesk.ai",
+) -> dict:
+    """
+    Send the weekly digest HTML email via Resend.
+
+    Returns a dict with ``{"ok": True, "id": "<message-id>"}`` on success or
+    ``{"ok": False, "error": "<message>"}`` on failure.
+    """
+    api_key = _resend_api_key()
+    if not api_key:
+        return {"ok": False, "error": "RESEND_API_KEY environment variable not set"}
+
+    if not _HAS_RESEND:
+        return {"ok": False, "error": "resend package is not installed"}
+
+    period_start = stats.get("period_start", "")[:10]
+    period_end = stats.get("period_end", "")[:10]
+    subject = f"Helpdesk.AI Weekly Digest — {period_start} to {period_end}"
+    html_body = _build_html(stats, summary, app_url)
+
+    try:
+        _resend_sdk.api_key = api_key
+        response = _resend_sdk.Emails.send({
+            "from": from_email,
+            "to": [admin_email],
+            "subject": subject,
+            "html": html_body,
+        })
+        msg_id = getattr(response, "id", None) or (response.get("id") if isinstance(response, dict) else None)
+        logger.info("Digest email sent to %s (id=%s)", admin_email, msg_id)
+        return {"ok": True, "id": msg_id}
+    except Exception as exc:
+        logger.error("Failed to send digest email to %s: %s", admin_email, exc)
+        return {"ok": False, "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — called by the scheduler and the manual-trigger endpoint
+# ---------------------------------------------------------------------------
+
+def run_digest_for_company(
+    supabase_client,
+    company_id: str,
+    admin_email: str,
+    gemini_service=None,
+    app_url: str = "https://helpdeskaiv1.vercel.app",
+) -> dict:
+    """
+    Full pipeline: fetch stats → generate summary → send email.
+    Returns a result dict suitable for API responses.
+    """
+    try:
+        stats = get_weekly_stats(supabase_client, company_id)
+    except Exception as exc:
+        return {"ok": False, "error": f"Stats query failed: {exc}"}
+
+    summary = generate_ai_summary(stats, gemini_service)
+    result = send_digest_email(admin_email, stats, summary, app_url=app_url)
+    result["stats"] = stats
+    result["summary"] = summary
+    return result

--- a/backend/main.py
+++ b/backend/main.py
@@ -494,6 +494,17 @@ try:
 except ImportError:
     ocr_service = None
 
+try:
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    _HAS_APSCHEDULER = True
+except ImportError:
+    AsyncIOScheduler = None
+    _HAS_APSCHEDULER = False
+
+from backend.digest_service import run_digest_for_company
+
+logger = logging.getLogger(__name__)
+
 LANGUAGE_NAMES = {
     "en": "English",
     "es": "Spanish",
@@ -634,9 +645,29 @@ async def lifespan(app: FastAPI):
     heartbeat_task = asyncio.create_task(_heartbeat_loop())
     print("[Startup] WebSocket heartbeat loop started (interval=30s).")
 
+    # Start APScheduler for weekly digest (Monday 08:00 UTC)
+    scheduler = None
+    if _HAS_APSCHEDULER:
+        scheduler = AsyncIOScheduler(timezone="UTC")
+        scheduler.add_job(
+            _run_weekly_digest_job,
+            trigger="cron",
+            day_of_week="mon",
+            hour=8,
+            minute=0,
+            id="weekly_digest",
+            replace_existing=True,
+        )
+        scheduler.start()
+        print("[Startup] Weekly digest scheduler started (Monday 08:00 UTC).")
+    else:
+        print("[Startup] APScheduler not installed — weekly digest cron disabled.")
+
     yield
 
     # Cancel background tasks on shutdown
+    if scheduler and scheduler.running:
+        scheduler.shutdown(wait=False)
     heartbeat_task.cancel()
     try:
         await heartbeat_task
@@ -1994,3 +2025,104 @@ async def sla_ticket_detail(ticket_id: str):
 async def metrics():
     """Prometheus scrape endpoint — exposes AI inference latency, request counts, and tokens."""
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+# ---------------------------------------------------------------------------
+# Weekly Digest — scheduler job + manual trigger endpoint
+# ---------------------------------------------------------------------------
+
+async def _run_weekly_digest_job() -> None:
+    """
+    APScheduler job: fan out to every company that has digest_enabled=True.
+    Queries system_settings for eligible companies, then sends each an email
+    using the admin's email from their profile.
+    """
+    if not supabase:
+        logger.warning("[Digest] Skipping — no Supabase connection")
+        return
+
+    try:
+        rows = (
+            supabase.table("system_settings")
+            .select("company_id, digest_enabled")
+            .eq("digest_enabled", True)
+            .execute()
+            .data or []
+        )
+    except Exception as exc:
+        logger.error("[Digest] Failed to fetch enabled companies: %s", exc)
+        return
+
+    for row in rows:
+        company_id = row.get("company_id")
+        if not company_id:
+            continue
+        try:
+            # Fetch admin email from profiles (role = 'admin' or any first match)
+            profile_res = (
+                supabase.table("profiles")
+                .select("email")
+                .eq("company_id", company_id)
+                .limit(1)
+                .execute()
+            )
+            profiles = profile_res.data or []
+            if not profiles or not profiles[0].get("email"):
+                logger.warning("[Digest] No admin email for company %s", company_id)
+                continue
+
+            admin_email = profiles[0]["email"]
+            result = run_digest_for_company(supabase, company_id, admin_email, gemini_service)
+            if result.get("ok"):
+                logger.info("[Digest] Sent to %s (company=%s)", admin_email, company_id)
+                # Update last_digest_sent timestamp
+                try:
+                    supabase.table("system_settings").update(
+                        {"last_digest_sent": datetime.datetime.now(datetime.timezone.utc).isoformat()}
+                    ).eq("company_id", company_id).execute()
+                except Exception:
+                    pass
+            else:
+                logger.error("[Digest] Failed for company %s: %s", company_id, result.get("error"))
+        except Exception as exc:
+            logger.error("[Digest] Unexpected error for company %s: %s", company_id, exc)
+
+
+class DigestSendRequest(BaseModel):
+    company_id: str
+    admin_email: str
+
+
+@app.post("/api/digest/send-now")
+async def digest_send_now(body: DigestSendRequest, _current_user: dict = Depends(get_current_user)):
+    """
+    Manually trigger a weekly digest email for a specific company.
+    Useful for testing and on-demand delivery.
+    """
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database not connected")
+
+    result = run_digest_for_company(
+        supabase,
+        body.company_id,
+        body.admin_email,
+        gemini_service,
+    )
+
+    if not result.get("ok"):
+        raise HTTPException(status_code=500, detail=result.get("error", "Digest send failed"))
+
+    # Record the send time in system_settings
+    try:
+        supabase.table("system_settings").update(
+            {"last_digest_sent": datetime.datetime.now(datetime.timezone.utc).isoformat()}
+        ).eq("company_id", body.company_id).execute()
+    except Exception:
+        pass
+
+    return {
+        "message": f"Digest sent to {body.admin_email}",
+        "email_id": result.get("id"),
+        "stats": result.get("stats"),
+        "summary": result.get("summary"),
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,4 +24,6 @@ httpx
 cryptography>=42.0.0
 websockets>=12.0
 prometheus-client>=0.19.0
+resend>=2.0.0
+apscheduler>=3.10.0
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -273,6 +273,7 @@ def mock_ai_services(request):
         "test_semantic_duplicates.py",
         "test_auth_cookie.py",
         "test_mobile_supabase_env.py",
+        "test_digest_service.py",
     }:
         yield
         return

--- a/backend/tests/test_digest_service.py
+++ b/backend/tests/test_digest_service.py
@@ -1,0 +1,280 @@
+"""Unit tests for backend/digest_service.py — Issue #208"""
+
+import unittest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+from backend.digest_service import (
+    get_weekly_stats,
+    generate_ai_summary,
+    send_digest_email,
+    _fallback_summary,
+    run_digest_for_company,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake Supabase client
+# ---------------------------------------------------------------------------
+
+def _make_ticket(status="open", category="Network", sla_status="active", days_ago=1):
+    created = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    return {"status": status, "category": category, "sla_status": sla_status, "created_at": created}
+
+
+class FakeQuery:
+    """Chainable fake that returns canned data on .execute()."""
+
+    def __init__(self, data):
+        self._data = data
+
+    def select(self, *_): return self
+    def gte(self, *_): return self
+    def lt(self, *_): return self
+    def eq(self, *_): return self
+
+    def execute(self):
+        r = MagicMock()
+        r.data = self._data
+        return r
+
+
+class FakeSupabase:
+    def __init__(self, this_week_data, last_week_data=None):
+        self._this_week = this_week_data
+        self._last_week = last_week_data or []
+        self._call_count = 0
+
+    def table(self, _name):
+        self._call_count += 1
+        # First call → this week, second call → last week
+        data = self._this_week if self._call_count % 2 == 1 else self._last_week
+        return FakeQuery(data)
+
+
+# ---------------------------------------------------------------------------
+# get_weekly_stats
+# ---------------------------------------------------------------------------
+
+class TestGetWeeklyStats(unittest.TestCase):
+
+    def test_raises_without_supabase(self):
+        with self.assertRaises(RuntimeError):
+            get_weekly_stats(None, "company-1")
+
+    def test_basic_totals(self):
+        tickets = [
+            _make_ticket("resolved", "Network"),
+            _make_ticket("open", "Hardware"),
+            _make_ticket("resolved", "Network"),
+            _make_ticket("open", "Software", sla_status="breached"),
+        ]
+        db = FakeSupabase(this_week_data=tickets, last_week_data=[_make_ticket()])
+        stats = get_weekly_stats(db, "company-1")
+
+        self.assertEqual(stats["total_tickets"], 4)
+        self.assertEqual(stats["resolved_count"], 2)
+        self.assertAlmostEqual(stats["resolution_rate"], 50.0)
+        self.assertEqual(stats["sla_breaches"], 1)
+
+    def test_top_categories_sorted(self):
+        tickets = [
+            _make_ticket(category="Network"),
+            _make_ticket(category="Network"),
+            _make_ticket(category="Hardware"),
+            _make_ticket(category="Software"),
+            _make_ticket(category="Network"),
+        ]
+        db = FakeSupabase(this_week_data=tickets)
+        stats = get_weekly_stats(db, "company-1")
+
+        cats = [c for c, _ in stats["top_categories"]]
+        self.assertEqual(cats[0], "Network")
+        self.assertLessEqual(len(stats["top_categories"]), 3)
+
+    def test_pct_change_positive(self):
+        db = FakeSupabase(
+            this_week_data=[_make_ticket()] * 10,
+            last_week_data=[_make_ticket()] * 5,
+        )
+        stats = get_weekly_stats(db)
+        self.assertAlmostEqual(stats["pct_change"], 100.0)
+
+    def test_pct_change_zero_last_week(self):
+        db = FakeSupabase(this_week_data=[_make_ticket()] * 3, last_week_data=[])
+        stats = get_weekly_stats(db)
+        self.assertEqual(stats["pct_change"], 0.0)
+
+    def test_empty_week(self):
+        db = FakeSupabase(this_week_data=[], last_week_data=[])
+        stats = get_weekly_stats(db)
+        self.assertEqual(stats["total_tickets"], 0)
+        self.assertEqual(stats["resolution_rate"], 0.0)
+        self.assertEqual(stats["sla_breaches"], 0)
+        self.assertEqual(stats["top_categories"], [])
+
+    def test_resolved_status_variants(self):
+        tickets = [
+            _make_ticket(status="Resolved"),
+            _make_ticket(status="closed"),
+            _make_ticket(status="auto-resolved"),
+            _make_ticket(status="open"),
+        ]
+        db = FakeSupabase(this_week_data=tickets)
+        stats = get_weekly_stats(db)
+        self.assertEqual(stats["resolved_count"], 3)
+
+
+# ---------------------------------------------------------------------------
+# generate_ai_summary
+# ---------------------------------------------------------------------------
+
+class TestGenerateAiSummary(unittest.TestCase):
+
+    def _sample_stats(self):
+        return {
+            "total_tickets": 20,
+            "total_tickets_last_week": 15,
+            "pct_change": 33.3,
+            "resolved_count": 16,
+            "resolution_rate": 80.0,
+            "sla_breaches": 2,
+            "top_categories": [("Network", 8), ("Hardware", 5), ("Software", 3)],
+            "period_start": "2026-05-21T00:00:00+00:00",
+            "period_end": "2026-05-28T00:00:00+00:00",
+        }
+
+    def test_fallback_when_gemini_none(self):
+        stats = self._sample_stats()
+        result = generate_ai_summary(stats, gemini_service=None)
+        self.assertIn("20", result)
+        self.assertIn("80.0", result)
+        self.assertIn("Network", result)
+
+    def test_fallback_when_not_initialized(self):
+        mock_gemini = MagicMock()
+        mock_gemini._initialized = False
+        stats = self._sample_stats()
+        result = generate_ai_summary(stats, gemini_service=mock_gemini)
+        self.assertIn("20", result)
+
+    def test_uses_gemini_when_initialized(self):
+        mock_response = MagicMock()
+        mock_response.text = "Great week. Tickets up 33%. Top issue: Network."
+        mock_gemini = MagicMock()
+        mock_gemini._initialized = True
+        mock_gemini.client.models.generate_content.return_value = mock_response
+
+        result = generate_ai_summary(self._sample_stats(), gemini_service=mock_gemini)
+        self.assertIn("Great week", result)
+        mock_gemini.client.models.generate_content.assert_called_once()
+
+    def test_falls_back_on_gemini_exception(self):
+        mock_gemini = MagicMock()
+        mock_gemini._initialized = True
+        mock_gemini.client.models.generate_content.side_effect = Exception("API error")
+
+        result = generate_ai_summary(self._sample_stats(), gemini_service=mock_gemini)
+        self.assertIn("20", result)
+
+    def test_fallback_summary_no_categories(self):
+        stats = self._sample_stats()
+        stats["top_categories"] = []
+        result = _fallback_summary(stats)
+        self.assertIn("N/A", result)
+
+    def test_fallback_trend_down(self):
+        stats = self._sample_stats()
+        stats["pct_change"] = -15.0
+        result = _fallback_summary(stats)
+        self.assertIn("down", result)
+
+
+# ---------------------------------------------------------------------------
+# send_digest_email
+# ---------------------------------------------------------------------------
+
+class TestSendDigestEmail(unittest.TestCase):
+
+    def _sample_stats(self):
+        return {
+            "total_tickets": 10,
+            "total_tickets_last_week": 8,
+            "pct_change": 25.0,
+            "resolved_count": 8,
+            "resolution_rate": 80.0,
+            "sla_breaches": 1,
+            "top_categories": [("Network", 5)],
+            "period_start": "2026-05-21T00:00:00+00:00",
+            "period_end": "2026-05-28T00:00:00+00:00",
+        }
+
+    def test_no_api_key_returns_error(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = send_digest_email("admin@example.com", self._sample_stats(), "Summary text")
+        self.assertFalse(result["ok"])
+        self.assertIn("RESEND_API_KEY", result["error"])
+
+    def test_no_resend_sdk_returns_error(self):
+        with patch.dict("os.environ", {"RESEND_API_KEY": "re_test"}):
+            with patch("backend.digest_service._HAS_RESEND", False):
+                result = send_digest_email("admin@example.com", self._sample_stats(), "Summary text")
+        self.assertFalse(result["ok"])
+        self.assertIn("resend package", result["error"])
+
+    def test_successful_send(self):
+        mock_response = MagicMock()
+        mock_response.id = "email-id-123"
+
+        with patch.dict("os.environ", {"RESEND_API_KEY": "re_test"}):
+            with patch("backend.digest_service._HAS_RESEND", True):
+                with patch("backend.digest_service._resend_sdk") as mock_sdk:
+                    mock_sdk.Emails.send.return_value = mock_response
+                    result = send_digest_email("admin@example.com", self._sample_stats(), "Summary text")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["id"], "email-id-123")
+
+    def test_send_exception_returns_error(self):
+        with patch.dict("os.environ", {"RESEND_API_KEY": "re_test"}):
+            with patch("backend.digest_service._HAS_RESEND", True):
+                with patch("backend.digest_service._resend_sdk") as mock_sdk:
+                    mock_sdk.Emails.send.side_effect = Exception("Network error")
+                    result = send_digest_email("admin@example.com", self._sample_stats(), "Summary text")
+
+        self.assertFalse(result["ok"])
+        self.assertIn("Network error", result["error"])
+
+
+# ---------------------------------------------------------------------------
+# run_digest_for_company
+# ---------------------------------------------------------------------------
+
+class TestRunDigestForCompany(unittest.TestCase):
+
+    def test_stats_failure_returns_error(self):
+        result = run_digest_for_company(None, "company-1", "admin@example.com")
+        self.assertFalse(result["ok"])
+        self.assertIn("Stats query failed", result["error"])
+
+    def test_full_pipeline_success(self):
+        tickets = [_make_ticket("resolved", "Network")] * 5
+        db = FakeSupabase(this_week_data=tickets, last_week_data=tickets)
+
+        mock_response = MagicMock()
+        mock_response.id = "msg-abc"
+
+        with patch.dict("os.environ", {"RESEND_API_KEY": "re_test"}):
+            with patch("backend.digest_service._HAS_RESEND", True):
+                with patch("backend.digest_service._resend_sdk") as mock_sdk:
+                    mock_sdk.Emails.send.return_value = mock_response
+                    result = run_digest_for_company(db, "company-1", "admin@example.com")
+
+        self.assertTrue(result["ok"])
+        self.assertIn("stats", result)
+        self.assertIn("summary", result)
+        self.assertEqual(result["stats"]["total_tickets"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- `backend/digest_service.py` — new digest service
- `get_weekly_stats()` → Supabase last 7 days query
- `generate_ai_summary()` → Gemini AI summary
- `send_digest_email()` → Resend SDK
- `POST /api/digest/send-now` manual trigger endpoint
- APScheduler cron every Monday 8AM UTC
- Admin settings toggle ON/OFF + "Send Now" button
- 19 unit tests all passing

## Why
Fixes #208 — admins had no automated weekly 
reporting on helpdesk performance.

## How to test
1. `pytest backend\tests\test_digest_service.py -v`
2. All 19 tests pass
3. Admin Settings → Weekly AI Digest toggle visible

## Screenshots
<img width="1158" height="644" alt="Screenshot 2026-05-28 011040" src="https://github.com/user-attachments/assets/521336b8-95e5-420b-ae52-b260edd16cf7" />

## Notes
- New packages: resend>=2.0.0, apscheduler>=3.10.0
- Supabase migration needed: ALTER TABLE system_settings 
  ADD COLUMN IF NOT EXISTS digest_enabled BOOLEAN DEFAULT FALSE,
  ADD COLUMN IF NOT EXISTS last_digest_sent TIMESTAMPTZ