### PR TITLE
feat: add React ErrorBoundary for graceful error recovery

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -6,6 +6,7 @@ import {
   useLocation
 } from "react-router-dom";
 import React, { useEffect } from "react";
+import ErrorBoundary from "./components/shared/ErrorBoundary";
 import { AnimatePresence } from "framer-motion";
 import { NotFound } from "./components/ui/not-found-2";
 import useTicketStore from "./store/ticketStore";
@@ -248,9 +249,10 @@ function App() {
     <BrowserRouter>
       <TitleUpdater />
       <ScrollToTop />
-      <Toaster />
-      <BugReportWidget />
-      <Routes>
+      <ErrorBoundary>
+        <Toaster />
+        <BugReportWidget />
+        <Routes>
         {/* Public */}
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<Login />} />
@@ -295,9 +297,14 @@ function App() {
 
         {/* Protected */}
         <Route element={<ProtectedRoute />}>
-          <Route path="/*" element={<AppLayout />} />
+          <Route path="/*" element={
+            <ErrorBoundary>
+              <AppLayout />
+            </ErrorBoundary>
+          } />
         </Route>
-      </Routes>
+        </Routes>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/Frontend/src/components/shared/ErrorBoundary.jsx
+++ b/Frontend/src/components/shared/ErrorBoundary.jsx
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null, errorInfo: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ errorInfo });
+    // Log to console in development
+    if (import.meta.env.DEV) {
+      console.error('[ErrorBoundary] Caught error:', error, errorInfo);
+    }
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  };
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback({
+          error: this.state.error,
+          retry: this.handleRetry,
+          reload: this.handleReload,
+        });
+      }
+
+      return (
+        <div className="flex min-h-[60vh] items-center justify-center px-6 py-16">
+          <div className="max-w-md rounded-2xl border border-red-200 bg-white p-8 text-center shadow-sm">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <svg
+                className="h-6 w-6 text-red-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+                />
+              </svg>
+            </div>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">
+              Something went wrong
+            </h2>
+            <p className="mb-6 text-sm text-slate-500">
+              An unexpected error occurred while loading this section. You can
+              try again or reload the page.
+            </p>
+            <div className="flex justify-center gap-3">
+              <button
+                onClick={this.handleRetry}
+                className="rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200"
+              >
+                Try Again
+              </button>
+              <button
+                onClick={this.handleReload}
+                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+              >
+                Reload Page
+              </button>
+            </div>
+            {import.meta.env.DEV && this.state.errorInfo && (
+              <details className="mt-4 text-left">
+                <summary className="cursor-pointer text-xs text-slate-400">
+                  Error Details (dev only)
+                </summary>
+                <pre className="mt-2 max-h-40 overflow-auto rounded bg-slate-50 p-2 text-xs text-red-600">
+                  {this.state.error?.toString()}
+                  {'\n'}
+                  {this.state.errorInfo.componentStack}
+                </pre>
+              </details>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/Frontend/src/components/shared/ErrorBoundary.jsx
+++ b/Frontend/src/components/shared/ErrorBoundary.jsx
@@ -12,9 +12,23 @@ class ErrorBoundary extends Component {
 
   componentDidCatch(error, errorInfo) {
     this.setState({ errorInfo });
-    // Log to console in development
+    // Log to console in development, report to monitoring in production
     if (import.meta.env.DEV) {
       console.error('[ErrorBoundary] Caught error:', error, errorInfo);
+    } else {
+      // Production: report to monitoring endpoint (non-blocking)
+      try {
+        fetch('/api/error-report', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message: error?.message,
+            componentStack: errorInfo?.componentStack,
+            url: window.location.href,
+            timestamp: new Date().toISOString(),
+          }),
+        }).catch(() => {}); // Silently ignore report failures
+      } catch (_) {} // Never let reporting break the error boundary
     }
   }
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,10 +39,13 @@ class FakeTable:
 
     def insert(self, payload):
         rows = payload if isinstance(payload, list) else [payload]
+        existing = self.db.setdefault(self.name, [])
         for r in rows:
             if "id" not in r:
-                r["id"] = len(self.db.get(self.name, [])) + 1
-        self.db.setdefault(self.name, []).extend(rows)
+                r["id"] = len(existing) + 1
+                existing.append(r)
+            else:
+                existing.append(r)
         self.inserted_rows = rows
         return self
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,354 @@
+import os
+import sys
+import types
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Force test environment variables before anything is imported
+os.environ["ALLOW_DEGRADED_STARTUP"] = "1"
+os.environ["SUPABASE_URL"] = "https://mock.supabase.co"
+os.environ["SUPABASE_SERVICE_KEY"] = "mockservicekey"
+os.environ["SLA_ESCALATION_ENABLED"] = "false"
+
+# Ensure root directory is in python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+class FakeResult:
+    def __init__(self, data=None):
+        self.data = data or []
+
+
+class FakeTable:
+    def __init__(self, db, name):
+        self.db = db
+        self.name = name
+        self.filters = {}
+        self.payload = None
+        self.limit_count = None
+        self.is_single = False
+        self.order_field = None
+        self.order_desc = False
+
+    def select(self, *_args):
+        return self
+
+    def update(self, payload):
+        self.payload = payload
+        return self
+
+    def insert(self, payload):
+        rows = payload if isinstance(payload, list) else [payload]
+        for r in rows:
+            if "id" not in r:
+                r["id"] = len(self.db.get(self.name, [])) + 1
+        self.db.setdefault(self.name, []).extend(rows)
+        self.inserted_rows = rows
+        return self
+
+    def eq(self, field, value):
+        self.filters[field] = value
+        return self
+
+    def order(self, field, desc=False):
+        self.order_field = field
+        self.order_desc = desc
+        return self
+
+    def limit(self, value):
+        self.limit_count = value
+        return self
+
+    def single(self):
+        self.is_single = True
+        return self
+
+    def execute(self):
+        if hasattr(self, "inserted_rows"):
+            return FakeResult(self.inserted_rows)
+
+        def _safe_eq(v1, v2):
+            if v1 == v2:
+                return True
+            if v1 is None or v2 is None:
+                return False
+            if isinstance(v1, int) and isinstance(v2, str):
+                try:
+                    return v1 == int(v2)
+                except ValueError:
+                    return False
+            if isinstance(v1, str) and isinstance(v2, int):
+                try:
+                    return int(v1) == v2
+                except ValueError:
+                    return False
+            return False
+
+        if self.payload is not None:
+            rows = self.db.setdefault(self.name, [])
+            updated_rows = []
+            for row in rows:
+                match = True
+                for k, v in self.filters.items():
+                    if not _safe_eq(row.get(k), v):
+                        match = False
+                        break
+                if match:
+                    row.update(self.payload)
+                    updated_rows.append(row)
+            return FakeResult(updated_rows)
+
+        rows = list(self.db.get(self.name, []))
+        for key, value in self.filters.items():
+            rows = [row for row in rows if _safe_eq(row.get(key), value)]
+
+        if self.order_field:
+            rows.sort(key=lambda x: x.get(self.order_field, ""), reverse=self.order_desc)
+
+        if self.limit_count is not None:
+            rows = rows[:self.limit_count]
+
+        if self.is_single:
+            return FakeResult(rows[0] if rows else None)
+        return FakeResult(rows)
+
+
+class FakeSupabase:
+    def __init__(self, db):
+        self.db = db
+
+    def table(self, name):
+        return FakeTable(self.db, name)
+
+    def rpc(self, name, params):
+        # Mock simple search matching logic
+        query = params.get("query_text", "").lower()
+        company_id = params.get("company_id")
+        
+        matching = []
+        tickets = self.db.get("tickets", [])
+        for t in tickets:
+            if company_id and t.get("company_id") != company_id:
+                continue
+            if query in str(t.get("subject", "")).lower() or query in str(t.get("description", "")).lower():
+                matching.append(t)
+        
+        class RpcMock:
+            def execute(self):
+                return FakeResult(matching)
+        return RpcMock()
+
+
+def _make_stub_module(name, attrs):
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _install_optional_ml_stubs():
+    # Provide import-safe stand-ins for optional ML modules used by backend.main.
+    class _BaseStub:
+        def __init__(self):
+            self._loaded = True
+
+        def load(self):
+            self._loaded = True
+
+    class _ClassifierStub(_BaseStub):
+        def predict(self, _text):
+            return {
+                "category": "Software",
+                "subcategory": "Software Install",
+                "priority": "Medium",
+                "auto_resolve": True,
+                "assigned_team": "Application Support",
+                "confidence": 0.95,
+            }
+
+    class _ClassifierV3Stub:
+        def predict(self, _text):
+            return {
+                "Category": {"prediction": "Software", "confidence": 0.95},
+                "Subcategory": {"prediction": "Software Install", "confidence": 0.95},
+                "priority": {"prediction": "Medium", "confidence": 0.95},
+            }
+
+    class _NERStub(_BaseStub):
+        def extract_entities(self, _text):
+            return [{"text": "VPN", "label": "PRODUCT", "confidence": 0.99}]
+
+    class _DuplicateStub(_BaseStub):
+        def find_semantic_duplicate(self, *_args, **_kwargs):
+            return {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "parent_ticket_id": None,
+                "is_potential_duplicate": False,
+                "similarity": 0.0,
+            }
+
+        def check_duplicate(self, *_args, **_kwargs):
+            return self.find_semantic_duplicate()
+
+        def generate_embedding(self, *_args, **_kwargs):
+            return [0.1] * 384
+
+        def add_ticket(self, *_args, **_kwargs):
+            return None
+
+        def is_available(self):
+            return True
+
+    class _RagStub(_BaseStub):
+        def search_knowledge_base(self, *_args, **_kwargs):
+            return None
+
+        def is_available(self):
+            return True
+
+    stubs = {
+        "backend.services.classifier_service": _make_stub_module(
+            "backend.services.classifier_service",
+            {
+                "ClassifierService": _ClassifierStub,
+                "TEAM_MAP": {"Software": "Application Support"},
+                "AUTO_RESOLVE_SUBS": {"Software Install"},
+            },
+        ),
+        "backend.services.classifier_v3": _make_stub_module(
+            "backend.services.classifier_v3",
+            {"classifier_v3": _ClassifierV3Stub()},
+        ),
+        "backend.services.ner_service": _make_stub_module(
+            "backend.services.ner_service",
+            {"NERService": _NERStub},
+        ),
+        "backend.services.duplicate_service": _make_stub_module(
+            "backend.services.duplicate_service",
+            {"DuplicateService": _DuplicateStub},
+        ),
+        "backend.services.rag_service": _make_stub_module(
+            "backend.services.rag_service",
+            {"RagService": _RagStub},
+        ),
+    }
+
+    for module_name, stub_module in stubs.items():
+        if module_name not in sys.modules:
+            sys.modules[module_name] = stub_module
+
+
+_install_optional_ml_stubs()
+
+
+@pytest.fixture
+def fake_db():
+    return {
+        "system_settings": [
+            {
+                "company_id": "company_A",
+                "ai_confidence_threshold": 0.80,
+                "duplicate_sensitivity": 0.85,
+                "enable_auto_resolve": True
+            },
+            {
+                "company_id": "company_B",
+                "ai_confidence_threshold": 0.80,
+                "duplicate_sensitivity": 0.85,
+                "enable_auto_resolve": True
+            }
+        ],
+        "profiles": [
+            {
+                "id": "user_A",
+                "company_id": "company_A",
+                "company": "Company A"
+            },
+            {
+                "id": "user_B",
+                "company_id": "company_B",
+                "company": "Company B"
+            }
+        ],
+        "tickets": [],
+        "ticket_messages": [],
+        "audit_logs": []
+    }
+
+
+@pytest.fixture
+def fake_supabase(fake_db):
+    from backend.auth.crypto import wrap_client
+    return wrap_client(FakeSupabase(fake_db))
+
+
+@pytest.fixture(autouse=True)
+def mock_ai_services(request):
+    if request.node.fspath.basename in {
+        "test_redis_cache.py",
+        "test_semantic_duplicates.py",
+        "test_auth_cookie.py",
+        "test_mobile_supabase_env.py",
+        "test_sla_service.py",
+        "test_language_pipeline.py",
+        "test_sla_predictor.py",
+        "test_translation_service.py",
+    }:
+        yield
+        return
+
+    import backend.main as main
+
+    with patch.object(main.classifier_service, "predict") as mock_v1_predict, \
+         patch.object(main.classifier_service, "load") as mock_v1_load, \
+         patch.object(main.classifier_v3, "predict") as mock_v3_predict, \
+         patch.object(main.ner_service, "extract_entities") as mock_ner_extract, \
+         patch.object(main.ner_service, "load") as mock_ner_load, \
+         patch.object(main.duplicate_service, "find_semantic_duplicate") as mock_dup_find, \
+         patch.object(main.duplicate_service, "check_duplicate") as mock_dup_check, \
+         patch.object(main.duplicate_service, "generate_embedding") as mock_dup_emb, \
+         patch.object(main.duplicate_service, "load") as mock_dup_load, \
+         patch.object(main.rag_service, "search_knowledge_base") as mock_rag_search, \
+         patch.object(main.rag_service, "load") as mock_rag_load:
+
+        # Stub default returns
+        mock_v1_predict.return_value = {
+            "category": "Software",
+            "subcategory": "Software Install",
+            "priority": "Medium",
+            "auto_resolve": True,
+            "assigned_team": "Application Support",
+            "confidence": 0.95,
+        }
+        mock_v3_predict.return_value = {
+            "Category": {"prediction": "Software", "confidence": 0.95},
+            "Subcategory": {"prediction": "Software Install", "confidence": 0.95},
+            "priority": {"prediction": "Medium", "confidence": 0.95},
+        }
+        mock_ner_extract.return_value = [
+            {"text": "VPN", "label": "PRODUCT", "confidence": 0.99}
+        ]
+        mock_dup_find.return_value = {
+            "is_duplicate": False,
+            "duplicate_ticket_id": None,
+            "parent_ticket_id": None,
+            "is_potential_duplicate": False,
+            "similarity": 0.0,
+        }
+        mock_dup_check.return_value = mock_dup_find.return_value
+        mock_dup_emb.return_value = [0.1] * 384
+        mock_rag_search.return_value = None
+
+        yield
+
+
+@pytest.fixture
+def test_client(fake_supabase):
+    with patch("backend.main.supabase", fake_supabase):
+        from fastapi.testclient import TestClient
+        from backend.main import app
+        # Ensure ALLOW_DEGRADED_STARTUP is set during client initialization
+        with patch.dict(os.environ, {"ALLOW_DEGRADED_STARTUP": "1"}):
+            with TestClient(app) as client:
+                yield client

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -1,0 +1,433 @@
+"""
+Unit tests for backend.services.translation_service (Issue #734).
+
+Covers:
+- detect_language (normal, empty/short text, exception handling)
+- get_supported_languages (returns copy, correct mappings)
+- _get_model_name (Helsinki-NLP naming convention)
+- translate_text (auto-detect, explicit source, same-lang short-circuit,
+  cache hit/miss, truncation, empty input, model failure)
+- translate_ticket (subject, description, messages, empty ticket)
+- clear_cache (clears both translation and model caches)
+
+All tests are self-contained: langdetect and transformers are mocked via
+sys.modules injection so the suite runs without optional ML packages installed.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+# ---------------------------------------------------------------------------
+# Module stubs (langdetect + transformers not installed in CI)
+# ---------------------------------------------------------------------------
+
+def _make_langdetect_stub(return_value: str = "en"):
+    """Return a fake langdetect module whose detect() always returns return_value."""
+    mod = types.ModuleType("langdetect")
+    mod.detect = lambda text: return_value
+    return mod
+
+
+def _make_langdetect_raises():
+    """Return a fake langdetect module whose detect() raises an exception."""
+    mod = types.ModuleType("langdetect")
+
+    def _detect(text):
+        raise Exception("no features in text")
+
+    mod.detect = _detect
+    return mod
+
+
+def _make_transformers_stub():
+    """Return a fake transformers module with MarianMTModel and MarianTokenizer."""
+    mod = types.ModuleType("transformers")
+
+    mock_tokenizer = MagicMock()
+    mock_model = MagicMock()
+
+    mock_tokenizer.return_value = {"input_ids": [[1, 2, 3]], "attention_mask": [[1, 1, 1]]}
+    mock_model.generate.return_value = [[4, 5, 6]]
+    mock_tokenizer.decode.return_value = "translated text"
+
+    mod.MarianMTModel = MagicMock()
+    mod.MarianTokenizer = MagicMock()
+    mod.MarianMTModel.from_pretrained.return_value = mock_model
+    mod.MarianTokenizer.from_pretrained.return_value = mock_tokenizer
+
+    return mod, mock_model, mock_tokenizer
+
+
+# Pre-inject stubs so the module import doesn't fail
+sys.modules.setdefault("langdetect", _make_langdetect_stub())
+_st_mod, _, _ = _make_transformers_stub()
+sys.modules.setdefault("transformers", _st_mod)
+
+from backend.services import translation_service as ts_mod
+from backend.services.translation_service import (
+    detect_language,
+    get_supported_languages,
+    _get_model_name,
+    translate_text,
+    translate_ticket,
+    clear_cache,
+    SUPPORTED_LANGUAGES,
+    MAX_TEXT_LENGTH,
+    MAX_CACHE_SIZE,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_language
+# ---------------------------------------------------------------------------
+
+class TestDetectLanguage(unittest.TestCase):
+
+    def setUp(self):
+        ts_mod._translation_cache.clear()
+        ts_mod._model_cache.clear()
+
+    def test_detect_english_text(self):
+        """Should detect English text and return 'en'."""
+        sys.modules["langdetect"] = _make_langdetect_stub("en")
+        result = detect_language("Hello, how are you today?")
+        self.assertEqual(result, "en")
+
+    def test_detect_spanish_text(self):
+        """Should detect Spanish text and return 'es'."""
+        sys.modules["langdetect"] = _make_langdetect_stub("es")
+        result = detect_language("Hola, \u00bfc\u00f3mo est\u00e1s?")
+        self.assertEqual(result, "es")
+
+    def test_detect_empty_string_returns_none(self):
+        """Empty string should return None without calling langdetect."""
+        result = detect_language("")
+        self.assertIsNone(result)
+
+    def test_detect_whitespace_only_returns_none(self):
+        """Whitespace-only string should return None."""
+        result = detect_language("   ")
+        self.assertIsNone(result)
+
+    def test_detect_short_text_returns_none(self):
+        """Text shorter than 3 characters should return None."""
+        result = detect_language("Hi")
+        self.assertIsNone(result)
+
+    def test_detect_exactly_3_chars_calls_langdetect(self):
+        """Text of exactly 3 characters should call langdetect."""
+        sys.modules["langdetect"] = _make_langdetect_stub("en")
+        result = detect_language("Hel")
+        self.assertEqual(result, "en")
+
+    def test_detect_langdetect_exception_returns_none(self):
+        """When langdetect raises, should return None and log warning."""
+        sys.modules["langdetect"] = _make_langdetect_raises()
+        result = detect_language("Some text that will fail detection")
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# get_supported_languages
+# ---------------------------------------------------------------------------
+
+class TestGetSupportedLanguages(unittest.TestCase):
+
+    def test_returns_dict(self):
+        result = get_supported_languages()
+        self.assertIsInstance(result, dict)
+
+    def test_returns_copy_not_reference(self):
+        """Modifying the returned dict should not affect the module constant."""
+        result = get_supported_languages()
+        result["xx"] = "Test Language"
+        self.assertNotIn("xx", SUPPORTED_LANGUAGES)
+
+    def test_contains_english(self):
+        result = get_supported_languages()
+        self.assertEqual(result["en"], "English")
+
+    def test_contains_all_15_languages(self):
+        result = get_supported_languages()
+        self.assertEqual(len(result), 15)
+
+    def test_contains_expected_languages(self):
+        result = get_supported_languages()
+        expected_codes = ["en", "es", "fr", "de", "it", "pt", "ru", "zh", "ja", "ko", "ar", "hi", "nl", "pl", "tr"]
+        for code in expected_codes:
+            self.assertIn(code, result)
+
+
+# ---------------------------------------------------------------------------
+# _get_model_name
+# ---------------------------------------------------------------------------
+
+class TestGetModelName(unittest.TestCase):
+
+    def test_english_to_spanish(self):
+        result = _get_model_name("en", "es")
+        self.assertEqual(result, "Helsinki-NLP/opus-mt-en-es")
+
+    def test_french_to_german(self):
+        result = _get_model_name("fr", "de")
+        self.assertEqual(result, "Helsinki-NLP/opus-mt-fr-de")
+
+    def test_format_consistency(self):
+        for src in ["en", "es", "fr"]:
+            for tgt in ["de", "it", "pt"]:
+                result = _get_model_name(src, tgt)
+                self.assertTrue(result.startswith("Helsinki-NLP/opus-mt-"))
+                self.assertIn(f"{src}-{tgt}", result)
+
+
+# ---------------------------------------------------------------------------
+# translate_text
+# ---------------------------------------------------------------------------
+
+class TestTranslateText(unittest.TestCase):
+
+    def setUp(self):
+        ts_mod._translation_cache.clear()
+        ts_mod._model_cache.clear()
+
+    def test_empty_text_returns_empty(self):
+        result = translate_text("", "en")
+        self.assertEqual(result["translated"], "")
+        self.assertFalse(result["cached"])
+
+    def test_whitespace_only_returns_empty(self):
+        result = translate_text("   ", "en")
+        self.assertEqual(result["translated"], "")
+
+    def test_same_language_short_circuit(self):
+        """When source_lang == target_lang, should return original text without translation."""
+        result = translate_text("Hello world", target_lang="en", source_lang="en")
+        self.assertEqual(result["translated"], "Hello world")
+        self.assertEqual(result["source_lang"], "en")
+        self.assertEqual(result["target_lang"], "en")
+        self.assertFalse(result["cached"])
+
+    def test_auto_detect_language(self):
+        """When source_lang is None, should auto-detect language."""
+        sys.modules["langdetect"] = _make_langdetect_stub("es")
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+        mock_tokenizer.decode.return_value = "Hello world"
+
+        result = translate_text("Hola mundo", target_lang="en")
+        self.assertEqual(result["source_lang"], "es")
+
+    def test_auto_detect_failure_returns_original(self):
+        """When language detection fails, should return original text."""
+        sys.modules["langdetect"] = _make_langdetect_raises()
+        result = translate_text("Some unknown text", target_lang="en")
+        self.assertEqual(result["translated"], "Some unknown text")
+        self.assertEqual(result["source_lang"], "unknown")
+
+    def test_translation_caching(self):
+        """Second call with same text should return cached result."""
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+        mock_tokenizer.decode.return_value = "Hola mundo"
+
+        result1 = translate_text("Hello world", target_lang="es", source_lang="en")
+        self.assertFalse(result1["cached"])
+
+        result2 = translate_text("Hello world", target_lang="es", source_lang="en")
+        self.assertTrue(result2["cached"])
+        self.assertEqual(result2["translated"], "Hola mundo")
+
+    def test_long_text_truncation(self):
+        """Text exceeding MAX_TEXT_LENGTH should be truncated."""
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+
+        long_text = "a" * (MAX_TEXT_LENGTH + 500)
+        result = translate_text(long_text, target_lang="es", source_lang="en")
+        self.assertIsNotNone(result["translated"])
+
+    def test_model_load_failure_returns_original(self):
+        """When model loading fails, should return original text."""
+        _st_mod = types.ModuleType("transformers")
+        _st_mod.MarianMTModel = MagicMock()
+        _st_mod.MarianTokenizer = MagicMock()
+        _st_mod.MarianMTModel.from_pretrained.side_effect = Exception("Model not found")
+        _st_mod.MarianTokenizer.from_pretrained.return_value = MagicMock()
+        sys.modules["transformers"] = _st_mod
+
+        result = translate_text("Hello", target_lang="fr", source_lang="en")
+        self.assertEqual(result["translated"], "Hello")
+
+    def test_translation_generation_failure_returns_original(self):
+        """When model.generate() fails, should return original text."""
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+        mock_model.generate.side_effect = Exception("CUDA out of memory")
+
+        result = translate_text("Hello", target_lang="fr", source_lang="en")
+        self.assertEqual(result["translated"], "Hello")
+
+    def test_cache_eviction_at_max_size(self):
+        """When cache reaches MAX_CACHE_SIZE, new entries should not be added."""
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+        mock_tokenizer.decode.return_value = "translated"
+
+        for i in range(MAX_CACHE_SIZE):
+            ts_mod._translation_cache[f"en:es:hash_{i}"] = f"translated_{i}"
+
+        result = translate_text("New unique text", target_lang="es", source_lang="en")
+        self.assertFalse(result["cached"])
+
+    def test_explicit_source_lang_skips_detection(self):
+        """When source_lang is provided, should not call langdetect."""
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+        mock_tokenizer.decode.return_value = "Bonjour le monde"
+
+        saved = sys.modules.pop("langdetect", None)
+        try:
+            result = translate_text("Hello world", target_lang="fr", source_lang="en")
+            self.assertEqual(result["source_lang"], "en")
+        finally:
+            if saved:
+                sys.modules["langdetect"] = saved
+
+
+# ---------------------------------------------------------------------------
+# translate_ticket
+# ---------------------------------------------------------------------------
+
+class TestTranslateTicket(unittest.TestCase):
+
+    def setUp(self):
+        ts_mod._translation_cache.clear()
+        ts_mod._model_cache.clear()
+        sys.modules["langdetect"] = _make_langdetect_stub("en")
+        _st_mod, mock_model, mock_tokenizer = _make_transformers_stub()
+        sys.modules["transformers"] = _st_mod
+        self.mock_tokenizer = mock_tokenizer
+
+    def test_translate_subject(self):
+        self.mock_tokenizer.decode.return_value = "Translated subject"
+        ticket = {"subject": "My ticket subject"}
+        result = translate_ticket(ticket, target_lang="es")
+        self.assertIn("subject", result["translations"])
+        self.assertEqual(result["translations"]["subject"]["translated"], "Translated subject")
+
+    def test_translate_description(self):
+        self.mock_tokenizer.decode.return_value = "Translated description"
+        ticket = {"description": "This is a description"}
+        result = translate_ticket(ticket, target_lang="fr")
+        self.assertIn("description", result["translations"])
+
+    def test_translate_messages(self):
+        self.mock_tokenizer.decode.return_value = "Translated message"
+        ticket = {
+            "messages": [
+                {"content": "First message"},
+                {"content": "Second message"},
+            ]
+        }
+        result = translate_ticket(ticket, target_lang="de")
+        self.assertIn("messages", result["translations"])
+        self.assertEqual(len(result["translations"]["messages"]), 2)
+        self.assertEqual(result["translations"]["messages"][0]["translated"], "Translated message")
+
+    def test_translate_full_ticket(self):
+        self.mock_tokenizer.decode.return_value = "Translated"
+        ticket = {
+            "subject": "Help me",
+            "description": "I have a problem",
+            "messages": [{"content": "Can someone help?"}],
+        }
+        result = translate_ticket(ticket, target_lang="ja")
+        self.assertIn("subject", result["translations"])
+        self.assertIn("description", result["translations"])
+        self.assertIn("messages", result["translations"])
+
+    def test_original_language_from_subject(self):
+        sys.modules["langdetect"] = _make_langdetect_stub("es")
+        self.mock_tokenizer.decode.return_value = "Translated"
+        ticket = {"subject": "Ayuda por favor"}
+        result = translate_ticket(ticket, target_lang="en")
+        self.assertEqual(result["original_language"], "es")
+
+    def test_original_language_from_description_when_no_subject(self):
+        sys.modules["langdetect"] = _make_langdetect_stub("fr")
+        self.mock_tokenizer.decode.return_value = "Translated"
+        ticket = {"description": "Aidez-moi s'il vous plait"}
+        result = translate_ticket(ticket, target_lang="en")
+        self.assertEqual(result["original_language"], "fr")
+
+    def test_empty_ticket_returns_empty_translations(self):
+        result = translate_ticket({}, target_lang="en")
+        self.assertEqual(result["translations"], {})
+        self.assertIsNone(result["original_language"])
+
+    def test_target_language_in_result(self):
+        ticket = {"subject": "Test"}
+        result = translate_ticket(ticket, target_lang="ko")
+        self.assertEqual(result["target_language"], "ko")
+
+    def test_messages_without_content_key(self):
+        """Messages missing 'content' key should translate empty string."""
+        self.mock_tokenizer.decode.return_value = ""
+        ticket = {"messages": [{"no_content": True}]}
+        result = translate_ticket(ticket, target_lang="en")
+        self.assertEqual(len(result["translations"]["messages"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# clear_cache
+# ---------------------------------------------------------------------------
+
+class TestClearCache(unittest.TestCase):
+
+    def test_clears_translation_cache(self):
+        ts_mod._translation_cache["test"] = "value"
+        self.assertEqual(len(ts_mod._translation_cache), 1)
+        clear_cache()
+        self.assertEqual(len(ts_mod._translation_cache), 0)
+
+    def test_clears_model_cache(self):
+        ts_mod._model_cache["test"] = MagicMock()
+        self.assertEqual(len(ts_mod._model_cache), 1)
+        clear_cache()
+        self.assertEqual(len(ts_mod._model_cache), 0)
+
+    def test_clear_empty_caches(self):
+        ts_mod._translation_cache.clear()
+        ts_mod._model_cache.clear()
+        clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# SUPPORTED_LANGUAGES constant
+# ---------------------------------------------------------------------------
+
+class TestSupportedLanguagesConstant(unittest.TestCase):
+
+    def test_is_dict(self):
+        self.assertIsInstance(SUPPORTED_LANGUAGES, dict)
+
+    def test_all_values_are_strings(self):
+        for code, name in SUPPORTED_LANGUAGES.items():
+            self.assertIsInstance(code, str)
+            self.assertIsInstance(name, str)
+
+    def test_all_keys_are_two_letter_codes(self):
+        for code in SUPPORTED_LANGUAGES:
+            self.assertEqual(len(code), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_translation_service.py
+++ b/backend/tests/test_translation_service.py
@@ -253,6 +253,8 @@ class TestTranslateText(unittest.TestCase):
         long_text = "a" * (MAX_TEXT_LENGTH + 500)
         result = translate_text(long_text, target_lang="es", source_lang="en")
         self.assertIsNotNone(result["translated"])
+        # Verify text was actually truncated (not passed through at full length)
+        self.assertLessEqual(len(result["translated"]), MAX_TEXT_LENGTH + 100)
 
     def test_model_load_failure_returns_original(self):
         """When model loading fails, should return original text."""


### PR DESCRIPTION
Fixes #738

## Summary
Adds a React Error Boundary component to prevent white-screen crashes when child components throw unhandled errors (e.g., malformed API responses, null references).

## Changes

### New: `ErrorBoundary.jsx`
- Class component with `getDerivedStateFromError` + `componentDidCatch`
- User-friendly fallback UI with warning icon, clear message, and two recovery buttons:
  - **Try Again** — resets error state without page reload
  - **Reload Page** — full page refresh as fallback
- Dev-mode only: expandable error details with component stack trace
- Supports custom `fallback` render prop for per-section customization

### Modified: `App.jsx`
- Imported `ErrorBoundary` and wrapped the main app routes
- **Top-level boundary**: catches errors across all routes (public, admin, master-admin)
- **AppLayout boundary**: granular isolation for the protected user dashboard — if dashboard crashes, public pages still work

## Behavior
- **Before**: Unhandled error → entire app crashes with blank white screen, no recovery
- **After**: Unhandled error → friendly error card with retry/reload options, rest of app continues working

## Testing
1. Trigger a component error (e.g., throw in a child component's render)
2. Verify fallback UI appears with retry/reload buttons
3. Click 'Try Again' — component should recover
4. Verify other routes still work when one section errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized error handling with a user-facing fallback UI offering "Try Again" and "Reload Page"; errors are captured and reported for diagnostics.

* **Tests**
  * Added comprehensive test infrastructure and extensive tests for translation and related services to improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->