### PR TITLE
security: harden env secret templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ env/
 # Ignore all env files anywhere in the repo
 **/.env
 **/.env.*
+!**/.env.example
+!**/.env.sample
+!**/.env.template
 
 
 # Models (Keep them if they are small, but here they are large. 

--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,19 @@
+# HELPDESK.AI Frontend environment reference
+# Copy this file to Frontend/.env.local for local development.
+# Never commit populated .env or .env.local files.
+
+# Backend API endpoints
+VITE_API_URL=http://localhost:7860
+VITE_BACKEND_URL=http://localhost:7860
+VITE_WS_URL=ws://localhost:7860
+
+# Supabase public client configuration
+# Use the anon/public key only. Never put a service-role key in the frontend.
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Optional feature flags and integrations
+VITE_USE_MOCK=true
+VITE_SUPPORT_EMAIL=support@helpdesk.ai
+VITE_YOUTUBE_API_KEY=
+VITE_STRIPE_GROWTH_LINK=

--- a/MobileApp/.env.example
+++ b/MobileApp/.env.example
@@ -1,2 +1,3 @@
 EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+EXPO_PUBLIC_BACKEND_URL=http://localhost:7860

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,6 +60,13 @@ REQUIRE_SUPABASE=false
 # Slack Alerts
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/yyy/zzz
 
+# Optional encrypted database fields
+# Generate a deployment-specific 32-byte key and keep it in your secret manager.
+DB_ENCRYPTION_SECRET_KEY=
+
+# Optional weekly digest email dispatch
+RESEND_API_KEY=
+
 # -----------------------------------------------------------------------------
 # Health-Check Probe (Docker / Kubernetes)
 # -----------------------------------------------------------------------------

--- a/backend/tests/test_mobile_supabase_env.py
+++ b/backend/tests/test_mobile_supabase_env.py
@@ -35,3 +35,40 @@ def test_mobile_env_example_documents_required_keys():
 
     assert "EXPO_PUBLIC_SUPABASE_URL=" in source
     assert "EXPO_PUBLIC_SUPABASE_ANON_KEY=" in source
+    assert "EXPO_PUBLIC_BACKEND_URL=" in source
+
+
+def test_frontend_env_example_documents_public_runtime_keys():
+    source = (
+        Path(__file__).resolve().parents[2] / "Frontend" / ".env.example"
+    ).read_text(encoding="utf-8")
+
+    expected_keys = [
+        "VITE_API_URL=",
+        "VITE_BACKEND_URL=",
+        "VITE_WS_URL=",
+        "VITE_SUPABASE_URL=",
+        "VITE_SUPABASE_ANON_KEY=",
+        "VITE_USE_MOCK=",
+        "VITE_SUPPORT_EMAIL=",
+        "VITE_YOUTUBE_API_KEY=",
+        "VITE_STRIPE_GROWTH_LINK=",
+    ]
+
+    for key in expected_keys:
+        assert key in source
+
+
+def test_env_examples_do_not_contain_secret_shaped_values():
+    repo_root = Path(__file__).resolve().parents[2]
+    example_paths = [
+        repo_root / "backend" / ".env.example",
+        repo_root / "Frontend" / ".env.example",
+        repo_root / "MobileApp" / ".env.example",
+    ]
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in example_paths)
+
+    assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in combined
+    assert "aejuenhqciagpntcqoir.supabase.co" not in combined
+    assert "sk_live_" not in combined
+    assert "re_123456789" not in combined


### PR DESCRIPTION
## Summary
- keep nested local env files ignored while explicitly allowing safe env example files to be tracked
- add a placeholder-only Frontend env example for the public Vite runtime variables used by the app
- document the mobile backend URL plus backend DB encryption and Resend env keys in existing examples
- extend regression coverage so env examples document required frontend/mobile keys and do not contain known secret-shaped values

## Validation
- python3 -m pytest backend/tests/test_mobile_supabase_env.py -q
- npm run check:ai-secrets (from Frontend)
- git check-ignore for backend, frontend, and mobile env files
- git ls-files env scan
- git diff --check

Closes #195

Please mirror the issue labels on this PR if accepted: gssoc, level:critical, type:security, type:bug, bounty.