### PR TITLE
fix(security): add auth to POST /tickets and restrict PATCH field allowlist (#547)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1392,8 +1392,8 @@ async def search_tickets(
 
 
 @app.post("/tickets", response_model=TicketRecord)
-async def create_ticket(ticket: TicketRecord):
-    """Save a new ticket into the system."""
+async def create_ticket(ticket: TicketRecord, current_user: dict = Depends(get_current_user)):
+    """Save a new ticket into the system. Requires authentication."""
     # Check for duplicates before adding
     existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
     if existing:
@@ -1407,11 +1407,17 @@ async def create_ticket(ticket: TicketRecord):
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
 async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
+    # Restrict updatable fields to prevent privilege escalation
+    ALLOWED_UPDATE_FIELDS = {
+        "status", "priority", "assigned_team", "last_user_viewed_at",
+        "updated_at", "messages", "metadata", "timeline", "summary",
+    }
+    sanitized = {k: v for k, v in updates.items() if k in ALLOWED_UPDATE_FIELDS}
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):
-            # Convert to dict, update, then back to model
+            # Convert to dict, update only allowed fields, then back to model
             ticket_dict = ticket.dict()
-            ticket_dict.update(updates)
+            ticket_dict.update(sanitized)
             updated_ticket = TicketRecord(**ticket_dict)
             TICKETS_DB[i] = updated_ticket
             return updated_ticket


### PR DESCRIPTION
## Summary

Fixes #547

### Problems
1. `POST /tickets` had no authentication — any anonymous caller could create tickets with fabricated `ticket_id` and `owner_id`.
2. `PATCH /tickets/{ticket_id}` accepted arbitrary key/value pairs, allowing attackers to overwrite `ticket_id`, `owner_id`, or inject unexpected fields.

### Fixes
1. **POST /tickets**: Added `Depends(get_current_user)` to require authentication.
2. **PATCH /tickets/{ticket_id}`: Introduced `ALLOWED_UPDATE_FIELDS` allowlist (`status`, `priority`, `assigned_team`, `last_user_viewed_at`, `updated_at`, `messages`, `metadata`, `timeline`, `summary`) to sanitize input and strip any fields not in the allowlist.

### Changes
- `backend/main.py`: Auth dependency on `create_ticket`, field sanitization in `update_ticket`