### PR TITLE
fix : handle empty text in check_duplicate method

### DIFF
--- a/backend/data/case_history_cache.json
+++ b/backend/data/case_history_cache.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ticket_id": "DISK-001",
+    "text": "Persistent ticket"
+  },
+  {
+    "ticket_id": "DISK-001",
+    "text": "Persistent ticket"
+  }
+]

--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -210,7 +210,13 @@ class DuplicateService:
         """
         self.load()
         
-        # If model is not available, return no duplicate found
+        if not text or not text.strip():
+            return {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "similarity": 0.0,
+            }
+
         if not self.is_available():
             print("[DuplicateService] DEGRADED: Duplicate check skipped (model not available)")
             return {


### PR DESCRIPTION
## Summary
- Handle empty/whitespace text in check_duplicate to avoid unnecessary model calls
- Return early with no duplicate found when text is empty

## Verification
`pytest backend/tests/ -v`