### PR TITLE
[Frontend] Add axios auth interceptor to inject Supabase tokens on all API calls

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,7 +1,6 @@
-import axios from 'axios';
+import apiClient from './apiClient';
 import { MOCK_TICKETS } from './mockData';
 import { API_CONFIG } from '../config';
-import { supabase } from '../lib/supabaseClient';
 
 const USE_MOCK = API_CONFIG.USE_MOCK;
 const API_BASE_URL = API_CONFIG.BACKEND_URL;
@@ -70,7 +69,7 @@ export const api = {
       return getStorage('tickets', MOCK_TICKETS);
     }
     try {
-      const response = await axios.get(`${API_BASE_URL}/tickets`);
+      const response = await apiClient.get(`/tickets`);
       const data = response?.data;
 
       // Normalize to the mock shape: an array of tickets
@@ -92,7 +91,7 @@ export const api = {
       return createTicketMock(ticketData);
     }
     try {
-      const response = await axios.post(`${API_BASE_URL}/tickets/save`, ticketData);
+      const response = await apiClient.post(`/tickets/save`, ticketData);
       const created = response?.data;
 
       // Normalize to mock shape: { data: <createdTicket> }
@@ -109,7 +108,7 @@ export const api = {
     try {
       const currentUser = JSON.parse(sessionStorage.getItem("currentUser") || "{}");
       // ALWAYS call the real backend for prediction if possible
-      const response = await axios.post(`${API_BASE_URL}/ai/analyze_ticket`, {
+      const response = await apiClient.post(`/ai/analyze_ticket`, {
         text: issueText,
         image_base64: imageBase64,
         image_text: "",
@@ -153,7 +152,7 @@ export const api = {
 
   getSlaEstimate: async (ticketId) => {
     try {
-      const response = await axios.get(`${API_BASE_URL}/tickets/${ticketId}/sla-estimate`);
+      const response = await apiClient.get(`/tickets/${ticketId}/sla-estimate`);
       return response.data;
     } catch (error) {
       console.error(`[SLA Estimate Error] Failed to fetch for ${ticketId}:`, error);
@@ -163,13 +162,8 @@ export const api = {
 
   logCorrection: async (correctionPayload) => {
     try {
-      const { data: { session } } = await supabase.auth.getSession();
-      const token = session?.access_token;
-      await axios.post(`${API_BASE_URL}/ai/log_correction`, correctionPayload, {
-        headers: token ? { Authorization: `Bearer ${token}` } : {}
-      });
+      await apiClient.post(`/ai/log_correction`, correctionPayload);
     } catch (error) {
-      // Non-fatal: log but don't break the UI flow
       console.warn("[Correction Log] Failed to save correction:", error);
     }
   }

--- a/Frontend/src/services/apiClient.js
+++ b/Frontend/src/services/apiClient.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { supabase } from '../lib/supabaseClient';
+import { API_CONFIG } from '../config';
+
+const apiClient = axios.create({
+  baseURL: API_CONFIG.BACKEND_URL,
+  withCredentials: true,
+  headers: { 'Content-Type': 'application/json' },
+});
+
+apiClient.interceptors.request.use(async (config) => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (session?.access_token) {
+    config.headers.Authorization = `Bearer ${session.access_token}`;
+  }
+  return config;
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error.response?.status === 401) {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session?.refresh_token) {
+        try {
+          const { data } = await supabase.auth.refreshSession();
+          if (data?.session?.access_token) {
+            error.config.headers.Authorization = `Bearer ${data.session.access_token}`;
+            return apiClient(error.config);
+          }
+        } catch {
+        }
+      }
+      window.dispatchEvent(new CustomEvent('auth:session-expired'));
+    }
+    if (error.response?.status === 403) {
+      window.dispatchEvent(new CustomEvent('auth:forbidden', {
+        detail: { message: error.response?.data?.detail || 'Access denied' },
+      }));
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;


### PR DESCRIPTION
## Description
The backend recently enforced authentication on 18 API endpoints. The frontend was using bare axios calls without any auth headers — every backend-dependent feature would return 401.

This PR adds a centralized axios instance (\piClient.js\) with:
- **Request interceptor**: automatically reads the Supabase session and attaches \Authorization: Bearer <token>\ to every outgoing request
- **Response interceptor**: on 401, attempts automatic token refresh via \supabase.auth.refreshSession()\; if refresh fails, dispatches \uth:session-expired\ event
- **403 handling**: dispatches \uth:forbidden\ event with the server's detail message

Also cleaned up the manual Bearer header handling in \logCorrection\ — the interceptor now handles it globally.

## Changes
- \Frontend/src/services/apiClient.js\ — **NEW** configured axios instance
- \Frontend/src/services/api.js\ — replaced \xios.get/post\ with \piClient.get/post\, removed manual token handling

## Related
Closes #749