### PR TITLE
fix: add proper type annotation for threshold parameter in duplicate_service.py

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -97,7 +97,7 @@ class DuplicateService:
         self._tickets.append((ticket_id, embedding, text))
         self.save_to_disk(ticket_id, text)
 
-    def check_duplicate(self, text: str, threshold: float = None) -> dict:
+    def check_duplicate(self, text: str, threshold: float | None = None) -> dict:
         """
         Check if a ticket is a duplicate of any stored ticket.
 


### PR DESCRIPTION
## Summary
- Changed `threshold: float = None` to `threshold: float | None = None` in `check_duplicate` method

## Refs
Refs #715