### PR TITLE
Fix: analyzeTicket defined inside useEffect creates new function on every render

### DIFF
--- a/Frontend/src/user/pages/AIProcessing.jsx
+++ b/Frontend/src/user/pages/AIProcessing.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useNavigate, useLocation } from 'react-router-dom';
 
@@ -32,18 +32,8 @@ const AIProcessing = () => {
     const hasCalledAPI = useRef(false);
     const [activeStep, setActiveStep] = useState(0);
 
-    useEffect(() => {
-        if (!text) {
-            console.warn("[AIProcessing] No ticket text found. Redirecting to /create-ticket");
-            navigate('/create-ticket');
-            return;
-        }
-
-        if (hasCalledAPI.current) return;
-        hasCalledAPI.current = true;
-
-        const analyzeTicket = async () => {
-            console.log("[AIProcessing] Starting analysis for:", text);
+    const analyzeTicket = useCallback(async () => {
+        console.log("[AIProcessing] Starting analysis for:", text);
 
             try {
 
@@ -377,12 +367,20 @@ const AIProcessing = () => {
                     navigate('/create-ticket');
                 }
             }
-        };
+    }, [text, image_text, image_base64, navigate, setAITicket, settings, user, profile, showToast, template_id, template_used, user_modified, ticket_title]);
+
+    useEffect(() => {
+        if (!text) {
+            console.warn("[AIProcessing] No ticket text found. Redirecting to /create-ticket");
+            navigate('/create-ticket');
+            return;
+        }
+
+        if (hasCalledAPI.current) return;
+        hasCalledAPI.current = true;
 
         analyzeTicket();
-
-     
-    }, [text, image_text, image_base64, navigate, setAITicket, settings, user, profile]);
+    }, [text, navigate, analyzeTicket]);
 
 
   


### PR DESCRIPTION
Closes #720

**Root cause**: \nalyzeTicket\ was defined as an inline function inside a \useEffect\ callback. On every render where dependencies changed, a new function instance was created.

**Fix**: Moved \nalyzeTicket\ outside the \useEffect\ and wrapped it in \useCallback\ with all dependencies listed. The \useEffect\ now only depends on \	ext\, \
avigate\, and the stable \nalyzeTicket\ reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized component performance through improved state management patterns to prevent unnecessary re-renders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->