### PR TITLE
feat: add keyboard shortcuts for rapid admin dashboard navigation (#640)

### DIFF
--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import ShortcutsHelpModal from '../../components/shared/ShortcutsHelpModal';
 
 /**
  * AdminLayout Component
@@ -12,6 +14,14 @@ import NotificationToast from '../../user/components/NotificationToast';
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
+
+    const toggleHelp = useCallback((force) => {
+        setIsShortcutsOpen(prev => force !== undefined ? force : !prev);
+    }, []);
+
+    // Register keyboard shortcuts
+    useKeyboardShortcuts({ onToggleHelp: toggleHelp });
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
@@ -43,6 +53,12 @@ const AdminLayout = () => {
 
             {/* Real-time System Notifications */}
             <NotificationToast />
+
+            {/* Keyboard Shortcuts Help Modal */}
+            <ShortcutsHelpModal
+                isOpen={isShortcutsOpen}
+                onClose={() => setIsShortcutsOpen(false)}
+            />
 
             {/* Mobile Nav Overlay (Emergency protocols) */}
             {isMobileNavOpen && (

--- a/Frontend/src/components/shared/ShortcutsHelpModal.jsx
+++ b/Frontend/src/components/shared/ShortcutsHelpModal.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Keyboard } from 'lucide-react';
+
+const DEFAULT_SHORTCUTS = [
+    { keys: ['G', 'D'], description: 'Go to Dashboard' },
+    { keys: ['G', 'T'], description: 'Go to Tickets' },
+    { keys: ['G', 'A'], description: 'Go to Analytics' },
+    { keys: ['G', 'U'], description: 'Go to Users' },
+    { keys: ['G', 'P'], description: 'Go to Profile' },
+    { keys: ['G', 'S'], description: 'Go to SLA Dashboard' },
+    { separator: true },
+    { keys: ['Ctrl', '/'], description: 'Toggle this help' },
+    { keys: ['Esc'], description: 'Close this help' },
+];
+
+const ShortcutsHelpModal = ({ isOpen, onClose, shortcuts, title }) => {
+    const items = shortcuts || DEFAULT_SHORTCUTS;
+
+    return (
+        <AnimatePresence>
+            {isOpen && (
+                <>
+                    {/* Backdrop */}
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        className="fixed inset-0 bg-black/40 z-40"
+                        onClick={() => onClose()}
+                    />
+
+                    {/* Modal */}
+                    <motion.div
+                        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                        animate={{ opacity: 1, scale: 1, y: 0 }}
+                        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+                        transition={{ duration: 0.15, ease: 'easeOut' }}
+                        className="fixed inset-4 md:inset-auto md:top-1/2 md:left-1/2 md:-translate-x-1/2 md:-translate-y-1/2 md:w-[420px] z-50 bg-white dark:bg-slate-900 rounded-2xl shadow-2xl border border-gray-100 dark:border-slate-700 overflow-hidden"
+                    >
+                        {/* Header */}
+                        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-slate-700">
+                            <div className="flex items-center gap-2">
+                                <Keyboard className="w-4 h-4 text-emerald-500" />
+                                <h2 className="text-sm font-bold text-gray-900 dark:text-white">
+                                    {title || 'Keyboard Shortcuts'}
+                                </h2>
+                            </div>
+                            <button
+                                onClick={() => onClose()}
+                                className="w-7 h-7 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-slate-800 transition-colors"
+                                aria-label="Close shortcuts"
+                            >
+                                <X className="w-4 h-4 text-gray-400" />
+                            </button>
+                        </div>
+
+                        {/* Shortcuts List */}
+                        <div className="px-5 py-4 max-h-[60vh] overflow-y-auto">
+                            {items.map((item, idx) => {
+                                if (item.separator) {
+                                    return <hr key={`sep-${idx}`} className="my-3 border-gray-100 dark:border-slate-700" />;
+                                }
+
+                                const keys = item.keys || [];
+                                return (
+                                    <div
+                                        key={idx}
+                                        className="flex items-center justify-between py-2"
+                                    >
+                                        <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                                            {item.description}
+                                        </span>
+                                        <div className="flex items-center gap-1">
+                                            {keys.map((k, ki) => (
+                                                <React.Fragment key={ki}>
+                                                    {ki > 0 && (
+                                                        <span className="text-xs text-gray-300 dark:text-gray-600 mx-0.5">+</span>
+                                                    )}
+                                                    <kbd className="inline-flex items-center justify-center min-w-[24px] h-[22px] px-1.5 text-[11px] font-bold text-gray-700 dark:text-gray-200 bg-gray-50 dark:bg-slate-800 border border-gray-200 dark:border-slate-600 rounded-md shadow-sm">
+                                                        {k}
+                                                    </kbd>
+                                                </React.Fragment>
+                                            ))}
+                                        </div>
+                                    </div>
+                                );
+                            })}
+                        </div>
+
+                        {/* Footer */}
+                        <div className="px-5 py-3 bg-gray-50 dark:bg-slate-800/50 border-t border-gray-100 dark:border-slate-700">
+                            <p className="text-[10px] text-gray-400 dark:text-gray-500 text-center">
+                                Press <kbd className="inline-flex items-center justify-center px-1 h-[18px] text-[10px] font-bold text-gray-500 bg-gray-100 dark:bg-slate-700 border border-gray-200 dark:border-slate-600 rounded">Ctrl</kbd> + <kbd className="inline-flex items-center justify-center px-1 h-[18px] text-[10px] font-bold text-gray-500 bg-gray-100 dark:bg-slate-700 border border-gray-200 dark:border-slate-600 rounded">/</kbd> anytime to toggle
+                            </p>
+                        </div>
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+};
+
+export default ShortcutsHelpModal;

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,97 @@
+/**
+ * useKeyboardShortcuts — Custom hook for rapid admin dashboard navigation.
+ *
+ * Supported shortcuts:
+ *   G + D  →  Dashboard
+ *   G + T  →  Tickets
+ *   G + A  →  Analytics
+ *   G + U  →  Users / Team
+ *   G + P  →  Profile / Settings
+ *   G + S  →  SLA Dashboard
+ *   Ctrl + /  →  Toggle shortcuts help modal
+ *   Escape  →  Close help modal / go back
+ */
+
+import { useEffect, useCallback, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const NAV_SHORTCUTS = [
+    { keys: ['g', 'd'], path: '/admin', label: 'Dashboard' },
+    { keys: ['g', 't'], path: '/admin/tickets', label: 'Tickets' },
+    { keys: ['g', 'a'], path: '/admin/analytics', label: 'Analytics' },
+    { keys: ['g', 'u'], path: '/admin/users', label: 'Users' },
+    { keys: ['g', 'p'], path: '/admin/profile', label: 'Profile' },
+    { keys: ['g', 's'], path: '/admin/sla', label: 'SLA Dashboard' },
+];
+
+export function useKeyboardShortcuts({
+    enabled = true,
+    onToggleHelp,
+} = {}) {
+    const navigate = useNavigate();
+    const buffer = useRef([]);
+    const bufferTimeout = useRef(null);
+
+    const handleKeyDown = useCallback((e) => {
+        if (!enabled) return;
+
+        // Don't trigger shortcuts when typing in input fields
+        const tag = e.target.tagName;
+        if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag) || e.target.isContentEditable) {
+            return;
+        }
+
+        // Ctrl+/ to toggle help modal
+        if (e.key === '/' && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            onToggleHelp?.();
+            return;
+        }
+
+        // Escape to close help
+        if (e.key === 'Escape') {
+            onToggleHelp?.(false);
+            return;
+        }
+
+        // Two-key sequence navigation
+        if (e.key.length === 1) {
+            const key = e.key.toLowerCase();
+            buffer.current.push(key);
+
+            // Check for matching sequences
+            for (const shortcut of NAV_SHORTCUTS) {
+                const seq = shortcut.keys;
+                if (buffer.current.length >= seq.length) {
+                    const last = buffer.current.slice(-seq.length).join('');
+                    if (last === seq.join('')) {
+                        e.preventDefault();
+                        navigate(shortcut.path);
+                        buffer.current = [];
+                        clearTimeout(bufferTimeout.current);
+                        return;
+                    }
+                }
+            }
+
+            // Clear buffer after 2 seconds of inactivity
+            clearTimeout(bufferTimeout.current);
+            bufferTimeout.current = setTimeout(() => {
+                buffer.current = [];
+            }, 2000);
+        }
+    }, [enabled, navigate, onToggleHelp]);
+
+    useEffect(() => {
+        if (!enabled) return;
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            clearTimeout(bufferTimeout.current);
+        };
+    }, [enabled, handleKeyDown]);
+
+    return {
+        shortcuts: NAV_SHORTCUTS,
+    };
+}


### PR DESCRIPTION
## What

Adds interactive keyboard shortcuts for rapid admin dashboard navigation. Press `G` then a second key to navigate between admin pages without clicking.

### New files:
- `hooks/useKeyboardShortcuts.js` — Custom hook that listens for two-key sequences (G+D, G+T, G+A, etc.) and navigates to the corresponding admin route. Buffer-based approach (2s timeout) so keys dont need to be pressed simultaneously. Also supports `Ctrl+/` to toggle the help modal and `Escape` to close it.
- `components/shared/ShortcutsHelpModal.jsx` — Reusable modal showing all available shortcuts with styled kbd elements. Animated with framer-motion.

### Modified files:
- `admin/layout/AdminLayout.jsx` — Wired the keyboard shortcuts hook and help modal into the admin layout.

### Shortcuts:
- G + D → Dashboard
- G + T → Tickets
- G + A → Analytics
- G + U → Users
- G + P → Profile
- G + S → SLA Dashboard
- Ctrl + / → Toggle help
- Escape → Close help

## Why

Team leads and admins managing large volumes of tickets need to navigate the dashboard rapidly. Keyboard shortcuts eliminate mouse-based navigation for common routes, matching the efficiency expectations of enterprise support tools (like Zendesk, Jira, or Linear).

## Testing

- Manually verified all two-key sequences navigate to correct routes
- Verified Ctrl+/ toggles the help modal
- Verified Escape closes the modal
- Verified shortcuts are disabled when typing in INPUT/TEXTAREA/SELECT fields
- Verified buffer clears after 2 seconds of inactivity (stale sequences dont trigger accidental navigation)