### PR TITLE
feat: add interactive keyboard shortcuts for rapid admin dashboard navigation (Fixes #640)

### DIFF
--- a/Frontend/src/admin/components/KeyboardShortcutsHelp.jsx
+++ b/Frontend/src/admin/components/KeyboardShortcutsHelp.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { X, Keyboard } from 'lucide-react';
+
+const SHORTCUTS = [
+    { keys: ['G', 'D'], label: 'Go to Dashboard' },
+    { keys: ['G', 'T'], label: 'Go to Tickets' },
+    { keys: ['G', 'U'], label: 'Go to Users' },
+    { keys: ['G', 'A'], label: 'Go to Analytics' },
+    { keys: ['G', 'S'], label: 'Go to Settings' },
+    { keys: ['G', 'P'], label: 'Go to Profile' },
+    { keys: ['G', 'L'], label: 'Go to SLA Monitor' },
+    { keys: ['?'], label: 'Toggle this shortcuts menu' },
+];
+
+const Kbd = ({ children }) => (
+    <kbd className="inline-flex items-center justify-center min-w-[28px] h-7 px-2 rounded-md border border-gray-300 bg-gray-100 text-xs font-bold text-gray-700 shadow-sm font-mono">
+        {children}
+    </kbd>
+);
+
+const KeyboardShortcutsHelp = ({ isOpen, onClose }) => {
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+            onClick={onClose}
+        >
+            <div
+                className="bg-white rounded-2xl shadow-2xl border border-gray-200 w-full max-w-md mx-4 overflow-hidden"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                    <div className="flex items-center gap-3">
+                        <Keyboard className="w-5 h-5 text-emerald-600" />
+                        <h2 className="text-lg font-bold text-gray-900">Keyboard Shortcuts</h2>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+                        aria-label="Close shortcuts"
+                    >
+                        <X className="w-5 h-5" />
+                    </button>
+                </div>
+
+                {/* Shortcuts List */}
+                <div className="px-6 py-4 space-y-3">
+                    {SHORTCUTS.map((shortcut, index) => (
+                        <div key={index} className="flex items-center justify-between">
+                            <span className="text-sm text-gray-700">{shortcut.label}</span>
+                            <div className="flex items-center gap-1.5">
+                                {shortcut.keys.map((key, ki) => (
+                                    <React.Fragment key={ki}>
+                                        {ki > 0 && <span className="text-xs text-gray-400 mx-0.5">then</span>}
+                                        <Kbd>{key}</Kbd>
+                                    </React.Fragment>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Footer */}
+                <div className="px-6 py-3 bg-gray-50 border-t border-gray-100">
+                    <p className="text-xs text-gray-500">
+                        Press <Kbd>?</Kbd> to toggle this menu at any time.
+                        Shortcuts work on admin pages only.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default KeyboardShortcutsHelp;

--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -3,6 +3,8 @@ import { Outlet } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import useKeyboardShortcuts from '../../hooks/useKeyboardShortcuts';
+import KeyboardShortcutsHelp from '../components/KeyboardShortcutsHelp';
 
 /**
  * AdminLayout Component
@@ -12,6 +14,13 @@ import NotificationToast from '../../user/components/NotificationToast';
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const [showShortcuts, setShowShortcuts] = useState(false);
+
+    // Activate keyboard shortcuts for the admin dashboard
+    useKeyboardShortcuts({
+        enabled: true,
+        onHelpToggle: () => setShowShortcuts(prev => !prev),
+    });
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
@@ -43,6 +52,9 @@ const AdminLayout = () => {
 
             {/* Real-time System Notifications */}
             <NotificationToast />
+
+            {/* Keyboard Shortcuts Help Overlay */}
+            <KeyboardShortcutsHelp isOpen={showShortcuts} onClose={() => setShowShortcuts(false)} />
 
             {/* Mobile Nav Overlay (Emergency protocols) */}
             {isMobileNavOpen && (

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,78 @@
+import { useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * useKeyboardShortcuts — Registers global keyboard shortcut listeners
+ * for rapid admin dashboard navigation.
+ *
+ * Shortcut map:
+ *   G then D  → /admin/dashboard
+ *   G then T  → /admin/tickets
+ *   G then U  → /admin/users
+ *   G then A  → /admin/analytics
+ *   G then S  → /admin/settings
+ *   G then P  → /admin/profile
+ *   G then L  → /admin/sla
+ *   ?        → toggle shortcuts help overlay
+ */
+const DEFAULT_SHORTCUTS = {
+    'd': '/admin/dashboard',
+    't': '/admin/tickets',
+    'u': '/admin/users',
+    'a': '/admin/analytics',
+    's': '/admin/settings',
+    'p': '/admin/profile',
+    'l': '/admin/sla',
+};
+
+const useKeyboardShortcuts = ({ enabled = true, onHelpToggle } = {}) => {
+    const navigate = useNavigate();
+
+    const handleKeyDown = useCallback((e) => {
+        if (!enabled) return;
+
+        // Ignore typing in input/textarea/select elements
+        const tag = e.target.tagName.toLowerCase();
+        if (tag === 'input' || tag === 'textarea' || tag === 'select' || e.target.isContentEditable) {
+            return;
+        }
+
+        // '?' toggles the help overlay
+        if (e.key === '?' && !e.shiftKey === false) {
+            // Shift+/ = ?
+            e.preventDefault();
+            if (onHelpToggle) onHelpToggle();
+            return;
+        }
+
+        // G-prefix shortcuts: G then [key] within 1 second
+        if (e.key === 'g' || e.key === 'G') {
+            window.__gKeyPressed = Date.now();
+            return;
+        }
+
+        // If G was pressed within the last second, check for a matching route key
+        if (window.__gKeyPressed && (Date.now() - window.__gKeyPressed) < 1000) {
+            const key = e.key.toLowerCase();
+            const path = DEFAULT_SHORTCUTS[key];
+            if (path) {
+                e.preventDefault();
+                window.__gKeyPressed = null;
+                navigate(path);
+                return;
+            }
+        }
+    }, [enabled, navigate, onHelpToggle]);
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            window.__gKeyPressed = null;
+        };
+    }, [enabled, handleKeyDown]);
+};
+
+export default useKeyboardShortcuts;


### PR DESCRIPTION
## What

Adds keyboard-driven navigation for the admin dashboard with a shortcuts help overlay.

**New files:**
- `Frontend/src/hooks/useKeyboardShortcuts.js` — custom hook that listens for `G + [key]` combinations and `?` to toggle the help menu
- `Frontend/src/admin/components/KeyboardShortcutsHelp.jsx` — modal overlay listing all available shortcuts

**Modified files:**
- `Frontend/src/admin/layout/AdminLayout.jsx` — integrates the hook and help modal

**Shortcut map:**
| Keys | Action |
|------|--------|
| `G` then `D` | Go to Dashboard |
| `G` then `T` | Go to Tickets |
| `G` then `U` | Go to Users |
| `G` then `A` | Go to Analytics |
| `G` then `S` | Go to Settings |
| `G` then `P` | Go to Profile |
| `G` then `L` | Go to SLA Monitor |
| `?` | Toggle shortcuts help |

## Why

Support team leads and administrators need to navigate the dashboard quickly without relying solely on mouse clicks. Keyboard shortcuts (`G + T` for tickets, `G + D` for dashboard, etc.) dramatically speed up common workflows like triaging tickets and monitoring SLA breaches.

## Testing

1. Navigate to any admin page (/admin/dashboard, /admin/tickets, etc.)
2. Press `?` — the shortcuts help modal should appear
3. Press `?` again — the modal should close
4. Press `G` then `T` — should navigate to /admin/tickets
5. Press `G` then `D` — should navigate to /admin/dashboard
6. Verify shortcuts do NOT fire when focused in an input/textarea field
7. Verify shortcuts do NOT fire on user-facing routes (non-admin pages)