### PR TITLE
fix(frontend): standardize env var usage in AdminSettings and add .env.example (#276)

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,11 @@
+# Frontend Environment Variables
+# Copy this file to .env.local and adjust values for your local setup.
+
+# Backend API URL (used by all components via src/config.js)
+# Supports both variable names for backward compatibility:
+#   VITE_API_URL is the preferred name
+#   VITE_BACKEND_URL is also accepted as a fallback
+VITE_API_URL=http://localhost:8000
+
+# Set to 'false' to disable mock data and use real API
+VITE_USE_MOCK=true

--- a/Frontend/src/admin/pages/AdminSettings.jsx
+++ b/Frontend/src/admin/pages/AdminSettings.jsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "../../components/ui/card";
 import WebhookSettings from "../../components/shared/WebhookSettings";
+import { API_CONFIG } from "@/config";
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
     Settings,
@@ -348,7 +349,7 @@ const AdminSettings = () => {
                                                 setIsSendingTest(true);
                                                 setTestEmailStatus("");
                                                 try {
-                                                    const backendUrl = import.meta.env.VITE_API_URL || import.meta.env.VITE_BACKEND_URL || "http://localhost:7860";
+                                                    const backendUrl = API_CONFIG.BACKEND_URL;
                                                     const response = await fetch(`${backendUrl}/api/digest/send-now`, {
                                                         method: "POST",
                                                         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

Fixes #276

### Changes
- **AdminSettings.jsx**: Refactored to import `API_CONFIG.BACKEND_URL` from `@/config` instead of directly reading `import.meta.env.VITE_API_URL || import.meta.env.VITE_BACKEND_URL`. This ensures AdminSettings uses the same centralized configuration as SLAPage.jsx and SLADashboard.jsx.
- **Frontend/.env.example**: Created with documented environment variables (`VITE_API_URL`, `VITE_USE_MOCK`) so new developers can quickly set up their local environment.

### Why
The environment variable mismatch between `VITE_API_URL` and `VITE_BACKEND_URL` caused the frontend to fall back to the production HuggingFace Space instead of using the local backend during development. This was the last remaining component that bypassed the centralized config.