### PR TITLE
feat: add Prometheus HTTP metrics instrumentation and secure /metrics endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
             supabase==2.22.4 \
             apscheduler \
             python-dotenv \
-            prometheus-client
+            prometheus-client \
+            prometheus-fastapi-instrumentator>=6.1.0
 
       - name: Smoke-test backend import (degraded mode allowed)
         env:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -111,3 +111,15 @@ ENV=production
 USE_REDIS_CACHE=false
 REDIS_URL=redis://127.0.0.1:6379/0
 REDIS_CACHE_TTL_SECONDS=3600
+
+
+# -----------------------------------------------------------------------------
+# Prometheus Metrics Endpoint Security (Issue #636)
+# -----------------------------------------------------------------------------
+# Bearer token required to access /metrics (empty = no token check, IP-only).
+# Set this in production to prevent unauthenticated metric scraping.
+METRICS_TOKEN=
+
+# Comma-separated list of IPs/CIDRs allowed to scrape /metrics.
+# Defaults to localhost + private ranges. Set to empty to disable IP filtering.
+METRICS_ALLOWED_IPS=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,8 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest, CollectorRegistry, REGISTRY
+from prometheus_fastapi_instrumentator import Instrumentator
 from fastapi.encoders import jsonable_encoder
 import asyncio
 from pathlib import Path
@@ -770,6 +771,24 @@ app.add_middleware(
 )
 
 app.include_router(auth_cookie_router)
+
+# ---------------------------------------------------------------------------
+# Prometheus HTTP request instrumentation
+# ---------------------------------------------------------------------------
+# Exposes http_request_duration_seconds, http_requests_total, http_requests_in_progress
+METRICS_TOKEN = os.environ.get("METRICS_TOKEN", "")
+METRICS_ALLOWED_IPS = {
+    ip.strip()
+    for ip in os.environ.get("METRICS_ALLOWED_IPS", "127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16").split(",")
+    if ip.strip()
+}
+
+instrumentator = Instrumentator(
+    should_group_status_codes=True,
+    should_group_untemplated=True,
+    excluded_handlers=["/metrics", "/health"],
+)
+instrumentator.instrument(app)
 
 # Translation service routes
 from backend.routes.translation import router as translation_router
@@ -2316,6 +2335,30 @@ async def sla_ticket_detail(ticket_id: str):
 
 
 @app.get("/metrics")
-async def metrics():
-    """Prometheus scrape endpoint — exposes AI inference latency, request counts, and tokens."""
+async def metrics(request: Request):
+    """Prometheus scrape endpoint — exposes HTTP request, AI inference, and system metrics.
+
+    Secured via optional ``METRICS_TOKEN`` bearer token and IP allowlist
+    (``METRICS_ALLOWED_IPS`` env var, defaults to private ranges).
+    """
+    # --- IP allowlist check ---
+    client_ip = request.client.host if request.client else ""
+    if METRICS_ALLOWED_IPS:
+        import ipaddress
+        try:
+            client_addr = ipaddress.ip_address(client_ip)
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Forbidden")
+        allowed = any(
+            client_addr in ipaddress.ip_network(cidr, strict=False)
+            for cidr in METRICS_ALLOWED_IPS
+        )
+        if not allowed:
+            # Fall back to token check if IP not in allowlist
+            auth = request.headers.get("authorization", "")
+            if METRICS_TOKEN and auth == f"Bearer {METRICS_TOKEN}":
+                pass  # Token grants access
+            else:
+                raise HTTPException(status_code=403, detail="Forbidden")
+
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,6 +25,7 @@ httpx
 cryptography>=42.0.0
 websockets>=12.0
 prometheus-client>=0.19.0
+prometheus-fastapi-instrumentator>=6.1.0
 openai-whisper>=20231117
 python-multipart>=0.0.9
 

--- a/deploy/monitoring/grafana_dashboard.json
+++ b/deploy/monitoring/grafana_dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "HELPDESK.AI service telemetry — AI inference latency, API throughput, token counts, and host resources.",
+  "description": "HELPDESK.AI service telemetry — HTTP request latency & throughput, AI inference latency, API throughput, token counts, and host resources.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
@@ -23,6 +23,13 @@
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "title": "HTTP Request Metrics",
+      "type": "row"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -42,7 +49,163 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 0},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "id": 101,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "title": "HTTP Request Latency (p50 / p95 / p99)",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "req/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 102,
+      "options": {
+        "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "title": "HTTP Request Rate (by status code)",
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(http_requests_total[1m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "id": 103,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "title": "HTTP In-Flight Requests",
+      "targets": [
+        {
+          "expr": "http_requests_in_progress",
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "req/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+      "id": 104,
+      "options": {
+        "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "multi"}
+      },
+      "title": "HTTP Request Rate (by handler)",
+      "targets": [
+        {
+          "expr": "sum by (handler) (rate(http_requests_total[1m]))",
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
+      "id": 200,
+      "title": "AI Inference Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "seconds",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
       "id": 1,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -87,7 +250,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 0},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
       "id": 2,
       "options": {
         "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
@@ -122,7 +285,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 9},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 26},
       "id": 3,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -137,6 +300,13 @@
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 34},
+      "id": 300,
+      "title": "Host Resources",
+      "type": "row"
     },
     {
       "datasource": {
@@ -157,7 +327,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 9},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 35},
       "id": 4,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -192,7 +362,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 18},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 35},
       "id": 5,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -212,7 +382,7 @@
   "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["helpdesk-ai", "fastapi", "ai-inference", "prometheus"],
+  "tags": ["helpdesk-ai", "fastapi", "ai-inference", "prometheus", "http-metrics"],
   "templating": {
     "list": [
       {
@@ -236,6 +406,6 @@
   "timezone": "",
   "title": "HELPDESK.AI — Service Telemetry",
   "uid": "helpdesk-ai-telemetry",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deploy/monitoring/prometheus.yml
+++ b/deploy/monitoring/prometheus.yml
@@ -1,0 +1,19 @@
+# prometheus.yml — Example scrape config for HELPDESK.AI
+#
+# Add this job to your existing Prometheus configuration.
+# The /metrics endpoint is secured by IP allowlist (default: private ranges)
+# and optional bearer token (METRICS_TOKEN env var).
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "helpdesk-ai"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["backend:8000"]  # Adjust to your deployment
+    # If METRICS_TOKEN is set, uncomment and configure:
+    # authorization:
+    #   type: Bearer
+    #   credentials: "<your-metrics-token>"


### PR DESCRIPTION
Closes #636

## Summary
Adds production-ready Prometheus metrics instrumentation to the FastAPI backend with secured access control.

## Changes

### 1. HTTP Request Instrumentation
- Integrated  to automatically track:
  -  — request latency histogram (p50/p95/p99)
  -  — request count by status code and handler
  -  — currently in-flight requests

### 2. /metrics Endpoint Security
- **IP allowlist**: defaults to private ranges (127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
- **Bearer token**: optional  env var for additional auth
- External requests without valid IP or token get 403 Forbidden

### 3. Grafana Dashboard Enhancement
- Added HTTP Request Metrics row with 4 new panels:
  - HTTP Request Latency (p50/p95/p99)
  - HTTP Request Rate by status code
  - HTTP In-Flight Requests
  - HTTP Request Rate by handler
- Organized panels into collapsible sections (HTTP / AI Inference / Host Resources)

### 4. Configuration
- Added  and  to 
- Added  scrape config example in 

## Testing
- Verify  returns 200 from localhost (default IP allowlist)
- Verify  returns 403 from external IPs without token
- Verify  bearer auth works for external scrapers
- Check Prometheus can scrape the new HTTP request metrics