### PR TITLE
fix(frontend): standardize environment variable name check and unify SLA API base resolution

### DIFF
--- a/Frontend/src/admin/components/SLADashboard.jsx
+++ b/Frontend/src/admin/components/SLADashboard.jsx
@@ -24,6 +24,7 @@ import {
   Users,
   Gauge,
 } from 'lucide-react';
+import { API_CONFIG } from '../../config';
 
 const PRIORITY_COLORS = {
   critical: { bg: '#FEF2F2', text: '#DC2626', border: '#FECACA', dot: '#DC2626' },
@@ -32,7 +33,7 @@ const PRIORITY_COLORS = {
   low: { bg: '#F0FDF4', text: '#16A34A', border: '#BBF7D0', dot: '#16A34A' },
 };
 
-const API_BASE = import.meta.env.VITE_API_URL || 'https://helpdesk-ai-backend-iq0w.onrender.com';
+const API_BASE = API_CONFIG.BACKEND_URL;
 
 /**
  * Fetch SLA dashboard stats from the backend.

--- a/Frontend/src/admin/pages/SLAPage.jsx
+++ b/Frontend/src/admin/pages/SLAPage.jsx
@@ -27,8 +27,9 @@ import {
 } from 'lucide-react';
 import SLADashboard from '../components/SLADashboard';
 import SLABadge from '../components/SLABadge';
+import { API_CONFIG } from '../../config';
 
-const API_BASE = import.meta.env.VITE_API_URL || 'https://helpdesk-ai-backend-iq0w.onrender.com';
+const API_BASE = API_CONFIG.BACKEND_URL;
 
 // ── Data fetching helpers ────────────────────────────────────────────────────
 

--- a/Frontend/src/config.js
+++ b/Frontend/src/config.js
@@ -3,7 +3,7 @@
  */
 
 const getBackendUrl = () => {
-    const envUrl = import.meta.env.VITE_BACKEND_URL;
+    const envUrl = import.meta.env.VITE_API_URL || import.meta.env.VITE_BACKEND_URL;
     if (envUrl) return envUrl.trim().replace(/\/$/, '');
 
     // Default fallback — override via VITE_BACKEND_URL env var


### PR DESCRIPTION
### Description of Changes
This pull request resolves the environment variable name mismatch between `VITE_API_URL` and `VITE_BACKEND_URL`, which previously prevented the local frontend development server from consistently communicating with the local backend.

The following changes have been implemented:
1. **Backward-Compatible Configuration:** Refactored `getBackendUrl` in [config.js](file:///Frontend/src/config.js) to resolve the base URL by checking both `VITE_API_URL` and `VITE_BACKEND_URL` sequentially:
   ```javascript
   const envUrl = import.meta.env.VITE_API_URL || import.meta.env.VITE_BACKEND_URL;
   ```
2. **Unified Administration Views:**
   - Modified [SLAPage.jsx](file:///Frontend/src/admin/pages/SLAPage.jsx) to import `API_CONFIG` from the global config instead of querying `import.meta.env` directly, and set `API_BASE` to `API_CONFIG.BACKEND_URL`.
   - Modified [SLADashboard.jsx](file:///Frontend/src/admin/components/SLADashboard.jsx) similarly to retrieve `API_CONFIG` and bind `API_BASE` directly to `API_CONFIG.BACKEND_URL`.

This unifies configuration management and guarantees that setting `VITE_API_URL` in `Frontend/.env.local` works consistently across the entire dashboard and administrative pages.

---

### Linked Issue
Closes #276
Ref: Defect Log `Bug 25` (Audit Defect Log `#191`)

---

### Verification and Build Checks
- **Build Verification:** Successfully built the production assets via `npm run build` without any compilation errors.
- **Configuration Consistency:** Verified that both SLA admin pages now cleanly inherit the resolved backend URL from `config.js`.
