### PR TITLE
fix : added priority validation in SLA prediction service

### DIFF
--- a/backend/services/sla_prediction_service.py
+++ b/backend/services/sla_prediction_service.py
@@ -87,6 +87,11 @@ class SLAPredictionService:
         now = now or _utcnow()
         created = _parse_iso(created_at)
 
+        if priority not in DEFAULT_SLA_HOURS:
+            raise ValueError(
+                f"Invalid priority '{priority}'. Must be one of: {', '.join(DEFAULT_SLA_HOURS.keys())}"
+            )
+
         sla_hours = DEFAULT_SLA_HOURS.get(priority, 72)
         if sla_breach_at:
             breach_dt = _parse_iso(sla_breach_at)


### PR DESCRIPTION
Refs #704.

Summary of What Has Been Done:
Added validation to check that priority is in DEFAULT_SLA_HOURS keys before processing in the SLA prediction service.

Changes Made:
- Modified backend/services/sla_prediction_service.py predict method
- Added ValueError raise for invalid priority values
- Provides clear error message listing valid priorities

Impact it Made:
- Fail fast for invalid priority values
- Helps catch configuration errors early
- Makes behavior explicit rather than silently using defaults
- Improves debuggability