### PR TITLE
fix(#545): require authentication on SLA ticket endpoints and enforce company scope

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2069,7 +2069,7 @@ class SLAStatsResponse(BaseModel):
 
 
 @app.get("/sla/stats", response_model=SLAStatsResponse)
-async def sla_stats():
+async def sla_stats(current_user: dict = Depends(get_current_user)):
     """Get aggregated SLA dashboard statistics across all tickets."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
@@ -2102,18 +2102,27 @@ async def sla_tickets(
     priority: str | None = None,
     limit: int = 100,
     offset: int = 0,
+    current_user: dict = Depends(get_current_user),
 ):
     """
-    List tickets with SLA status. Filter by sla_status and/or priority.
+    List tickets with SLA status. Requires authentication.
+    Results are scoped to the caller's company unless the caller has a master admin role.
+    Filter by sla_status and/or priority.
     """
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
+
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile)
 
     query = (
         supabase.table("tickets")
         .select("id, ticket_id, subject, summary, priority, status, assigned_team, sla_status, escalation_level, remaining_seconds, created_at, sla_breach_at, sla_warning_at, last_escalated_at")
         .order("created_at", desc=True)
     )
+
+    if company_scope:
+        query = query.eq("company_id", company_scope)
 
     if status and status != "all":
         query = query.eq("sla_status", status)
@@ -2141,8 +2150,12 @@ class EscalationLogEntry(BaseModel):
 
 
 @app.get("/sla/escalations")
-async def sla_escalations(limit: int = 50, offset: int = 0):
-    """Fetch escalation log history."""
+async def sla_escalations(
+    limit: int = 50,
+    offset: int = 0,
+    current_user: dict = Depends(get_current_user),
+):
+    """Fetch escalation log history. Requires authentication."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
 
@@ -2281,8 +2294,11 @@ async def update_system_settings(body: dict):
 
 
 @app.get("/sla/tickets/{ticket_id}")
-async def sla_ticket_detail(ticket_id: str):
-    """Get detailed SLA info for a specific ticket."""
+async def sla_ticket_detail(
+    ticket_id: str,
+    current_user: dict = Depends(get_current_user),
+):
+    """Get detailed SLA info for a specific ticket. Requires authentication."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
 
@@ -2292,6 +2308,14 @@ async def sla_ticket_detail(ticket_id: str):
         raise HTTPException(status_code=404, detail="Ticket not found")
 
     ticket = res.data
+
+    # Enforce company-level authorization so callers cannot view tickets from
+    # other tenants by guessing or iterating ticket IDs.
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile)
+    if company_scope and ticket.get("company_id") != company_scope:
+        raise HTTPException(status_code=403, detail="User not authorized for this tenant")
+
     result = sla_engine.evaluate_ticket(ticket)
 
     # Fetch escalation history for this ticket


### PR DESCRIPTION
## Related Issue

Closes #545

## Description

The SLA ticket endpoints queried Supabase and returned full ticket records with no authentication check. Any unauthenticated HTTP client could enumerate the entire ticket database, fetch individual tickets by ID, and read SLA escalation history.

Affected endpoints before this fix:
- `GET /sla/tickets` — returned all tickets in the system
- `GET /sla/tickets/{ticket_id}` — returned full ticket details for any ID
- `GET /sla/escalations` — returned escalation log history
- `GET /sla/stats` — returned aggregated SLA statistics

All four endpoints now require a valid session via `Depends(get_current_user)`.

`GET /sla/tickets` and `GET /sla/tickets/{ticket_id}` additionally enforce company-level tenant scoping through the existing `_ticket_company_scope()` helper so users can only read tickets belonging to their own company. Master admin roles retain cross-tenant access.

## Type of Change

- [x] Bug fix

## Testing Done

- [x] Unauthenticated requests to `GET /sla/tickets` now return `401 Not authenticated`
- [x] Authenticated requests scoped to `company_id` only return tickets for that company
- [x] `GET /sla/tickets/{ticket_id}` returns `403` when a ticket belongs to a different tenant
- [x] Master admin callers can still access tickets across tenants
- [x] No new warnings or errors introduced
- [x] Existing functionality for authenticated users is unchanged

## Checklist

- [x] My code follows the project guidelines
- [x] I reviewed my own changes
- [x] I linked the related issue
- [x] This PR targets the `gssoc` branch