### PR TITLE
test: prevent tracking real env files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Assert no real env files are tracked
+        run: |
+          python - <<'PY'
+          import pathlib
+          import subprocess
+
+          allowed = {'backend/.env.example', 'MobileApp/.env.example'}
+          tracked = subprocess.check_output(['git', 'ls-files'], text=True).splitlines()
+          offenders = []
+          for path in tracked:
+              name = pathlib.PurePosixPath(path).name
+              if path in allowed:
+                  continue
+              if name == '.env' or name.startswith('.env.') or name.endswith('.env') or '.env.' in name:
+                  offenders.append(path)
+
+          if offenders:
+              raise SystemExit('Real env files must not be tracked: ' + ', '.join(offenders))
+          print('OK — no real env files are tracked.')
+          PY
+
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ env/
 # Ignore all env files anywhere in the repo
 **/.env
 **/.env.*
+**/*.env
+**/*.env.*
+!.env.example
+!**/.env.example
+!**/*.env.example
+!**/env.example
 
 
 # Models (Keep them if they are small, but here they are large. 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -272,6 +272,7 @@ def mock_ai_services(request):
         "test_redis_cache.py",
         "test_semantic_duplicates.py",
         "test_auth_cookie.py",
+        "test_env_secret_tracking.py",
         "test_mobile_supabase_env.py",
         "test_sla_service.py",
         "test_sla_predictor.py",

--- a/backend/tests/test_env_secret_tracking.py
+++ b/backend/tests/test_env_secret_tracking.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import subprocess
+
+
+ALLOWED_ENV_EXAMPLES = {
+    "backend/.env.example",
+    "MobileApp/.env.example",
+}
+
+
+def test_no_real_env_files_are_tracked():
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    tracked_env_files = []
+    for raw_path in result.stdout.splitlines():
+        path = raw_path.strip()
+        name = Path(path).name
+        if not path:
+            continue
+        if path in ALLOWED_ENV_EXAMPLES:
+            continue
+        if name == ".env" or name.startswith(".env.") or name.endswith(".env") or ".env." in name:
+            tracked_env_files.append(path)
+
+    assert tracked_env_files == []


### PR DESCRIPTION
## Summary
- tighten `.gitignore` coverage for nested `.env`, `.env.*`, `*.env`, and `*.env.*` files while keeping example templates trackable
- add a lightweight regression test that fails if any real env file is tracked by Git
- add the same guard to backend CI so secret-bearing env files fail fast before dependency install

## Notes
- Current `gssoc` no longer tracks `backend/.env` or `Frontend/.env.local`; this PR keeps that cleanup from regressing.
- Any keys exposed before this cleanup should still be rotated by the project maintainers.

## Validation
- `python3 -m pytest backend/tests/test_env_secret_tracking.py backend/tests/test_mobile_supabase_env.py`
- local CI guard snippet: no real env files tracked
- `git diff --check`

Closes #195