### PR TITLE
fix : added null-check for whisper model in voice health endpoint

### DIFF
--- a/backend/routes/voice.py
+++ b/backend/routes/voice.py
@@ -152,6 +152,12 @@ async def voice_health():
             "model_loaded": False,
             "message": "Whisper package not installed.",
         }
+    except AttributeError:
+        return {
+            "status": "unavailable",
+            "model_loaded": False,
+            "message": "Whisper model not available.",
+        }
 
 
 def _extract_title(text: str, max_length: int = 80) -> str:


### PR DESCRIPTION
Refs #700.

Summary of What Has Been Done:
Added AttributeError handling to the voice_health endpoint to prevent errors when Whisper model is not loaded.

Changes Made:
- Modified backend/routes/voice.py voice_health function
- Added except AttributeError block to handle case when _whisper_model doesn't exist
- Returns appropriate status indicating model unavailability

Impact it Made:
- Prevents 500 errors when voice service is not fully configured
- Provides clear health status for monitoring
- Improves reliability of voice API endpoints