### PR TITLE
fix: change websocket heartbeat from pong to ping (#381)

### DIFF
--- a/Frontend/src/hooks/useWebSocket.js
+++ b/Frontend/src/hooks/useWebSocket.js
@@ -83,7 +83,7 @@ export default function useWebSocket(companyId) {
     // Periodic pings
     pingTimerRef.current = setInterval(() => {
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify({ type: "pong" }));
+        wsRef.current.send(JSON.stringify({ type: "ping" }));
       }
     }, PING_INTERVAL_MS);
   }, []);

--- a/backend/main.py
+++ b/backend/main.py
@@ -83,7 +83,7 @@ from backend.auth_cookie import router as auth_cookie_router, get_current_user  
 # ---------------------------------------------------------------------------
 
 HEARTBEAT_INTERVAL = 30  # seconds between ping broadcasts
-HEARTBEAT_TIMEOUT = 10   # seconds to wait for a pong before disconnect
+HEARTBEAT_TIMEOUT = 10   # seconds to wait for a pong before disconnect (reserved — not yet enforced; should track last_pong per connection)
 
 
 class ConnectionManager:


### PR DESCRIPTION
﻿## Summary
Fixed the WebSocket client heartbeat in `useWebSocket.js` that was sending `{"type": "pong"}` instead of `{"type": "ping"}`. The server already sends `{"type": "ping"}` and expects `{"type": "pong"}` responses - the client's own periodic timer should send `{"type": "ping"}`.

## Changes
- Changed client heartbeat from `{"type": "pong"}` to `{"type": "ping"}` on line 86 of useWebSocket.js
- Added documentation comment to HEARTBEAT_TIMEOUT constant in main.py

Fixes #381
