### PR TITLE
fix: [BOUNTY] [level:intermediate] Add Interactive Keyboard Shortcuts for Rapid Admin Dashboard Navigation

### DIFF
--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import useKeyboardShortcuts from '../../hooks/useKeyboardShortcuts';
 
 /**
  * AdminLayout Component
@@ -12,6 +13,9 @@ import NotificationToast from '../../user/components/NotificationToast';
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+    // Rapid keyboard navigation (G+D, G+T, …) and Ctrl+F search focus.
+    useKeyboardShortcuts();
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// Active keyboard shortcuts for rapid admin dashboard navigation.
+// Two-key sequences (e.g. G then D) navigate via React Router.
+// Ctrl/Cmd + F focuses the first visible search input on the page.
+export const ADMIN_SHORTCUTS = [
+    { keys: ['g', 'd'], path: '/admin/dashboard', combo: 'G then D', description: 'Go to Dashboard' },
+    { keys: ['g', 't'], path: '/admin/tickets', combo: 'G then T', description: 'Go to Tickets' },
+    { keys: ['g', 'u'], path: '/admin/users', combo: 'G then U', description: 'Go to Users' },
+    { keys: ['g', 'a'], path: '/admin/analytics', combo: 'G then A', description: 'Go to Analytics' },
+    { keys: ['g', 'p'], path: '/admin/profile', combo: 'G then P', description: 'Go to Profile' },
+    { keys: ['g', 's'], path: '/admin/settings', combo: 'G then S', description: 'Go to Settings' },
+];
+
+export const SHORTCUTS_LEGEND = [
+    ...ADMIN_SHORTCUTS.map(({ combo, description }) => ({ combo, description })),
+    { combo: 'Ctrl + F', description: 'Focus the page search input' },
+];
+
+const SEQUENCE_TIMEOUT_MS = 1200;
+
+const isTypingTarget = (target) => {
+    if (!target || !target.tagName) return false;
+    const tag = target.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
+};
+
+const useKeyboardShortcuts = (shortcuts = ADMIN_SHORTCUTS) => {
+    const navigate = useNavigate();
+    const lastKeyRef = useRef({ key: null, time: 0 });
+
+    useEffect(() => {
+        const handler = (event) => {
+            // Ctrl/Cmd + F → focus the first visible search input.
+            if ((event.ctrlKey || event.metaKey) && event.key && event.key.toLowerCase() === 'f') {
+                const searchInput = document.querySelector(
+                    'input[type="search"], input[placeholder*="earch" i]'
+                );
+                if (searchInput) {
+                    event.preventDefault();
+                    searchInput.focus();
+                }
+                return;
+            }
+
+            if (isTypingTarget(event.target)) return;
+            if (event.ctrlKey || event.metaKey || event.altKey) return;
+            if (!event.key || event.key.length !== 1) return;
+
+            const key = event.key.toLowerCase();
+            const now = Date.now();
+            const last = lastKeyRef.current;
+
+            const match = shortcuts.find(
+                (s) =>
+                    s.keys.length === 2 &&
+                    s.keys[0] === last.key &&
+                    s.keys[1] === key &&
+                    now - last.time <= SEQUENCE_TIMEOUT_MS
+            );
+
+            if (match) {
+                event.preventDefault();
+                navigate(match.path);
+                lastKeyRef.current = { key: null, time: 0 };
+                return;
+            }
+
+            lastKeyRef.current = { key, time: now };
+        };
+
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [navigate, shortcuts]);
+};
+
+export default useKeyboardShortcuts;

--- a/Frontend/src/user/pages/Help.jsx
+++ b/Frontend/src/user/pages/Help.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { HelpCircle, Mail, MessageSquare, Book, ChevronRight, ChevronDown, Video, PlayCircle, Filter, Search, LifeBuoy } from 'lucide-react';
+import { HelpCircle, Mail, MessageSquare, Book, ChevronRight, ChevronDown, Video, PlayCircle, Filter, Search, LifeBuoy, Keyboard, X } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardContent } from "../../components/ui/card";
 import { YOUTUBE_RESOURCES, VIDEO_CATEGORIES } from '../../data/youtubeResources';
+import { SHORTCUTS_LEGEND } from '../../hooks/useKeyboardShortcuts';
 
 import useAuthStore from "../../store/authStore";
 
@@ -34,6 +35,7 @@ const Help = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
 
     const generateMailto = () => {
         const email = "bonthalamadhavi1@gmail.com";
@@ -312,6 +314,24 @@ ${fullName}`;
                             </div>
                         </div>
 
+                        {/* Keyboard Shortcuts Legend Trigger */}
+                        <button
+                            type="button"
+                            onClick={() => setIsShortcutsOpen(true)}
+                            className="w-full bg-white rounded-3xl p-6 shadow-sm border border-gray-100 flex items-center justify-between text-left hover:border-emerald-200 hover:shadow-md transition-all focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                        >
+                            <div className="flex items-center gap-3">
+                                <div className="p-2 bg-emerald-50 text-emerald-600 rounded-lg">
+                                    <Keyboard size={20} />
+                                </div>
+                                <div>
+                                    <h4 className="font-bold text-gray-900">Keyboard Shortcuts</h4>
+                                    <p className="text-sm text-gray-500 mt-1">Navigate faster across the app</p>
+                                </div>
+                            </div>
+                            <ChevronRight className="w-5 h-5 text-gray-400" />
+                        </button>
+
                         {/* System Status Sidebar Entry */}
                         <div className="bg-white rounded-3xl p-6 shadow-sm border border-gray-100 flex items-center justify-between">
                             <div>
@@ -324,6 +344,49 @@ ${fullName}`;
 
                 </div>
             </main>
+
+            {/* Keyboard Shortcuts Legend Overlay */}
+            {isShortcutsOpen && (
+                <div
+                    className="fixed inset-0 bg-slate-900/70 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-in fade-in duration-200"
+                    onClick={() => setIsShortcutsOpen(false)}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Keyboard shortcuts"
+                >
+                    <div
+                        className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 animate-in zoom-in-95 duration-200"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="flex items-center justify-between mb-5">
+                            <h3 className="text-lg font-bold text-gray-900 flex items-center gap-2">
+                                <Keyboard className="w-5 h-5 text-emerald-600" /> Keyboard Shortcuts
+                            </h3>
+                            <button
+                                type="button"
+                                onClick={() => setIsShortcutsOpen(false)}
+                                className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded-md focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                                aria-label="Close shortcuts legend"
+                            >
+                                <X size={18} />
+                            </button>
+                        </div>
+                        <ul className="divide-y divide-gray-100">
+                            {SHORTCUTS_LEGEND.map(({ combo, description }) => (
+                                <li key={combo} className="flex items-center justify-between py-3">
+                                    <span className="text-sm text-gray-700">{description}</span>
+                                    <kbd className="px-2.5 py-1 text-xs font-semibold text-gray-700 bg-gray-100 border border-gray-200 rounded-md">
+                                        {combo}
+                                    </kbd>
+                                </li>
+                            ))}
+                        </ul>
+                        <p className="mt-5 text-xs text-gray-500">
+                            Tip: shortcuts are disabled while typing in inputs or text areas.
+                        </p>
+                    </div>
+                </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
Closes #640.

Frontend deps not installed. Pre-existing env state; my changes are syntactically clean React code following the file's existing conventions.

## Summary

Added `Frontend/src/hooks/useKeyboardShortcuts.js` — a custom hook that registers a global `keydown` listener, recognizes two-key sequences (`G+D`, `G+T`, `G+U`, `G+A`, `G+P`, `G+S`) within a 1.2s window and navigates via React Router, plus `Ctrl/Cmd+F` to focus the first search input; it ignores keys while typing in inputs/textareas. Wired the hook into `AdminLayout.jsx` so it activates across the admin dashboard, and added a `Keyboard Shortcuts` button in `Help.jsx` that opens a small legend overlay listing every active shortcut (driven by the exported `SHORTCUTS_LEGEND`).

Tests: no test suite detected

---
_Bounty attempt._