### PR TITLE
fix(security): add rate limiting to POST /ai/analyze endpoint (#546)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1455,7 +1455,8 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
     return await analyze_only(enriched)
 
 @app.post("/ai/analyze")
-async def analyze_only(request_body: TicketRequest):
+@limiter.limit("10/minute")
+async def analyze_only(request_body: TicketRequest, request: Request):
     """
     PERFORMANCE UPGRADE: AI Analysis phase only. 
     Does NOT persist to DB. This allows the user to review the analysis 


### PR DESCRIPTION
## Summary

Fixes #546

### Problem
The `POST /ai/analyze` endpoint had no rate limiting, while the related `POST /ai/analyze_ticket` endpoint was limited to 10 requests/minute. An attacker could bypass rate limiting by calling `/ai/analyze` directly, exhausting AI model capacity and driving up compute costs.

### Fix
Added `@limiter.limit("10/minute")` and `request: Request` parameter to `analyze_only()` to match the existing rate limit on `analyze_ticket`.

### Changes
- `backend/main.py`: Added rate limiter decorator and `request` parameter to `/ai/analyze` endpoint