### PR TITLE
test : add unit tests for DuplicateService add_ticket method

### DIFF
--- a/ISSUE_CANDIDATES_AUTOMATION.md
+++ b/ISSUE_CANDIDATES_AUTOMATION.md
@@ -1,0 +1,81 @@
+# Issue Candidates for HELPDESK.AI
+
+## Issue 1
+- **Title**: test : add unit tests for DuplicateService check_duplicate method
+- **Type**: test
+- **Files to create**: backend/tests/test_duplicate_service.py
+- **Summary**: Add unit tests for check_duplicate method covering threshold override, empty ticket store, and degraded mode
+- **Verification**: `pytest backend/tests/test_duplicate_service.py -v`
+- **Conflict Risk**: Low
+
+## Issue 2
+- **Title**: test : add unit tests for DuplicateService add_ticket method
+- **Type**: test
+- **Files to create**: backend/tests/test_duplicate_service_add.py
+- **Summary**: Add unit tests for add_ticket method covering ticket creation and disk persistence
+- **Verification**: `pytest backend/tests/test_duplicate_service_add.py -v`
+- **Conflict Risk**: Low
+
+## Issue 3
+- **Title**: fix : handle empty text in check_duplicate method
+- **Type**: fix
+- **Files to modify**: backend/services/duplicate_service.py
+- **Summary**: Handle empty/whitespace text in check_duplicate to avoid unnecessary model calls
+- **Verification**: `pytest backend/tests/ -v`
+- **Conflict Risk**: Low
+
+## Issue 4
+- **Title**: feat : add threshold validation in check_duplicate method
+- **Type**: feat
+- **Files to modify**: backend/services/duplicate_service.py
+- **Summary**: Add validation that threshold is between 0 and 1
+- **Verification**: `pytest backend/tests/ -v`
+- **Conflict Risk**: Low
+
+## Issue 5
+- **Title**: test : add unit tests for classifier_v3 predict method edge cases
+- **Type**: test
+- **Files to create**: backend/tests/test_classifier_v3.py
+- **Summary**: Add unit tests for classifier_v3 covering None confidence and empty text input
+- **Verification**: `pytest backend/tests/test_classifier_v3.py -v`
+- **Conflict Risk**: Low
+
+## Issue 6
+- **Title**: fix : handle None values in notification_routing service
+- **Type**: fix
+- **Files to modify**: backend/services/notification_routing.py
+- **Summary**: Add null checks for category and priority in notification routing
+- **Verification**: `pytest backend/tests/ -v`
+- **Conflict Risk**: Low
+
+## Issue 7
+- **Title**: test : add unit tests for notification_routing get_route method
+- **Type**: test
+- **Files to create**: backend/tests/test_notification_routing.py
+- **Summary**: Add unit tests for get_route covering priority-based routing and channel selection
+- **Verification**: `pytest backend/tests/test_notification_routing.py -v`
+- **Conflict Risk**: Low
+
+## Issue 8
+- **Title**: fix : handle missing env vars gracefully in gemini_service
+- **Type**: fix
+- **Files to modify**: backend/services/gemini_service.py
+- **Summary**: Return graceful response instead of raising exception when API key is missing
+- **Verification**: `pytest backend/tests/ -v`
+- **Conflict Risk**: Low
+
+## Issue 9
+- **Title**: test : add unit tests for gemini_service generate_response method
+- **Type**: test
+- **Files to create**: backend/tests/test_gemini_service.py
+- **Summary**: Add unit tests for generate_response covering API key missing and fallback scenarios
+- **Verification**: `pytest backend/tests/test_gemini_service.py -v`
+- **Conflict Risk**: Low
+
+## Issue 10
+- **Title**: fix : add input validation to ocr_service process_document method
+- **Type**: fix
+- **Files to modify**: backend/services/ocr_service.py
+- **Summary**: Add validation for file path existence and supported formats
+- **Verification**: `pytest backend/tests/ -v`
+- **Conflict Risk**: Low

--- a/backend/data/case_history_cache.json
+++ b/backend/data/case_history_cache.json
@@ -1,0 +1,6 @@
+[
+  {
+    "ticket_id": "DISK-001",
+    "text": "Persistent ticket"
+  }
+]

--- a/backend/tests/test_duplicate_service_add.py
+++ b/backend/tests/test_duplicate_service_add.py
@@ -1,0 +1,74 @@
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.modules['sentence_transformers'] = MagicMock()
+
+from backend.services.duplicate_service import DuplicateService
+
+
+class TestDuplicateServiceAddTicket:
+    """Tests for DuplicateService.add_ticket method"""
+
+    def test_add_ticket_creates_embedding_and_persists(self):
+        """Test that add_ticket stores ticket in memory and saves to disk"""
+        svc = DuplicateService()
+        mock_model = MagicMock()
+        mock_embedding = MagicMock()
+        mock_model.encode.return_value = mock_embedding
+        svc.model = mock_model
+        svc._loaded = True
+        svc._load_failed = False
+
+        with patch.object(svc, 'save_to_disk') as mock_save:
+            svc.add_ticket("TICKET-001", "Test ticket text")
+
+        assert len(svc._tickets) == 1
+        assert svc._tickets[0][0] == "TICKET-001"
+        assert svc._tickets[0][1] == mock_embedding
+        assert svc._tickets[0][2] == "Test ticket text"
+        mock_save.assert_called_once_with("TICKET-001", "Test ticket text")
+
+    def test_add_ticket_degraded_mode_skips_embedding(self):
+        """Test that add_ticket returns early when model is not available"""
+        svc = DuplicateService()
+        svc._loaded = False
+        svc._load_failed = True
+
+        with patch.object(svc, 'save_to_disk') as mock_save:
+            svc.add_ticket("TICKET-002", "Another ticket")
+
+        assert len(svc._tickets) == 0
+        mock_save.assert_not_called()
+
+    def test_add_ticket_multiple_tickets(self):
+        """Test adding multiple tickets accumulates in memory"""
+        svc = DuplicateService()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = MagicMock()
+        svc.model = mock_model
+        svc._loaded = True
+
+        with patch.object(svc, 'save_to_disk'):
+            svc.add_ticket("TICKET-A", "First ticket")
+            svc.add_ticket("TICKET-B", "Second ticket")
+            svc.add_ticket("TICKET-C", "Third ticket")
+
+        assert len(svc._tickets) == 3
+        assert svc._tickets[0][0] == "TICKET-A"
+        assert svc._tickets[1][0] == "TICKET-B"
+        assert svc._tickets[2][0] == "TICKET-C"
+
+    def test_add_ticket_persists_to_disk(self):
+        """Test that add_ticket calls save_to_disk with correct args"""
+        svc = DuplicateService()
+        mock_model = MagicMock()
+        mock_model.encode.return_value = MagicMock()
+        svc.model = mock_model
+        svc._loaded = True
+
+        with patch.object(svc, 'save_to_disk', wraps=svc.save_to_disk) as mock_save:
+            svc.add_ticket("DISK-001", "Persistent ticket")
+
+        mock_save.assert_called_once_with("DISK-001", "Persistent ticket")


### PR DESCRIPTION
## Summary
- Add 4 unit tests for add_ticket method covering ticket creation, disk persistence, degraded mode, and multiple tickets

## Verification
`pytest backend/tests/test_duplicate_service_add.py -v`