### PR TITLE
Fix: Incorrect type annotation for threshold parameter in duplicate_service

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -97,7 +97,7 @@ class DuplicateService:
         self._tickets.append((ticket_id, embedding, text))
         self.save_to_disk(ticket_id, text)
 
-    def check_duplicate(self, text: str, threshold: float = None) -> dict:
+    def check_duplicate(self, text: str, threshold: float | None = None) -> dict:
         """
         Check if a ticket is a duplicate of any stored ticket.
 


### PR DESCRIPTION
Closes #715

**Root cause**: \check_duplicate\ signature had \	hreshold: float = None\, which is a type error since \None\ is not a valid \loat\.

**Fix**: Changed to \	hreshold: float | None = None\ to properly reflect the optional parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code type consistency for better code quality and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->