### PR TITLE
feat(voice): Add Voice-to-Ticket Speech Recognition with Whisper - Fixes #207

### DIFF
--- a/Frontend/src/admin/components/TicketTable.jsx
+++ b/Frontend/src/admin/components/TicketTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ShieldCheck, Clock, ExternalLink } from 'lucide-react';
+import { ShieldCheck, Clock, ExternalLink, Mic } from 'lucide-react';
 import { formatTimelineDate } from '../../utils/dateUtils';
 
 const categoryDotColors = {
@@ -76,6 +76,7 @@ const TicketTable = ({ tickets = [], isLoading = false, limit = null }) => {
                         const translationMeta = ticket?.metadata?.translation;
                         const isTranslated = Boolean(translationMeta?.translated);
                         const sourceLanguageName = translationMeta?.source_language_name || translationMeta?.source_language || 'Unknown';
+                        const isVoiceTicket = ticket?.metadata?.source === 'voice';
 
                         // Truncated subject
                         const subject = ticket.subject || ticket.summary || 'Untitled ticket';
@@ -129,9 +130,16 @@ const TicketTable = ({ tickets = [], isLoading = false, limit = null }) => {
                                             </div>
                                         )}
                                         <div style={{ display: 'flex', flexDirection: 'column', maxWidth: '220px' }}>
-                                            <span style={{ fontSize: '13px', fontWeight: 500, color: '#111827', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                                {truncSubject}
-                                            </span>
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                                <span style={{ fontSize: '13px', fontWeight: 500, color: '#111827', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                                    {truncSubject}
+                                                </span>
+                                                {isVoiceTicket && (
+                                                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', background: '#ede9fe', color: '#7c3aed', border: '1px solid #ddd6fe', borderRadius: '6px', padding: '2px 6px', fontSize: '9px', fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', whiteSpace: 'nowrap', flexShrink: 0 }}>
+                                                        <Mic size={9} /> Voice
+                                                    </span>
+                                                )}
+                                            </div>
                                             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                                                 <span style={{ fontSize: '11px', color: '#6b7280' }}>
                                                     {effectiveCategory || 'General'}

--- a/Frontend/src/user/pages/AIProcessing.jsx
+++ b/Frontend/src/user/pages/AIProcessing.jsx
@@ -24,7 +24,7 @@ const steps = [
 const AIProcessing = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { text, image_text, image_base64, template_id, template_used, user_modified, ticket_title, original_text, original_language } = location.state || {};
+    const { text, image_text, image_base64, template_id, template_used, user_modified, ticket_title, original_text, original_language, source } = location.state || {};
     const setAITicket = useTicketStore((state) => state.setAITicket);
     const { settings } = useAdminStore();
     const { user, profile } = useAuthStore();
@@ -279,7 +279,8 @@ const AIProcessing = () => {
                     originalIssue: original_text || text,
                     originalLanguage: original_language || 'en',
                     capturedFileBase64: image_base64,
-                    ocrText: image_text
+                    ocrText: image_text,
+                    source: source || 'text',
                 };
 
                 setAITicket(aiTicketObject);

--- a/Frontend/src/user/pages/CreateTicket.jsx
+++ b/Frontend/src/user/pages/CreateTicket.jsx
@@ -36,44 +36,46 @@ const CreateTicket = () => {
     const [extractedOCR, setExtractedOCR] = useState('');
     const [isOcrLoading, setIsOcrLoading] = useState(false);
     const [isListening, setIsListening] = useState(false);
-    const isListeningRef = useRef(false);
     const fileInputRef = useRef(null);
     const navigate = useNavigate();
     const location = useLocation();
     const MAX_CHARS = 1000;
-    const supportsSpeech = 'SpeechRecognition' in window || 'webkitSpeechRecognition' in window;
+    const MAX_RECORDING_SECONDS = 120;
+    // MediaRecorder is universally supported in Chrome, Firefox, and Edge
+    const supportsVoice = typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
     const [selectedLanguage, setSelectedLanguage] = useState('en');
     const [isTranslating, setIsTranslating] = useState(false);
     const [isLangOpen, setIsLangOpen] = useState(false);
     const langRef = useRef(null);
 
     // ── Smart Template state (v2: two-step highlight → activate flow) ──
-    const [highlightedTemplateId, setHighlightedTemplateId] = useState(null);  // Card highlighted (preview)
-    const [activatedTemplateId, setActivatedTemplateId] = useState(null);      // Template committed (form shown)
-    const [formValues, setFormValues] = useState({});                          // Dynamic form field values
+    const [highlightedTemplateId, setHighlightedTemplateId] = useState(null);
+    const [activatedTemplateId, setActivatedTemplateId] = useState(null);
+    const [formValues, setFormValues] = useState({});
     const [templateUsed, setTemplateUsed] = useState(false);
     const [userModified, setUserModified] = useState(false);
 
     // Voice UI states
     const [showVoiceModal, setShowVoiceModal] = useState(false);
     const [voiceTranscript, setVoiceTranscript] = useState('');
-    const [interimVoice, setInterimVoice] = useState('');
+    const [isTranscribing, setIsTranscribing] = useState(false);
+    const [countdown, setCountdown] = useState(MAX_RECORDING_SECONDS);
+    const [ticketSource, setTicketSource] = useState('text'); // "voice" | "text"
 
     // Voice Refs & Visualizer
-    const recognitionRef = useRef(null);
+    const mediaRecorderRef = useRef(null);
+    const audioChunksRef = useRef([]);
     const audioContextRef = useRef(null);
     const analyserRef = useRef(null);
     const dataArrayRef = useRef(null);
     const animationFrameRef = useRef(null);
+    const countdownTimerRef = useRef(null);
     const [visualizerData, setVisualizerData] = useState(new Array(16).fill(15));
     const streamRef = useRef(null);
 
     useEffect(() => {
         return () => {
-            isListeningRef.current = false;
-            if (recognitionRef.current) recognitionRef.current.stop();
-            if (audioContextRef.current) audioContextRef.current.close();
-            if (animationFrameRef.current) cancelAnimationFrame(animationFrameRef.current);
+            _cleanupVoiceResources();
         };
     }, []);
 
@@ -121,144 +123,174 @@ const CreateTicket = () => {
         }
     };
 
-    const toggleMic = () => {
-        if (isListening) {
-            stopListening();
-            return;
+    const _cleanupVoiceResources = () => {
+        if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+            mediaRecorderRef.current.stop();
         }
-        startListening();
-    };
-
-    const startListening = async () => {
-        const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-        
-        if (!SpeechRecognition) {
-            setError("Speech recognition is not supported in this browser.");
-            return;
-        }
-
-        try {
-            // Start Visualizer for UI feedback
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            streamRef.current = stream;
-            
-            const AudioContext = window.AudioContext || window.webkitAudioContext;
-            audioContextRef.current = new AudioContext();
-            const source = audioContextRef.current.createMediaStreamSource(stream);
-            const analyser = audioContextRef.current.createAnalyser();
-            analyser.fftSize = 64;
-            const bufferLength = analyser.frequencyBinCount;
-            const dataArray = new Uint8Array(bufferLength);
-            analyserRef.current = analyser;
-            dataArrayRef.current = dataArray;
-            source.connect(analyser);
-
-            const updateVisualizer = () => {
-                if (!analyserRef.current) return;
-                analyserRef.current.getByteFrequencyData(dataArrayRef.current);
-                const bars = [];
-                for (let i = 0; i < 16; i++) {
-                    const val = dataArrayRef.current[i] || 0;
-                    const height = Math.max(5, (val / 255) * 50);
-                    bars.push(height);
-                }
-                setVisualizerData(bars);
-                animationFrameRef.current = requestAnimationFrame(updateVisualizer);
-            };
-            updateVisualizer();
-
-            // Initialize Speech Recognition
-            const recognition = new SpeechRecognition();
-            recognition.continuous = true;
-            recognition.interimResults = true;
-            recognition.lang = 'en-US';
-
-            recognition.onresult = (event) => {
-                let finalStr = '';
-                let interimStr = '';
-                for (let i = event.resultIndex; i < event.results.length; ++i) {
-                    if (event.results[i].isFinal) {
-                        finalStr += event.results[i][0].transcript;
-                    } else {
-                        interimStr += event.results[i][0].transcript;
-                    }
-                }
-                if (finalStr) setVoiceTranscript(prev => prev + ' ' + finalStr);
-                setInterimVoice(interimStr);
-            };
-
-            recognition.onerror = (event) => {
-                console.error("Speech Recognition Error:", event.error);
-                if (event.error !== 'no-speech') {
-                    setError(`Microphone error: ${event.error}`);
-                    stopListening();
-                }
-            };
-
-            recognition.onend = () => {
-                if (isListeningRef.current) {
-                    try {
-                        recognitionRef.current?.start();
-                    } catch {
-                        // start() may throw if already running — safely ignore
-                    }
-                } else {
-                    if (animationFrameRef.current) {
-                        cancelAnimationFrame(animationFrameRef.current);
-                        animationFrameRef.current = null;
-                    }
-                }
-            };
-
-            recognitionRef.current = recognition;
-            recognition.start();
-
-            setIsListening(true);
-            isListeningRef.current = true;
-            setShowVoiceModal(true);
-            setVoiceTranscript('');
-            setInterimVoice('');
-            setError('');
-
-        } catch (err) {
-            console.error("Microphone access denied:", err);
-            setError("Could not access microphone. Please ensure permissions are granted.");
-        }
-    };
-
-    const stopListening = () => {
-        setIsListening(false);
-        isListeningRef.current = false;
-        if (recognitionRef.current) {
-            recognitionRef.current.stop();
-            recognitionRef.current = null;
-        }
+        mediaRecorderRef.current = null;
+        audioChunksRef.current = [];
         if (animationFrameRef.current) {
             cancelAnimationFrame(animationFrameRef.current);
             animationFrameRef.current = null;
         }
         if (audioContextRef.current) {
-            audioContextRef.current.close();
+            audioContextRef.current.close().catch(() => {});
             audioContextRef.current = null;
         }
         if (streamRef.current) {
-            streamRef.current.getTracks().forEach(track => track.stop());
+            streamRef.current.getTracks().forEach(t => t.stop());
+            streamRef.current = null;
+        }
+        if (countdownTimerRef.current) {
+            clearInterval(countdownTimerRef.current);
+            countdownTimerRef.current = null;
+        }
+    };
+
+    const toggleMic = () => {
+        if (isListening) {
+            _stopAndTranscribe();
+        } else {
+            _startRecording();
+        }
+    };
+
+    const _startRecording = async () => {
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            streamRef.current = stream;
+
+            // Waveform visualizer
+            const AudioContext = window.AudioContext || window.webkitAudioContext;
+            audioContextRef.current = new AudioContext();
+            const src = audioContextRef.current.createMediaStreamSource(stream);
+            const analyser = audioContextRef.current.createAnalyser();
+            analyser.fftSize = 64;
+            const buf = new Uint8Array(analyser.frequencyBinCount);
+            analyserRef.current = analyser;
+            dataArrayRef.current = buf;
+            src.connect(analyser);
+            const _tick = () => {
+                if (!analyserRef.current) return;
+                analyserRef.current.getByteFrequencyData(dataArrayRef.current);
+                const bars = Array.from({ length: 16 }, (_, i) =>
+                    Math.max(5, ((dataArrayRef.current[i] || 0) / 255) * 50)
+                );
+                setVisualizerData(bars);
+                animationFrameRef.current = requestAnimationFrame(_tick);
+            };
+            _tick();
+
+            // MediaRecorder — WebM in Chrome, OGG in Firefox, both handled by Whisper
+            audioChunksRef.current = [];
+            const recorder = new MediaRecorder(stream);
+            recorder.ondataavailable = (e) => {
+                if (e.data.size > 0) audioChunksRef.current.push(e.data);
+            };
+            mediaRecorderRef.current = recorder;
+            recorder.start(250); // chunk every 250ms
+
+            // 120-second countdown → auto-stop
+            setCountdown(MAX_RECORDING_SECONDS);
+            countdownTimerRef.current = setInterval(() => {
+                setCountdown(prev => {
+                    if (prev <= 1) {
+                        _stopAndTranscribe();
+                        return 0;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+
+            setIsListening(true);
+            setShowVoiceModal(true);
+            setVoiceTranscript('');
+            setIsTranscribing(false);
+            setError('');
+        } catch (err) {
+            console.error("Microphone access denied:", err);
+            setError(
+                err.name === 'NotAllowedError'
+                    ? 'Microphone permission denied. Click the 🔒 icon in your browser address bar to enable it.'
+                    : `Could not access microphone: ${err.message}`
+            );
+        }
+    };
+
+    const _stopAndTranscribe = () => {
+        setIsListening(false);
+        if (countdownTimerRef.current) {
+            clearInterval(countdownTimerRef.current);
+            countdownTimerRef.current = null;
+        }
+        if (animationFrameRef.current) {
+            cancelAnimationFrame(animationFrameRef.current);
+            animationFrameRef.current = null;
+        }
+
+        const recorder = mediaRecorderRef.current;
+        if (!recorder || recorder.state === 'inactive') {
+            _cleanupVoiceResources();
+            return;
+        }
+
+        setIsTranscribing(true);
+
+        recorder.onstop = async () => {
+            const mimeType = recorder.mimeType || 'audio/webm';
+            const blob = new Blob(audioChunksRef.current, { type: mimeType });
+            const ext = mimeType.includes('ogg') ? 'ogg' : 'webm';
+
+            const form = new FormData();
+            form.append('audio', blob, `recording.${ext}`);
+
+            try {
+                const { API_CONFIG } = await import('../../config');
+                const res = await fetch(`${API_CONFIG.BACKEND_URL}/api/voice/transcribe`, {
+                    method: 'POST',
+                    body: form,
+                });
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({}));
+                    throw new Error(err.detail || `Transcription failed (${res.status})`);
+                }
+                const data = await res.json();
+                setVoiceTranscript(data.transcribed_text || '');
+            } catch (err) {
+                console.error('Transcription error:', err);
+                setError(`Transcription failed: ${err.message}`);
+                setShowVoiceModal(false);
+            } finally {
+                setIsTranscribing(false);
+                _cleanupVoiceResources();
+            }
+        };
+
+        recorder.stop();
+        if (streamRef.current) {
+            streamRef.current.getTracks().forEach(t => t.stop());
             streamRef.current = null;
         }
     };
 
     const handleSaveVoice = () => {
-        stopListening();
-        setIssue(prev => {
-            const combined = prev + ' ' + voiceTranscript + ' ' + interimVoice;
-            return combined.trim().substring(0, MAX_CHARS);
-        });
+        if (voiceTranscript.trim()) {
+            setIssue(prev => {
+                const combined = (prev + ' ' + voiceTranscript).trim();
+                return combined.substring(0, MAX_CHARS);
+            });
+            setTicketSource('voice');
+        }
         setShowVoiceModal(false);
+        setVoiceTranscript('');
     };
 
     const handleCancelVoice = () => {
-        stopListening();
+        if (isListening) _cleanupVoiceResources();
+        setIsListening(false);
+        setIsTranscribing(false);
         setShowVoiceModal(false);
+        setVoiceTranscript('');
     };
 
     const handleFileChange = (e) => {
@@ -412,6 +444,8 @@ const CreateTicket = () => {
                     template_used: templateUsed,
                     user_modified: userModified,
                     ticket_title: ticketTitle.trim() || null,
+                    // Voice metadata
+                    source: ticketSource,
                 }
             });
 
@@ -578,8 +612,8 @@ const CreateTicket = () => {
                                         </div>
                                     )}
 
-                                    {/* Premium Voice Visualizer */}
-                                    {supportsSpeech && (
+                                    {/* Voice Input Panel */}
+                                    {supportsVoice && (
                                         <div className="relative overflow-hidden rounded-3xl border border-emerald-100 bg-gradient-to-br from-emerald-50/50 to-white p-6 shadow-sm">
                                             <div className="flex items-center justify-between mb-4">
                                                 <div className="flex items-center gap-3">
@@ -587,13 +621,18 @@ const CreateTicket = () => {
                                                         <Mic size={20} className={isListening ? "animate-pulse" : ""} />
                                                     </div>
                                                     <div>
-                                                        <h4 className="text-sm font-bold text-gray-900">Voice Assistant</h4>
-                                                        <p className="text-xs text-gray-500 font-medium">{isListening ? "Listening to your voice..." : "Tap to describe via voice"}</p>
+                                                        <h4 className="text-sm font-bold text-gray-900">Voice Input</h4>
+                                                        <p className="text-xs text-gray-500 font-medium">
+                                                            {isListening
+                                                                ? `Recording… ${countdown}s remaining`
+                                                                : "Tap to dictate your issue"}
+                                                        </p>
                                                     </div>
                                                 </div>
                                                 <Button
                                                     type="button"
                                                     onClick={toggleMic}
+                                                    disabled={isTranscribing}
                                                     className={`h-12 w-12 rounded-full flex items-center justify-center transition-all duration-500 border-none
                                                         ${isListening
                                                             ? 'bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-200 scale-110'
@@ -603,7 +642,7 @@ const CreateTicket = () => {
                                                 </Button>
                                             </div>
 
-                                            {/* Siri-style Wave Animation */}
+                                            {/* Waveform bars while recording */}
                                             <AnimatePresence>
                                                 {isListening && (
                                                     <motion.div
@@ -639,7 +678,7 @@ const CreateTicket = () => {
                                                     className="bg-white/60 backdrop-blur-sm rounded-xl p-3 border border-emerald-50/50"
                                                 >
                                                     <p className="text-sm text-emerald-800 font-medium italic">
-                                                        "Speak clearly, our AI is transcribing..."
+                                                        "Speak clearly — Whisper AI will transcribe your words."
                                                     </p>
                                                 </motion.div>
                                             )}
@@ -762,41 +801,63 @@ const CreateTicket = () => {
                             exit={{ scale: 0.95, opacity: 0, y: 20 }}
                             className="w-full max-w-lg bg-white rounded-[2rem] shadow-2xl overflow-hidden border border-slate-100 flex flex-col"
                         >
+                            {/* Modal header */}
                             <div className="p-6 bg-emerald-50/50 border-b border-emerald-100 flex items-center justify-between">
                                 <div className="flex items-center gap-3">
                                     <div className="relative flex items-center justify-center w-10 h-10 rounded-full bg-emerald-100 text-emerald-600">
                                         {isListening && (
                                             <span className="absolute inset-0 rounded-full border-2 border-emerald-400 animate-ping"></span>
                                         )}
-                                        <Mic size={20} className={isListening ? "animate-pulse" : ""} />
+                                        {isTranscribing
+                                            ? <Loader2 size={20} className="animate-spin" />
+                                            : <Mic size={20} className={isListening ? "animate-pulse" : ""} />
+                                        }
                                     </div>
                                     <div>
-                                        <h3 className="font-bold text-gray-900 leading-tight">Live Dictation</h3>
-                                        <p className="text-xs text-emerald-600 font-medium">{isListening ? "Listening..." : "Paused"}</p>
+                                        <h3 className="font-bold text-gray-900 leading-tight">Voice Input</h3>
+                                        <p className="text-xs text-emerald-600 font-medium">
+                                            {isTranscribing
+                                                ? "Transcribing your voice with Whisper AI…"
+                                                : isListening
+                                                    ? `Recording — ${countdown}s left`
+                                                    : voiceTranscript
+                                                        ? "Transcription complete"
+                                                        : "Ready"}
+                                        </p>
                                     </div>
                                 </div>
                                 <button
                                     onClick={handleCancelVoice}
-                                    className="p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 rounded-full transition-colors"
+                                    disabled={isTranscribing}
+                                    className="p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 rounded-full transition-colors disabled:opacity-40"
                                 >
                                     <X size={20} />
                                 </button>
                             </div>
 
-                            <div className="p-8 min-h-[200px] max-h-[300px] overflow-y-auto relative">
-                                <p className="text-gray-800 text-lg leading-relaxed font-medium">
-                                    {voiceTranscript}
-                                    <span className="text-gray-400"> {interimVoice}</span>
-                                    {isListening && <span className="inline-block w-2 h-5 ml-1 align-middle bg-emerald-400 animate-pulse"></span>}
-                                </p>
-                                {!voiceTranscript && !interimVoice && (
-                                    <div className="h-full flex items-center justify-center text-gray-400 text-sm font-medium italic">
-                                        Start speaking... we're listening.
+                            {/* Modal body */}
+                            <div className="p-8 min-h-[200px] max-h-[300px] overflow-y-auto relative flex items-center justify-center">
+                                {isTranscribing ? (
+                                    <div className="flex flex-col items-center gap-3 text-center">
+                                        <Loader2 size={36} className="animate-spin text-emerald-500" />
+                                        <p className="text-sm font-medium text-gray-500">Transcribing your voice…</p>
                                     </div>
+                                ) : isListening ? (
+                                    <p className="text-gray-400 text-sm font-medium italic text-center">
+                                        Speak clearly — click Stop or wait for the timer.
+                                    </p>
+                                ) : voiceTranscript ? (
+                                    <p className="text-gray-800 text-base leading-relaxed font-medium w-full">
+                                        {voiceTranscript}
+                                    </p>
+                                ) : (
+                                    <p className="text-gray-400 text-sm font-medium italic text-center">
+                                        Press Record to start. Max 120 seconds.
+                                    </p>
                                 )}
                             </div>
 
-                            {/* Siri-style Wave Animation */}
+                            {/* Waveform — only while recording */}
                             <AnimatePresence>
                                 {isListening && (
                                     <motion.div
@@ -812,11 +873,7 @@ const CreateTicket = () => {
                                                     height: visualizerData[i] || 15,
                                                     backgroundColor: (visualizerData[i] || 15) > 30 ? '#10b981' : '#34d399'
                                                 }}
-                                                transition={{
-                                                    type: 'spring',
-                                                    stiffness: 300,
-                                                    damping: 20
-                                                }}
+                                                transition={{ type: 'spring', stiffness: 300, damping: 20 }}
                                                 className="w-1.5 rounded-full bg-emerald-400"
                                             />
                                         ))}
@@ -824,23 +881,37 @@ const CreateTicket = () => {
                                 )}
                             </AnimatePresence>
 
+                            {/* Modal footer */}
                             <div className="p-6 bg-gray-50 flex gap-4 border-t border-gray-100">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={handleCancelVoice}
-                                    className="flex-1 font-bold text-gray-600 border-gray-200 hover:bg-white h-12 rounded-xl"
-                                >
-                                    Cancel
-                                </Button>
-                                <Button
-                                    type="button"
-                                    onClick={handleSaveVoice}
-                                    disabled={!voiceTranscript && !interimVoice}
-                                    className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white font-bold h-12 rounded-xl shadow-lg shadow-emerald-200"
-                                >
-                                    Insert Text
-                                </Button>
+                                {isListening ? (
+                                    <Button
+                                        type="button"
+                                        onClick={_stopAndTranscribe}
+                                        className="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold h-12 rounded-xl shadow-lg shadow-red-100"
+                                    >
+                                        Stop Recording
+                                    </Button>
+                                ) : (
+                                    <>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={handleCancelVoice}
+                                            disabled={isTranscribing}
+                                            className="flex-1 font-bold text-gray-600 border-gray-200 hover:bg-white h-12 rounded-xl"
+                                        >
+                                            Cancel
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            onClick={handleSaveVoice}
+                                            disabled={isTranscribing || !voiceTranscript}
+                                            className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white font-bold h-12 rounded-xl shadow-lg shadow-emerald-200"
+                                        >
+                                            Use This Text
+                                        </Button>
+                                    </>
+                                )}
                             </div>
                         </motion.div>
                     </motion.div>

--- a/Frontend/src/user/pages/TicketTracking.jsx
+++ b/Frontend/src/user/pages/TicketTracking.jsx
@@ -70,6 +70,7 @@ const TicketTracking = () => {
                         ocr_text: aiTicket.ocr_text,
                         image_description: aiTicket.image_description
                     },
+                    source: aiTicket.source || 'text',
                     entities: aiTicket.entities,
                     solution_steps: resolutionSteps,
                     ocr_text: aiTicket.ocr_text || "",

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,7 +20,7 @@ from contextlib import asynccontextmanager
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect, UploadFile, File
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
@@ -76,6 +76,9 @@ from backend.services.spam_service import SpamService
 from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sla_policy
 from backend.services.redis_cache import redis_cache
 from backend.auth_cookie import router as auth_cookie_router, get_current_user  # noqa: F401
+from backend.services.voice_service import voice_service, validate_audio_upload
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +365,7 @@ class TicketSaveRequest(BaseModel):
     ocr_text: str = ""
     needs_review: bool = False
     routing_confidence: float = 0.0
+    source: str = "text"  # "voice" | "text"
 
 
 
@@ -1107,7 +1111,7 @@ async def save_ticket(request_body: TicketSaveRequest):
         existing_metadata = final_data.get("metadata") or {}
         extra_keys = (
             "entities", "solution_steps", "ocr_text", "needs_review", "routing_confidence",
-            "is_potential_duplicate", "parent_ticket_id"
+            "is_potential_duplicate", "parent_ticket_id", "source"
         )
         for extra_key in extra_keys:
             if extra_key in final_data and final_data[extra_key] not in (None, "", [], {}):
@@ -1994,3 +1998,54 @@ async def sla_ticket_detail(ticket_id: str):
 async def metrics():
     """Prometheus scrape endpoint — exposes AI inference latency, request counts, and tokens."""
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+# ---------------------------------------------------------------------------
+# Voice-to-Ticket — Whisper transcription endpoint
+# ---------------------------------------------------------------------------
+
+@app.post("/api/voice/transcribe")
+async def voice_transcribe(audio: UploadFile = File(...)):
+    """
+    Transcribe an audio file using OpenAI Whisper (local, no API key).
+
+    Accepts: WAV, WebM, OGG, MP3, MP4, M4A (multipart/form-data field: audio)
+    Max duration enforced client-side (120 s); server validates non-empty upload.
+
+    Returns:
+        transcribed_text  — full transcription
+        detected_language — ISO-639-1 language code
+        confidence        — 0.0–1.0 estimate from Whisper avg log-prob
+    """
+    content_type = audio.content_type or ""
+    filename = audio.filename or "audio.webm"
+
+    raw_bytes = await audio.read()
+
+    err = validate_audio_upload(filename, content_type, len(raw_bytes))
+    if err:
+        raise HTTPException(status_code=422, detail=err)
+
+    import tempfile
+    suffix = "." + filename.rsplit(".", 1)[-1] if "." in filename else ".webm"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(raw_bytes)
+        tmp_path = tmp.name
+
+    try:
+        result = voice_service.transcribe(tmp_path)
+    finally:
+        try:
+            import os as _os
+            _os.unlink(tmp_path)
+        except OSError:
+            pass
+
+    if result.get("error"):
+        raise HTTPException(status_code=500, detail=result["error"])
+
+    return {
+        "transcribed_text": result["transcribed_text"],
+        "detected_language": result["detected_language"],
+        "confidence": result["confidence"],
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,4 +24,7 @@ httpx
 cryptography>=42.0.0
 websockets>=12.0
 prometheus-client>=0.19.0
+resend>=2.0.0
+apscheduler>=3.10.0
+openai-whisper>=20231117
 

--- a/backend/services/voice_service.py
+++ b/backend/services/voice_service.py
@@ -1,0 +1,135 @@
+"""
+Voice-to-Ticket Transcription Service — Issue #207
+
+Uses OpenAI Whisper (local, no API key) to transcribe audio uploads.
+Supports WAV, WebM, OGG, MP3, MP4, and M4A formats.
+"""
+
+import os
+import logging
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_AUDIO_SECONDS = 120
+ACCEPTED_MIMETYPES = {
+    "audio/wav", "audio/wave", "audio/x-wav",
+    "audio/webm", "audio/ogg", "audio/mpeg",
+    "audio/mp4", "audio/m4a", "audio/x-m4a",
+    "video/webm",  # Chrome records WebM with a video/* MIME
+}
+ACCEPTED_EXTENSIONS = {".wav", ".webm", ".ogg", ".mp3", ".mp4", ".m4a"}
+
+try:
+    import whisper as _whisper_module
+    _HAS_WHISPER = True
+except ImportError:
+    _whisper_module = None
+    _HAS_WHISPER = False
+
+
+class VoiceService:
+    """Lazy-loading Whisper transcription service."""
+
+    def __init__(self) -> None:
+        self._model = None
+        self._model_name: str = os.environ.get("WHISPER_MODEL", "tiny")
+        self._initialized: bool = False
+
+    def _load(self) -> bool:
+        if self._initialized:
+            return True
+        if not _HAS_WHISPER:
+            logger.warning("[VoiceService] openai-whisper not installed")
+            return False
+        try:
+            logger.info("[VoiceService] Loading Whisper model '%s'...", self._model_name)
+            self._model = _whisper_module.load_model(self._model_name)
+            self._initialized = True
+            logger.info("[VoiceService] Whisper model loaded")
+            return True
+        except Exception as exc:
+            logger.error("[VoiceService] Failed to load Whisper: %s", exc)
+            return False
+
+    def transcribe(self, audio_path: str) -> dict:
+        """
+        Transcribe audio at *audio_path* and return a result dict.
+
+        Returns:
+            {
+                "transcribed_text": str,
+                "detected_language": str,   # ISO-639-1 code, e.g. "en"
+                "confidence": float,        # 0.0–1.0 estimated from avg log-prob
+                "error": str | None,
+            }
+        """
+        if not self._load():
+            return {
+                "transcribed_text": "",
+                "detected_language": "unknown",
+                "confidence": 0.0,
+                "error": "Whisper model is not available. Install openai-whisper.",
+            }
+
+        try:
+            result = self._model.transcribe(
+                audio_path,
+                fp16=False,  # CPU-safe
+                verbose=False,
+            )
+
+            text = (result.get("text") or "").strip()
+            language = result.get("language") or "unknown"
+
+            # Whisper reports per-segment avg_logprob. Map to a rough confidence.
+            segments = result.get("segments") or []
+            if segments:
+                avg_lp = sum(s.get("avg_logprob", -1.0) for s in segments) / len(segments)
+                # avg_logprob is in (−∞, 0]. Clamp to [−1, 0] then invert.
+                confidence = max(0.0, min(1.0, 1.0 + avg_lp))
+            else:
+                confidence = 0.0 if not text else 0.5
+
+            return {
+                "transcribed_text": text,
+                "detected_language": language,
+                "confidence": round(confidence, 3),
+                "error": None,
+            }
+
+        except Exception as exc:
+            logger.error("[VoiceService] Transcription failed: %s", exc)
+            return {
+                "transcribed_text": "",
+                "detected_language": "unknown",
+                "confidence": 0.0,
+                "error": str(exc),
+            }
+
+
+def validate_audio_upload(filename: str, content_type: str, file_size_bytes: int) -> Optional[str]:
+    """
+    Return an error string if the upload is invalid, otherwise None.
+
+    Checks:
+    - File extension is accepted
+    - MIME type is accepted (or at least the extension is)
+    - File is not empty
+    """
+    suffix = Path(filename).suffix.lower()
+    if suffix not in ACCEPTED_EXTENSIONS:
+        return (
+            f"Unsupported file format '{suffix}'. "
+            f"Accepted: {', '.join(sorted(ACCEPTED_EXTENSIONS))}"
+        )
+
+    if file_size_bytes == 0:
+        return "Audio file is empty."
+
+    return None
+
+
+voice_service = VoiceService()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -273,6 +273,7 @@ def mock_ai_services(request):
         "test_semantic_duplicates.py",
         "test_auth_cookie.py",
         "test_mobile_supabase_env.py",
+        "test_voice_service.py",
     }:
         yield
         return

--- a/backend/tests/test_voice_service.py
+++ b/backend/tests/test_voice_service.py
@@ -1,0 +1,256 @@
+"""Unit tests for backend/services/voice_service.py — Issue #207"""
+
+import os
+import struct
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from backend.services.voice_service import (
+    VoiceService,
+    validate_audio_upload,
+    ACCEPTED_EXTENSIONS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal WAV fixture — 0.1 s of silence at 16 kHz mono 16-bit PCM
+# ---------------------------------------------------------------------------
+
+def _make_wav_bytes(duration_frames: int = 1600, sample_rate: int = 16000) -> bytes:
+    """Return a valid WAV file as bytes (silence)."""
+    num_channels = 1
+    bits_per_sample = 16
+    byte_rate = sample_rate * num_channels * bits_per_sample // 8
+    block_align = num_channels * bits_per_sample // 8
+    data_size = duration_frames * block_align
+    pcm_data = b'\x00' * data_size
+
+    header = struct.pack(
+        '<4sI4s4sIHHIIHH4sI',
+        b'RIFF',
+        36 + data_size,
+        b'WAVE',
+        b'fmt ',
+        16,           # PCM chunk size
+        1,            # AudioFormat PCM
+        num_channels,
+        sample_rate,
+        byte_rate,
+        block_align,
+        bits_per_sample,
+        b'data',
+        data_size,
+    )
+    return header + pcm_data
+
+
+def _wav_fixture() -> str:
+    """Write a WAV file to a temp path and return the path."""
+    tmp = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+    tmp.write(_make_wav_bytes())
+    tmp.close()
+    return tmp.name
+
+
+# ---------------------------------------------------------------------------
+# validate_audio_upload
+# ---------------------------------------------------------------------------
+
+class TestValidateAudioUpload(unittest.TestCase):
+
+    def test_accepted_wav(self):
+        self.assertIsNone(validate_audio_upload('recording.wav', 'audio/wav', 1024))
+
+    def test_accepted_webm(self):
+        self.assertIsNone(validate_audio_upload('recording.webm', 'audio/webm', 2048))
+
+    def test_accepted_mp3(self):
+        self.assertIsNone(validate_audio_upload('clip.mp3', 'audio/mpeg', 512))
+
+    def test_accepted_ogg(self):
+        self.assertIsNone(validate_audio_upload('voice.ogg', 'audio/ogg', 800))
+
+    def test_rejected_txt(self):
+        err = validate_audio_upload('notes.txt', 'text/plain', 100)
+        self.assertIsNotNone(err)
+        self.assertIn('.txt', err)
+
+    def test_rejected_empty_file(self):
+        err = validate_audio_upload('recording.wav', 'audio/wav', 0)
+        self.assertIsNotNone(err)
+        self.assertIn('empty', err.lower())
+
+    def test_rejected_unknown_extension(self):
+        err = validate_audio_upload('audio.xyz', 'audio/xyz', 500)
+        self.assertIsNotNone(err)
+
+    def test_all_accepted_extensions_pass(self):
+        for ext in ACCEPTED_EXTENSIONS:
+            with self.subTest(ext=ext):
+                result = validate_audio_upload(f'file{ext}', 'audio/wav', 100)
+                self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# VoiceService — unit tests with mocked Whisper
+# ---------------------------------------------------------------------------
+
+class TestVoiceService(unittest.TestCase):
+
+    def _make_service(self) -> VoiceService:
+        svc = VoiceService()
+        return svc
+
+    def test_transcribe_returns_error_when_no_whisper(self):
+        svc = self._make_service()
+        with patch('backend.services.voice_service._HAS_WHISPER', False):
+            svc._initialized = False
+            svc._model = None
+            result = svc.transcribe('/nonexistent/path.wav')
+        self.assertIn('error', result)
+        self.assertIsNotNone(result['error'])
+        self.assertEqual(result['transcribed_text'], '')
+
+    def test_transcribe_returns_text_on_success(self):
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            'text': 'My laptop screen is broken',
+            'language': 'en',
+            'segments': [{'avg_logprob': -0.2}],
+        }
+
+        svc = self._make_service()
+        svc._model = mock_model
+        svc._initialized = True
+
+        wav_path = _wav_fixture()
+        try:
+            result = svc.transcribe(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        self.assertEqual(result['transcribed_text'], 'My laptop screen is broken')
+        self.assertEqual(result['detected_language'], 'en')
+        self.assertGreater(result['confidence'], 0.0)
+        self.assertIsNone(result['error'])
+
+    def test_confidence_clamped_to_0_1(self):
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            'text': 'test',
+            'language': 'en',
+            'segments': [{'avg_logprob': -10.0}],  # very negative → confidence near 0
+        }
+        svc = self._make_service()
+        svc._model = mock_model
+        svc._initialized = True
+
+        wav_path = _wav_fixture()
+        try:
+            result = svc.transcribe(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        self.assertGreaterEqual(result['confidence'], 0.0)
+        self.assertLessEqual(result['confidence'], 1.0)
+
+    def test_confidence_fallback_when_no_segments(self):
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            'text': 'hello',
+            'language': 'en',
+            'segments': [],
+        }
+        svc = self._make_service()
+        svc._model = mock_model
+        svc._initialized = True
+
+        wav_path = _wav_fixture()
+        try:
+            result = svc.transcribe(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        # Non-empty text with no segments → 0.5
+        self.assertEqual(result['confidence'], 0.5)
+
+    def test_transcribe_wraps_exception(self):
+        mock_model = MagicMock()
+        mock_model.transcribe.side_effect = RuntimeError('CUDA out of memory')
+
+        svc = self._make_service()
+        svc._model = mock_model
+        svc._initialized = True
+
+        wav_path = _wav_fixture()
+        try:
+            result = svc.transcribe(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        self.assertEqual(result['transcribed_text'], '')
+        self.assertIn('CUDA out of memory', result['error'])
+
+    def test_load_fails_gracefully_without_package(self):
+        svc = self._make_service()
+        with patch('backend.services.voice_service._HAS_WHISPER', False):
+            svc._initialized = False
+            loaded = svc._load()
+        self.assertFalse(loaded)
+        self.assertFalse(svc._initialized)
+
+    def test_load_skips_if_already_initialized(self):
+        svc = self._make_service()
+        svc._initialized = True
+        # _load should short-circuit without touching _whisper_module
+        with patch('backend.services.voice_service._whisper_module') as mock_pkg:
+            result = svc._load()
+        mock_pkg.load_model.assert_not_called()
+        self.assertTrue(result)
+
+    def test_empty_transcript_when_whisper_returns_blank(self):
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = {
+            'text': '   ',
+            'language': 'unknown',
+            'segments': [],
+        }
+        svc = self._make_service()
+        svc._model = mock_model
+        svc._initialized = True
+
+        wav_path = _wav_fixture()
+        try:
+            result = svc.transcribe(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        self.assertEqual(result['transcribed_text'], '')
+        self.assertEqual(result['confidence'], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Wav fixture sanity
+# ---------------------------------------------------------------------------
+
+class TestWavFixture(unittest.TestCase):
+
+    def test_fixture_is_valid_wav(self):
+        wav = _make_wav_bytes()
+        self.assertTrue(wav.startswith(b'RIFF'))
+        self.assertIn(b'WAVE', wav[:12])
+        self.assertIn(b'fmt ', wav)
+        self.assertIn(b'data', wav)
+
+    def test_fixture_file_exists_and_nonzero(self):
+        path = _wav_fixture()
+        try:
+            self.assertTrue(os.path.exists(path))
+            self.assertGreater(os.path.getsize(path), 0)
+        finally:
+            os.unlink(path)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What changed
- `backend/services/voice_service.py` — Whisper STT service
- `POST /api/voice/transcribe` endpoint
- Returns { transcribed_text, detected_language, confidence }
- mic button in CreateTicket with MediaRecorder
- 120s countdown timer + 3-state modal UI
- Voice badge (purple) in admin TicketTable
- source stored in metadata JSONB (no migration needed)
- 18 unit tests all passing

## Why
Fixes #207 — users forced to type tickets manually.
Voice input reduces friction for non-technical users.

## How to test
1. `pytest backend\tests\test_voice_service.py -v`
2. All 18 tests pass

## Screenshots
<img width="1155" height="749" alt="Screenshot 2026-05-28 130819" src="https://github.com/user-attachments/assets/cbab1bd9-52f0-46f0-8132-e10e0b3dc8d6" />


## Notes
- Whisper loads lazily (no startup cost)
- No Supabase migration needed
- New package: openai-whisper>=20231117