### PR TITLE
fix(auth): handle URL-encoded email plus signs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from contextlib import asynccontextmanager
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, Response
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
@@ -28,7 +28,9 @@ from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
 import asyncio
 from pathlib import Path
-from pydantic import BaseModel
+import urllib.parse
+import re
+from pydantic import BaseModel, validator
 from dotenv import load_dotenv
 
 # Load environment variables from backend/.env
@@ -1143,12 +1145,34 @@ class LoginBody(BaseModel):
     email: str
     password: str
 
+    @validator('email', pre=True, allow_reuse=True)
+    def decode_and_validate_email(cls, v):
+        if not isinstance(v, str):
+            raise ValueError("Email must be a string")
+        # Decode %2B to + without turning + into a space
+        decoded = urllib.parse.unquote(v)
+        # RFC-compliant basic regex that allows aliases like + and .
+        pattern = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+        if not re.match(pattern, decoded):
+            raise ValueError("Invalid email format")
+        return decoded
+
 class SignupBody(BaseModel):
     email: str
     password: str
     full_name: str | None = None
     role: str | None = "user"
     company: str | None = None
+
+    @validator('email', pre=True, allow_reuse=True)
+    def decode_and_validate_email(cls, v):
+        if not isinstance(v, str):
+            raise ValueError("Email must be a string")
+        decoded = urllib.parse.unquote(v)
+        pattern = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+        if not re.match(pattern, decoded):
+            raise ValueError("Invalid email format")
+        return decoded
 
 @app.post("/auth/login")
 async def auth_login(body: LoginBody, response: Response):
@@ -1159,7 +1183,7 @@ async def auth_login(body: LoginBody, response: Response):
             {"email": body.email, "password": body.password}
         )
     except Exception as exc:
-        raise HTTPException(status_code=401, detail=str(exc)) from exc
+        raise HTTPException(status_code=401, detail="Invalid email or password.") from exc
 
     session = getattr(result, "session", None)
     user = getattr(result, "user", None)
@@ -1191,7 +1215,7 @@ async def auth_signup(body: SignupBody, response: Response):
             }
         )
     except Exception as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail="Invalid signup details or email already in use.") from exc
 
     session = getattr(result, "session", None)
     user = getattr(result, "user", None)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,54 @@
+import pytest
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fastapi.testclient import TestClient
+from main import app, LoginBody
+
+client = TestClient(app)
+
+def test_login_valid_email_formats():
+    """Test that valid emails including aliases are accepted by validation, even if unauthorized"""
+    valid_emails = [
+        "john@gmail.com",
+        "john.doe@gmail.com",
+        "john+test@gmail.com",
+        "john%2Btest@gmail.com",
+        "user.name+alias@domain.com",
+        "dev_team+support@example.org"
+    ]
+    
+    for email in valid_emails:
+        response = client.post("/auth/login", json={"email": email, "password": "password"})
+        assert response.status_code in (401, 503), f"Email {email} failed validation unexpectedly. Code: {response.status_code}, Body: {response.text}"
+        if response.status_code == 401:
+            assert response.json()["detail"] == "Invalid email or password.", f"Unexpected error detail for {email}"
+
+def test_login_invalid_email_formats():
+    """Test that malformed emails are rejected with 422 Unprocessable Entity"""
+    invalid_emails = [
+        "john@",
+        "@gmail.com",
+        "invalid-email",
+        "john@gmail",
+        "john doe@gmail.com"
+    ]
+    
+    for email in invalid_emails:
+        response = client.post("/auth/login", json={"email": email, "password": "password"})
+        assert response.status_code == 422, f"Email {email} was incorrectly accepted"
+        assert "Invalid email format" in str(response.json()), f"Unexpected validation error for {email}"
+
+def test_signup_valid_email_formats():
+    """Test that valid emails are accepted for signup"""
+    response = client.post("/auth/signup", json={"email": "new.user+alias@gmail.com", "password": "password"})
+    assert response.status_code in (400, 503), "Validation should pass but DB error expected"
+    if response.status_code == 400:
+         assert response.json()["detail"] == "Invalid signup details or email already in use."
+
+def test_signup_invalid_email_formats():
+    """Test that malformed emails are rejected for signup"""
+    response = client.post("/auth/signup", json={"email": "invalid@", "password": "password"})
+    assert response.status_code == 422
+    assert "Invalid email format" in str(response.json())


### PR DESCRIPTION
Resolves #548.

**Changes:**
- Added robust email validation and explicit URL decoding logic inside the Pydantic payloads for both Login and Signup.
- Updated authentication endpoint exception handlers to output graceful, user-friendly error messages rather than raw DB stack traces or 500 Internal Server errors.
- Added a `pytest` suite for the `auth` controller to guarantee regressions don't occur when parsing complex but valid email aliases containing `+` marks or URL encodings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email authentication now accepts aliased email formats (e.g., user+tag@example.com)

* **Bug Fixes**
  * Authentication endpoints return standardized error messages instead of technical details
  * Enhanced email format validation with improved RFC compliance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->