### PR TITLE
fix: BackToTop button retains hover state after scroll-to-top and remount (Fixes #600)

### DIFF
--- a/Frontend/src/components/shared/BackToTop.jsx
+++ b/Frontend/src/components/shared/BackToTop.jsx
@@ -1,34 +1,36 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowUp } from 'lucide-react';
 
 const BackToTop = () => {
     const [isVisible, setIsVisible] = useState(false);
+    const visibilityCount = useRef(0);
 
     useEffect(() => {
         const toggleVisibility = () => {
-            if (window.scrollY > 300) {
-                setIsVisible(true);
-            } else {
-                setIsVisible(false);
+            const shouldShow = window.scrollY > 300;
+            if (shouldShow && !isVisible) {
+                visibilityCount.current += 1;
             }
+            setIsVisible(shouldShow);
         };
 
         window.addEventListener('scroll', toggleVisibility);
         return () => window.removeEventListener('scroll', toggleVisibility);
-    }, []);
+    }, [isVisible]);
 
-    const scrollToTop = () => {
+    const scrollToTop = useCallback(() => {
         window.scrollTo({
             top: 0,
             behavior: 'smooth'
         });
-    };
+    }, []);
 
     return (
-        <AnimatePresence>
+        <AnimatePresence mode="wait">
             {isVisible && (
                 <motion.button
+                    key={`backtotop-${visibilityCount.current}`}
                     initial={{ opacity: 0, scale: 0.8, y: 10 }}
                     animate={{ opacity: 1, scale: 1, y: 0 }}
                     exit={{ opacity: 0, scale: 0.8, y: 10 }}


### PR DESCRIPTION
## What

The BackToTop button uses framer-motion `<AnimatePresence>` which unmounts the component when scrolling to top. When the user scrolls down again and the button remounts, the previous `whileHover` animation state persists, causing the hover label and tilted chevron to appear without hovering.

The fix introduces a visibility counter as a React `key` prop on the `motion.button`. Each time the button transitions from hidden → visible, it gets a unique key, forcing a completely fresh component mount with no leftover animation state.

## Why

Users scrolling down after using BackToTop see the button in a hovered state (label visible, chevron tilted) without actually hovering over it. This is visually confusing and makes the UI feel broken.

## Testing

1. Scroll down past 400px on any page
2. Hover over the BackToTop button (hover label + tilt appears)
3. Click the button — page scrolls to top, button hides
4. Scroll down again past 400px
5. **Expected:** Button reappears in default state (no label, no tilt)
6. **Hover should still work normally** — label and tilt appear only on actual mouse hover