### PR TITLE
fix(backend): remove obsolete mock in-memory database endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -460,21 +460,7 @@ class Message(BaseModel):
     timestamp: str
 
 
-class TicketRecord(BaseModel):
-    ticket_id: str
-    owner_id: str
-    summary: str
-    category: str
-    subcategory: str
-    priority: str
-    status: str
-    assigned_team: str
-    created_at: str
-    updated_at: str | None = None
-    last_user_viewed_at: str | None = None
-    messages: list[Message] = []
-    metadata: dict = {}
-    timeline: dict = {} # Milestones: created, analyzed, triaged, routed, in_progress, resolved
+
 
 
 class AuditLogProfile(BaseModel):
@@ -495,8 +481,7 @@ class AuditLogRecord(BaseModel):
     performed_by_profile: AuditLogProfile | None = None
 
 
-# --- In-Memory Database (to be replaced with SQL later) ---
-TICKETS_DB: list[TicketRecord] = []
+
 
 
 class HealthResponse(BaseModel):
@@ -1497,38 +1482,7 @@ async def search_tickets(
         return filtered
 
 
-@app.post("/tickets", response_model=TicketRecord)
-async def create_ticket(ticket: TicketRecord, current_user: dict = Depends(get_current_user)):
-    """Save a new ticket into the system. Requires authentication."""
-    # Check for duplicates before adding
-    existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
-    if existing:
-        return existing
-        
-    TICKETS_DB.append(ticket)
-    print(f"[DB] Ticket #{ticket.ticket_id} created for user {ticket.owner_id}")
-    return ticket
 
-
-@app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
-    """Partially update a ticket's fields (e.g., status, viewed_at)."""
-    # Restrict updatable fields to prevent privilege escalation
-    ALLOWED_UPDATE_FIELDS = {
-        "status", "priority", "assigned_team", "last_user_viewed_at",
-        "updated_at", "messages", "metadata", "timeline", "summary",
-    }
-    sanitized = {k: v for k, v in updates.items() if k in ALLOWED_UPDATE_FIELDS}
-    for i, ticket in enumerate(TICKETS_DB):
-        if str(ticket.ticket_id) == str(ticket_id):
-            # Convert to dict, update only allowed fields, then back to model
-            ticket_dict = ticket.dict()
-            ticket_dict.update(sanitized)
-            updated_ticket = TicketRecord(**ticket_dict)
-            TICKETS_DB[i] = updated_ticket
-            return updated_ticket
-    
-    raise HTTPException(status_code=404, detail="Ticket not found")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
Addresses #633  by removing dead and obsolete mock in-memory database endpoints in the FastAPI backend (`backend/main.py`).

### Changes
- Removed obsolete `TicketRecord` Pydantic model.
- Removed unused in-memory ticket list `TICKETS_DB`.
- Removed dead `POST /tickets` and `PATCH /tickets/{ticket_id}` endpoints which were completely disconnected from the production Supabase database.

### Validation
Verified syntactic and compilation correctness using Python's AST parser:
`python -c "import ast; ast.parse(open('backend/main.py', encoding='utf-8').read())"`
closes #633