### PR TITLE
fix : added language validation in translation_service.py

### DIFF
--- a/backend/services/translation_service.py
+++ b/backend/services/translation_service.py
@@ -98,6 +98,16 @@ def translate_text(
     if not text or not text.strip():
         return {"translated": "", "source_lang": source_lang, "target_lang": target_lang, "cached": False}
 
+    # Validate target language is supported
+    if target_lang not in SUPPORTED_LANGUAGES:
+        return {
+            "translated": text,
+            "source_lang": source_lang,
+            "target_lang": target_lang,
+            "cached": False,
+            "error": "unsupported_language",
+        }
+
     # Truncate very long text
     if len(text) > MAX_TEXT_LENGTH:
         text = text[:MAX_TEXT_LENGTH] + "..."


### PR DESCRIPTION
Refs #698.

Summary of What Has Been Done:
Added validation to check if target_lang exists in SUPPORTED_LANGUAGES before attempting translation.

Changes Made:
- Modified backend/services/translation_service.py translate_text function
- Added early validation that target_lang is in SUPPORTED_LANGUAGES
- Return error dict with 'error' key set to 'unsupported_language' when invalid language is provided
- Keeps backward compatibility with existing behavior for valid languages

Impact it Made:
- Fail fast with clear error for unsupported languages
- Helps developers catch configuration errors early
- Prevents silent failures that are hard to debug