### PR TITLE
feat: standardize security headers and env-configurable CORS (#637)

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -28,7 +28,7 @@
   <link rel="icon" type="image/png" href="/favicon.png" />
 
   <!-- Security Headers (Content Security Policy) -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://helpdeskaiv1.vercel.app https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; form-action 'self'; base-uri 'self'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' http://localhost:8000 https://ritesh19180-ai-helpdesk-api.hf.space https://helpdeskaiv1.vercel.app https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; form-action 'self'; base-uri 'self'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <meta http-equiv="X-Frame-Options" content="DENY" />
   <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -26,6 +26,12 @@
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="/favicon.png" />
+
+  <!-- Security Headers (Content Security Policy) -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://helpdeskaiv1.vercel.app https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none'; form-action 'self'; base-uri 'self'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
+  <meta http-equiv="X-Frame-Options" content="DENY" />
+  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
 </head>
 
 <body>

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware as _BaseHTTPMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from fastapi.encoders import jsonable_encoder
@@ -756,14 +757,33 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-# CORS — locked to production + local dev only
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
+# Security headers middleware
+class _SecurityHeadersMiddleware(_BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response: Response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
+        return response
+
+app.add_middleware(_SecurityHeadersMiddleware)
+
+# CORS — locked to production + local dev only, configurable via ALLOWED_ORIGINS env
+_cors_origins_raw = os.environ.get("ALLOWED_ORIGINS", "")
+if _cors_origins_raw:
+    _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
+else:
+    _cors_origins = [
         "https://helpdeskaiv1.vercel.app",
         "http://localhost:5173",
         "http://localhost:3000",
-    ],
+    ]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## What

Adds comprehensive HTTP security headers and makes CORS origins configurable via environment variable.

### Backend (FastAPI)
- Added `_SecurityHeadersMiddleware` that sets: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `X-XSS-Protection: 1; mode=block`, `Strict-Transport-Security: max-age=31536000; includeSubDomains`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- Made CORS `allow_origins` configurable via `ALLOWED_ORIGINS` env variable (comma-separated), falling back to the existing hardcoded defaults

### Frontend (Vite)
- Added CSP meta tag: restricts scripts, styles, fonts, connections, frames, and form actions to authorized origins only
- Added `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy` http-equiv meta tags for environments where server-side headers are not set

## Why

Without these protections, the application is vulnerable to:
- Cross-Site Scripting (XSS) via inline script injection
- Clickjacking via iframe embedding
- MIME-type sniffing attacks
- Missing HSTS exposing users to SSL stripping
- CORS being locked to hardcoded values requiring code changes for new deployments

## Testing

- Verified all backend security headers are set via middleware
- Verified CSP meta tags are present in the HTML
- Backend Python syntax verified with ast.parse
- CORS behavior unchanged for default origins; env-based override works when ALLOWED_ORIGINS is set