### PR TITLE
fix : add input validation to ocr_service extract_text method

### DIFF
--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -29,19 +29,23 @@ class OCRService:
         Returns:
             A single cleaned string of extracted text, or "" on failure.
         """
-        if not image_base64:
+        if not image_base64 or not image_base64.strip():
+            return ""
+
+        image_base64 = image_base64.strip()
+
+        if "," in image_base64:
+            image_base64 = image_base64.split(",", 1)[1]
+
+        missing_padding = len(image_base64) % 4
+        if missing_padding:
+            image_base64 += "=" * (4 - missing_padding)
+
+        if not all(c in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=" for c in image_base64):
+            print(f"[OCRService] Invalid base64 characters detected.")
             return ""
 
         try:
-            # Strip data URI prefix if present (e.g., "data:image/png;base64,...")
-            if "," in image_base64:
-                image_base64 = image_base64.split(",", 1)[1]
-            
-            # Add back missing padding
-            missing_padding = len(image_base64) % 4
-            if missing_padding:
-                image_base64 += "=" * (4 - missing_padding)
-
             image_bytes = base64.b64decode(image_base64)
             reader = _get_reader()
             results = reader.readtext(image_bytes, detail=0, paragraph=True)

--- a/backend/tests/test_ocr_service.py
+++ b/backend/tests/test_ocr_service.py
@@ -1,0 +1,48 @@
+import pytest
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.modules['easyocr'] = MagicMock()
+
+from backend.services.ocr_service import OCRService
+
+
+class TestOCRServiceInputValidation:
+    """Tests for input validation in ocr_service"""
+
+    def test_extract_text_empty_string_returns_empty(self):
+        """Test that empty string returns empty without processing"""
+        svc = OCRService()
+        result = svc.extract_text("")
+        assert result == ""
+
+    def test_extract_text_whitespace_only_returns_empty(self):
+        """Test that whitespace-only input returns empty"""
+        svc = OCRService()
+        result = svc.extract_text("   ")
+        assert result == ""
+
+    def test_extract_text_none_input_returns_empty(self):
+        """Test that None input returns empty"""
+        svc = OCRService()
+        result = svc.extract_text(None)
+        assert result == ""
+
+    def test_extract_text_invalid_base64_returns_empty(self):
+        """Test that invalid base64 characters return empty"""
+        svc = OCRService()
+        result = svc.extract_text("not valid base64!!!")
+        assert result == ""
+
+    def test_extract_text_valid_base64_processes(self):
+        """Test that valid base64 data is processed"""
+        svc = OCRService()
+
+        with patch('base64.b64decode', return_value=b'fake_image_data'):
+            with patch('backend.services.ocr_service._get_reader') as mock_get_reader:
+                mock_reader = MagicMock()
+                mock_reader.readtext.return_value = ["extracted text"]
+                mock_get_reader.return_value = mock_reader
+
+                result = svc.extract_text("dGVzdCBkYXRh")
+                assert result == "extracted text"


### PR DESCRIPTION
## Summary
- Add validation for empty/whitespace input
- Add validation for invalid base64 characters
- Return empty string gracefully instead of raising exceptions

## Verification
`pytest backend/tests/test_ocr_service.py -v`