### PR TITLE
fix: Feature: Implement Full-Text Search for Tickets using Supabase pg_trgm

### DIFF
--- a/Frontend/src/admin/components/AdminHeader.jsx
+++ b/Frontend/src/admin/components/AdminHeader.jsx
@@ -1,37 +1,111 @@
-import React, { useState, useRef, useEffect } from 'react';
-import { Search, Bell, Menu, User, ChevronDown, Settings, LogOut, UserCircle, X, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
+import { Search, Bell, Menu, User, ChevronDown, Settings, LogOut, UserCircle, X, PanelLeftClose, PanelLeftOpen, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import NotificationPopover from '../../user/components/NotificationPopover';
 import useAuthStore from '../../store/authStore';
 import { Avatar, AvatarFallback, AvatarImage } from "../../components/ui/avatar";
+import { supabase } from "../../lib/supabaseClient";
+import { formatTicketId } from "../../utils/format";
 
 /**
  * AdminHeader Component
  * Refined 64px header for the administrative console.
- * Features a solid white background, specific search placeholder, 
+ * Features a solid white background, specific search placeholder,
  * and a functional avatar dropdown menu.
  */
 const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar }) => {
     const [isProfileOpen, setIsProfileOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
+    const [searchResults, setSearchResults] = useState([]);
+    const [isSearching, setIsSearching] = useState(false);
+    const [isResultsOpen, setIsResultsOpen] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(-1);
     const dropdownRef = useRef(null);
     const searchRef = useRef(null);
+    const searchContainerRef = useRef(null);
     const navigate = useNavigate();
     const { logout, profile: adminProfile } = useAuthStore();
     const initials = adminProfile?.full_name ? adminProfile.full_name.split(' ').map(n => n[0]).join('').toUpperCase() : 'AD';
 
+    const trimmedQuery = useMemo(() => searchQuery.trim(), [searchQuery]);
+
+    // Debounced (300ms) full-text search against Supabase pg_trgm RPC.
+    useEffect(() => {
+        if (!trimmedQuery) {
+            setSearchResults([]);
+            setIsSearching(false);
+            setActiveIndex(-1);
+            return;
+        }
+
+        let cancelled = false;
+        setIsSearching(true);
+        const handle = setTimeout(async () => {
+            const { data, error } = await supabase.rpc('search_tickets', { q: trimmedQuery, limit_count: 8 });
+            if (cancelled) return;
+            if (error) {
+                console.warn('[AdminHeader] search_tickets RPC failed:', error.message);
+                setSearchResults([]);
+            } else {
+                setSearchResults(data || []);
+            }
+            setActiveIndex(-1);
+            setIsSearching(false);
+        }, 300);
+
+        return () => {
+            cancelled = true;
+            clearTimeout(handle);
+        };
+    }, [trimmedQuery]);
+
+    const openResultForIndex = (idx) => {
+        const target = searchResults[idx];
+        if (!target) return;
+        navigate(`/admin/ticket/${target.id}`);
+        setSearchQuery('');
+        setSearchResults([]);
+        setIsResultsOpen(false);
+        setActiveIndex(-1);
+        searchRef.current?.blur();
+    };
+
     const handleSearchKeyDown = (e) => {
-        if (e.key === 'Enter' && searchQuery.trim()) {
-            navigate(`/admin/tickets?q=${encodeURIComponent(searchQuery.trim())}`);
-            searchRef.current?.blur();
+        if (e.key === 'ArrowDown') {
+            if (!searchResults.length) return;
+            e.preventDefault();
+            setIsResultsOpen(true);
+            setActiveIndex((prev) => (prev + 1) % searchResults.length);
+        } else if (e.key === 'ArrowUp') {
+            if (!searchResults.length) return;
+            e.preventDefault();
+            setIsResultsOpen(true);
+            setActiveIndex((prev) => (prev <= 0 ? searchResults.length - 1 : prev - 1));
+        } else if (e.key === 'Enter') {
+            if (activeIndex >= 0 && searchResults[activeIndex]) {
+                e.preventDefault();
+                openResultForIndex(activeIndex);
+            } else if (trimmedQuery) {
+                navigate(`/admin/tickets?q=${encodeURIComponent(trimmedQuery)}`);
+                setIsResultsOpen(false);
+                searchRef.current?.blur();
+            }
         } else if (e.key === 'Escape') {
-            setSearchQuery('');
+            if (isResultsOpen) {
+                setIsResultsOpen(false);
+            } else {
+                setSearchQuery('');
+            }
+            setActiveIndex(-1);
             searchRef.current?.blur();
         }
     };
 
     const handleSearchClear = () => {
         setSearchQuery('');
+        setSearchResults([]);
+        setIsResultsOpen(false);
+        setActiveIndex(-1);
         searchRef.current?.focus();
     };
 
@@ -40,6 +114,9 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
         const handleClickOutside = (event) => {
             if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
                 setIsProfileOpen(false);
+            }
+            if (searchContainerRef.current && !searchContainerRef.current.contains(event.target)) {
+                setIsResultsOpen(false);
             }
         };
         document.addEventListener('mousedown', handleClickOutside);
@@ -50,6 +127,8 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
         await logout();
         navigate('/login');
     };
+
+    const showResultsPanel = isResultsOpen && trimmedQuery.length > 0;
 
     return (
         <header className="h-16 bg-white border-b border-slate-200 sticky top-0 z-30 px-6 md:px-10 flex items-center justify-between">
@@ -74,18 +153,27 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                 )}
 
                 {/* Primary Search Terminal */}
-                <div className="flex-1 max-w-xl relative hidden md:block">
+                <div ref={searchContainerRef} className="flex-1 max-w-xl relative hidden md:block">
                     <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 w-4 h-4 pointer-events-none" />
                     <input
                         ref={searchRef}
                         type="text"
                         value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
+                        onChange={(e) => { setSearchQuery(e.target.value); setIsResultsOpen(true); }}
+                        onFocus={() => { if (trimmedQuery) setIsResultsOpen(true); }}
                         onKeyDown={handleSearchKeyDown}
-                        placeholder="Search tickets, users… (press Enter)"
+                        placeholder="Search tickets by id, subject, status, assignee…"
+                        role="combobox"
+                        aria-expanded={showResultsPanel}
+                        aria-controls="admin-search-results"
+                        aria-autocomplete="list"
+                        aria-activedescendant={activeIndex >= 0 ? `admin-search-result-${activeIndex}` : undefined}
                         className="w-full bg-slate-50/50 border border-slate-200 rounded-xl pl-11 pr-9 py-2 text-sm font-medium tracking-tight focus:outline-none focus:ring-4 focus:ring-emerald-600/5 focus:border-emerald-600 focus:bg-white transition-all text-slate-600 placeholder:text-slate-400"
                     />
-                    {searchQuery && (
+                    {isSearching && (
+                        <Loader2 className="absolute right-9 top-1/2 -translate-y-1/2 text-slate-400 w-3.5 h-3.5 animate-spin" />
+                    )}
+                    {searchQuery && !isSearching && (
                         <button
                             onClick={handleSearchClear}
                             className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-300 hover:text-slate-500 transition-colors"
@@ -93,6 +181,56 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                         >
                             <X size={14} />
                         </button>
+                    )}
+
+                    {showResultsPanel && (
+                        <div
+                            id="admin-search-results"
+                            role="listbox"
+                            className="absolute left-0 right-0 mt-2 bg-white border border-slate-200 rounded-2xl shadow-xl shadow-slate-200/50 py-2 max-h-96 overflow-y-auto animate-in fade-in zoom-in-95 duration-150 z-40"
+                        >
+                            {isSearching && searchResults.length === 0 && (
+                                <div className="px-4 py-3 text-xs font-bold text-slate-400 flex items-center gap-2">
+                                    <Loader2 size={12} className="animate-spin" /> Searching tickets…
+                                </div>
+                            )}
+                            {!isSearching && searchResults.length === 0 && (
+                                <div className="px-4 py-3 text-xs font-bold text-slate-400">
+                                    No tickets match &ldquo;{trimmedQuery}&rdquo;.
+                                </div>
+                            )}
+                            {searchResults.map((result, idx) => {
+                                const isActive = idx === activeIndex;
+                                return (
+                                    <button
+                                        key={result.id}
+                                        id={`admin-search-result-${idx}`}
+                                        role="option"
+                                        aria-selected={isActive}
+                                        onMouseEnter={() => setActiveIndex(idx)}
+                                        onMouseDown={(e) => e.preventDefault()}
+                                        onClick={() => openResultForIndex(idx)}
+                                        className={`w-full text-left px-4 py-2 flex flex-col gap-0.5 transition-colors ${isActive ? 'bg-emerald-50' : 'hover:bg-slate-50'}`}
+                                    >
+                                        <div className="flex items-center justify-between gap-3">
+                                            <span className="text-[11px] font-black text-slate-500 tracking-wider uppercase">
+                                                {formatTicketId(result.id)}
+                                            </span>
+                                            <span className="text-[10px] font-bold text-emerald-600 uppercase tracking-wider">
+                                                {result.status || '—'}
+                                            </span>
+                                        </div>
+                                        <div className="text-xs font-bold text-slate-800 truncate">
+                                            {result.subject || result.description || 'Untitled ticket'}
+                                        </div>
+                                        <div className="text-[10px] font-medium text-slate-400 flex items-center gap-2 truncate">
+                                            {result.category && <span className="uppercase tracking-wider">{result.category}</span>}
+                                            {result.assignee_name && <span>• {result.assignee_name}</span>}
+                                        </div>
+                                    </button>
+                                );
+                            })}
+                        </div>
                     )}
                 </div>
             </div>

--- a/supabase/migrations/20260530000000_ticket_search.sql
+++ b/supabase/migrations/20260530000000_ticket_search.sql
@@ -1,0 +1,76 @@
+-- Full-text ticket search via pg_trgm.
+-- Adds trigram indexes on the searchable ticket columns plus a
+-- security-invoker RPC so callers automatically inherit existing
+-- row level security (admins see only their company, users see only
+-- their own tickets, etc.).
+
+create extension if not exists pg_trgm;
+
+create index if not exists tickets_subject_trgm_idx
+    on public.tickets using gin (subject gin_trgm_ops);
+
+create index if not exists tickets_description_trgm_idx
+    on public.tickets using gin (description gin_trgm_ops);
+
+create index if not exists tickets_category_trgm_idx
+    on public.tickets using gin (category gin_trgm_ops);
+
+create index if not exists tickets_status_trgm_idx
+    on public.tickets using gin (status gin_trgm_ops);
+
+create index if not exists profiles_full_name_trgm_idx
+    on public.profiles using gin (full_name gin_trgm_ops);
+
+create or replace function public.search_tickets(q text, limit_count int default 8)
+returns table (
+    id uuid,
+    subject text,
+    description text,
+    category text,
+    status text,
+    priority text,
+    assigned_agent_id uuid,
+    assignee_name text,
+    created_at timestamptz,
+    rank real
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+    select
+        t.id,
+        t.subject,
+        t.description,
+        t.category,
+        t.status,
+        t.priority,
+        t.assigned_agent_id,
+        p.full_name as assignee_name,
+        t.created_at,
+        greatest(
+            similarity(coalesce(t.subject, ''), q),
+            similarity(coalesce(t.description, ''), q),
+            similarity(coalesce(t.category, ''), q),
+            similarity(coalesce(t.status, ''), q),
+            similarity(coalesce(p.full_name, ''), q)
+        ) as rank
+    from public.tickets t
+    left join public.profiles p on p.id = t.assigned_agent_id
+    where
+        q is not null
+        and length(trim(q)) > 0
+        and (
+            coalesce(t.subject, '') ilike '%' || q || '%'
+            or coalesce(t.description, '') ilike '%' || q || '%'
+            or coalesce(t.category, '') ilike '%' || q || '%'
+            or coalesce(t.status, '') ilike '%' || q || '%'
+            or coalesce(t.id::text, '') ilike '%' || q || '%'
+            or coalesce(p.full_name, '') ilike '%' || q || '%'
+        )
+    order by rank desc nulls last, t.created_at desc
+    limit greatest(1, least(coalesce(limit_count, 8), 50));
+$$;
+
+grant execute on function public.search_tickets(text, int) to authenticated;


### PR DESCRIPTION
Closes #379.

Frontend deps aren't installed in this clone, so I can't fully run build/lint, but the file changes follow existing conventions and imports.

## Summary

Added Supabase pg_trgm-backed live ticket search to satisfy bounty #379:

- **`supabase/migrations/20260530000000_ticket_search.sql`** — enables `pg_trgm`, adds GIN trigram indexes on `tickets.subject/description/category/status` and `profiles.full_name`, and defines a `search_tickets(q, limit_count)` RPC (SECURITY INVOKER so existing RLS scopes results to the caller's role/company automatically). Returns ticket id, subject, description, category, status, priority, assignee name, and a similarity rank.
- **`Frontend/src/admin/components/AdminHeader.jsx`** — kept the existing search input but wired it to a 300ms-debounced `supabase.rpc('search_tickets', …)` call, rendered a dropdown of up to 8 matches under the input with loading/empty states, added full keyboard navigation (ArrowUp/Down highlight, Enter opens the highlighted ticket via `/admin/ticket/:id`, Escape clears/closes), click-outside dismissal, and ARIA combobox/listbox roles. Plain Enter without a highlighted result still falls back to the existing `/admin/tickets?q=…` page filter for continuity.

Tests: no test suite detected

---
_Bounty attempt._