### PR TITLE
fix: eliminate duplicate SLA escalation log entries

### DIFF
--- a/backend/services/sla_engine.py
+++ b/backend/services/sla_engine.py
@@ -282,38 +282,11 @@ class SLAEngine:
             except Exception as e:
                 logger.error(f"[SLA] Failed to update ticket {ticket.get('id')}: {e}")
 
-        # Log escalations to escalation_logs table
-        for item in escalated:
-            self._log_escalation(item["ticket"], item["sla_result"])
-
         logger.info(
             f"[SLA] Checked {len(tickets)} tickets "
             f"— {len(escalated)} escalated."
         )
         return escalated
-
-    # ------------------------------------------------------------------
-    # Escalation logging
-    # ------------------------------------------------------------------
-
-    def _log_escalation(self, ticket: dict, result: dict):
-        """Insert an escalation event into the escalation_logs table."""
-        if not self.supabase:
-            return
-        try:
-            self.supabase.table("escalation_logs").insert({
-                "ticket_id": ticket["id"],
-                "ticket_subject": ticket.get("subject") or ticket.get("summary", ""),
-                "priority": ticket.get("priority", "medium"),
-                "sla_status": result["sla_status"],
-                "escalation_level": result["escalation_level"],
-                "remaining_seconds": result["remaining_seconds"],
-                "assigned_team": ticket.get("assigned_team", ""),
-                "triggered_at": datetime.datetime.utcnow().isoformat() + "Z",
-                "notification_channels": [],  # populated by notifier
-            }).execute()
-        except Exception as e:
-            logger.error(f"[SLA] Failed to log escalation: {e}")
 
     # ------------------------------------------------------------------
     # Multi-channel notification dispatch

--- a/supabase/migrations/20260529000000_fix_duplicate_escalation_logging.sql
+++ b/supabase/migrations/20260529000000_fix_duplicate_escalation_logging.sql
@@ -1,0 +1,67 @@
+-- Fix duplicate SLA escalation logging
+--
+-- The old trigger trg_log_sla_breach logged only BREACHED transitions in
+-- escalation_logs, but the backend also independently called _log_escalation()
+-- for the same events, creating duplicate entries.
+--
+-- This migration:
+--  1. Drops the old trigger and function that only handled BREACHED
+--  2. Creates a new unified trigger that logs both WARNING and BREACHED
+--     transitions, making the DB the single source of truth for audit logging
+--  3. Backend _log_escalation() call is removed to eliminate duplication
+
+-- Drop old trigger and function
+DROP TRIGGER IF EXISTS trg_log_sla_breach ON public.tickets;
+DROP FUNCTION IF EXISTS public.log_sla_breach;
+
+-- Create a unified escalation logging function
+CREATE OR REPLACE FUNCTION public.log_sla_escalation()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.sla_status = 'breached' AND (OLD.sla_status IS DISTINCT FROM 'breached') THEN
+        INSERT INTO public.escalation_logs (
+            ticket_id, ticket_subject, priority, sla_status,
+            escalation_level, remaining_seconds, assigned_team,
+            notification_channels, triggered_at
+        ) VALUES (
+            NEW.id,
+            COALESCE(NEW.subject, NEW.summary, ''),
+            NEW.priority,
+            'breached',
+            COALESCE(NEW.escalation_level, 1),
+            COALESCE(NEW.remaining_seconds, 0),
+            COALESCE(NEW.assigned_team, ''),
+            '{}',
+            now()
+        );
+    END IF;
+
+    IF NEW.sla_status = 'warning' AND (OLD.sla_status IS DISTINCT FROM 'warning') THEN
+        INSERT INTO public.escalation_logs (
+            ticket_id, ticket_subject, priority, sla_status,
+            escalation_level, remaining_seconds, assigned_team,
+            notification_channels, triggered_at
+        ) VALUES (
+            NEW.id,
+            COALESCE(NEW.subject, NEW.summary, ''),
+            NEW.priority,
+            'warning',
+            COALESCE(NEW.escalation_level, 1),
+            COALESCE(NEW.remaining_seconds, 0),
+            COALESCE(NEW.assigned_team, ''),
+            '{}',
+            now()
+        );
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the unified trigger
+DROP TRIGGER IF EXISTS trg_log_sla_escalation ON public.tickets;
+CREATE TRIGGER trg_log_sla_escalation
+    AFTER UPDATE OF sla_status ON public.tickets
+    FOR EACH ROW
+    WHEN (NEW.sla_status IN ('breached', 'warning'))
+    EXECUTE FUNCTION public.log_sla_escalation();


### PR DESCRIPTION
## Description

Every SLA breach event creates **duplicate entries** in the \escalation_logs\ table because two independent mechanisms log the same transition — the PostgreSQL trigger \	rg_log_sla_breach\ and the backend's \_log_escalation()\ method in \check_all_active_tickets()\.

## Changes

### Backend (\ackend/services/sla_engine.py\)
- Removed the \_log_escalation()\ call from \check_all_active_tickets()\ that duplicated the DB trigger's work
- Removed the \_log_escalation()\ method entirely since it's no longer used
- The \escalated\ list is preserved for notification dispatch (Slack/Teams/email)

### Database (\supabase/migrations/20260529000000_fix_duplicate_escalation_logging.sql\)
- Dropped old \	rg_log_sla_breach\ trigger (only handled BREACHED)
- Created unified \	rg_log_sla_escalation\ trigger that logs **both** BREACHED and WARNING transitions
- New trigger function \public.log_sla_escalation()\ checks for status transitions to avoid re-logging on subsequent updates

## Why not keep both paths?
- The DB trigger fires atomically with the UPDATE, guaranteeing exactly one log entry per transition
- The backend would create a second entry because it evaluated the result independently
- Centralizing in the DB makes the audit trail reliable regardless of backend restarts or race conditions

Fixes #584