### PR TITLE
fix: convert dict entities to text strings for highlights field (Fixes #386)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1852,7 +1852,7 @@ async def analyze_only(request_body: TicketRequest, request: Request):
         image_description=gemini_analysis["image_description"],
         ocr_text=gemini_analysis["ocr_text"],
         image_url=request_body.image_url,
-        highlights=[e.text for e in entities] if entities else [],
+        highlights=[e.get("text", "") for e in entities] if entities else [],
         timeline=timeline,
         env_metadata=env_metadata,
         spam_check=SpamCheck(**spam_result),


### PR DESCRIPTION
## What

The `/ai/analyze` endpoint crashes with a 500 error because the `highlights` field in `TicketResponse` is typed as `list[str]` but receives `list[dict]` objects.

**Root cause:** `ner_service.extract_entities()` returns `list[dict]` with keys `{"text", "label", "confidence"}`. When this list is passed to `highlights=[e.text for e in entities]`, it crashes with `AttributeError: dict object has no attribute text` because the entities variable is still `list[dict]` at that point in the code (it is only converted to `list[EntityInfo]` in the separate `entities=` parameter).

**Fix:** Changed line 1855 from:
```python
highlights=[e.text for e in entities] if entities else []
```
to:
```python
highlights=[e.get("text", "") for e in entities] if entities else []
```

The `analyze_stream()` endpoint already had the correct form (`e.get("text", "")`) on line 2019 — it was only the `analyze_only()` function that had the wrong access pattern.

## Why

Users hitting the `/ai/analyze` endpoint get a 500 error when NER entities are present, making the AI analysis feature completely broken whenever entities are detected. Pydantic v2 cannot coerce `dict` objects into `str`.

## Testing

- When `entities = [{"text": "Python", "label": "tech", "confidence": 0.95}]`, highlights becomes `["Python"]` ✓
- When `entities = []`, highlights becomes `[]` ✓
- When `entities = [{"label": "tech"}]` (missing text key), highlights becomes `[""]` ✓ (graceful fallback)