### PR TITLE
fix: use correct id field for realtime ticket UPDATE/DELETE events (Fixes #736)

### DIFF
--- a/Frontend/src/hooks/useRealtimeNotifications.js
+++ b/Frontend/src/hooks/useRealtimeNotifications.js
@@ -32,11 +32,11 @@ const useTicketsRealtime = () => {
                     }
 
                     if (eventType === 'UPDATE') {
-                        updateTicket(newRecord.ticket_id, newRecord);
+                        updateTicket(newRecord.id, newRecord);
                     }
 
                     if (eventType === 'DELETE') {
-                        removeTicket(oldRecord.ticket_id);
+                        removeTicket(oldRecord.id);
                     }
                 }
             )


### PR DESCRIPTION
Fixes #736

## Summary
Fix realtime ticket subscription using wrong field name (`ticket_id` instead of `id`), causing all UPDATE and DELETE events to silently fail.

## Root Cause
The Supabase `postgres_changes` payload uses actual column names from the database schema. The `tickets` table uses `id` (UUID) as its primary key, but `useRealtimeNotifications.js` was reading `payload.new.ticket_id` and `payload.old.ticket_id` - fields that do not exist in the payload.

## Impact (Before Fix)
- **UPDATE events silently fail:** `newRecord.ticket_id` is undefined, so `updateTicket(undefined, newRecord)` never matches any ticket in the store
- **DELETE events silently fail:** `oldRecord.ticket_id` is undefined, so `removeTicket(undefined)` never matches
- **Data inconsistency:** Over time, admin dashboard shows stale tickets that have been updated or deleted in the database

## Changes
- `Frontend/src/hooks/useRealtimeNotifications.js`:
  - Line 35: `newRecord.ticket_id` changed to `newRecord.id`
  - Line 39: `oldRecord.ticket_id` changed to `oldRecord.id`

## Why Only the Hook Needed Changes
The `ticketStore.js` already handles both `id` and `ticket_id` via `(t.id ?? t.ticket_id)` in `updateTicket` and `removeTicket`. The store was correct - only the hook was passing the wrong field.

## Evidence
`MyTickets.jsx` (line 80) does this correctly using `t.id === payload.new.id`, confirming `id` is the correct field name for Supabase realtime payloads.

## Testing
1. Open admin dashboard with a ticket list
2. In another tab, update a ticket status or priority
3. Verify the dashboard reflects the change in real-time (no page refresh needed)
4. Delete a ticket and verify it disappears from the list immediately
