### PR TITLE
fix: validate OCR file upload type and size to prevent server crashes (Fixes #741)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -99,6 +99,7 @@ class TicketRequest(BaseModel):
             return v
         # Strip data URI prefix if present
         raw = v
+        has_mime = False
         if "," in v:
             prefix, raw = v.split(",", 1)
             # Validate MIME type from data URI
@@ -108,7 +109,8 @@ class TicketRequest(BaseModel):
                 raise ValueError(
                     f"Unsupported file type '{mime}'. Allowed: PNG, JPEG, TIFF, PDF"
                 )
-        # Validate decoded size (max 10MB)
+            has_mime = bool(mime)
+        # Validate decoded size (max 10MB) and check magic bytes
         try:
             missing_padding = len(raw) % 4
             if missing_padding:
@@ -119,10 +121,24 @@ class TicketRequest(BaseModel):
                 raise ValueError(
                     f"File size {len(decoded) / 1024 / 1024:.1f}MB exceeds 10MB limit"
                 )
+            # Magic byte validation for raw base64 without data: prefix
+            if not has_mime and len(decoded) >= 4:
+                magic = decoded[:4]
+                allowed_magics = (
+                    b"\x89PNG",        # PNG
+                    b"\xff\xd8\xff", # JPEG
+                    b"II\x2a\x00",   # TIFF (little-endian)
+                    b"MM\x00\x2a",   # TIFF (big-endian)
+                    b"%PDF",           # PDF
+                )
+                if not any(magic.startswith(m) for m in allowed_magics):
+                    raise ValueError(
+                        "Unrecognized file type. Allowed: PNG, JPEG, TIFF, PDF"
+                    )
         except Exception as e:
-            if "exceeds" in str(e) or "Unsupported" in str(e):
+            if "exceeds" in str(e) or "Unsupported" in str(e) or "Unrecognized" in str(e):
                 raise
-            raise ValueError("Invalid base64 image data")
+            raise ValueError("Invalid base64 image data") from e
         return v
 
 class TicketSaveRequest(BaseModel):

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,8 @@ from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
 import asyncio
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+import base64 as _base64_mod
 from dotenv import load_dotenv
 
 # Load environment variables from backend/.env
@@ -90,6 +91,39 @@ class TicketRequest(BaseModel):
     image_url: str | None = None
     confidence_threshold: float = 0.20
     duplicate_sensitivity: float = 0.85
+
+    @field_validator("image_base64")
+    @classmethod
+    def validate_image_base64(cls, v: str) -> str:
+        if not v:
+            return v
+        # Strip data URI prefix if present
+        raw = v
+        if "," in v:
+            prefix, raw = v.split(",", 1)
+            # Validate MIME type from data URI
+            allowed_types = {"image/png", "image/jpeg", "image/tiff", "application/pdf"}
+            mime = prefix.split(":")[1].split(";")[0] if ":" in prefix else ""
+            if mime and mime not in allowed_types:
+                raise ValueError(
+                    f"Unsupported file type '{mime}'. Allowed: PNG, JPEG, TIFF, PDF"
+                )
+        # Validate decoded size (max 10MB)
+        try:
+            missing_padding = len(raw) % 4
+            if missing_padding:
+                raw += "=" * (4 - missing_padding)
+            decoded = _base64_mod.b64decode(raw, validate=True)
+            max_size = 10 * 1024 * 1024  # 10MB
+            if len(decoded) > max_size:
+                raise ValueError(
+                    f"File size {len(decoded) / 1024 / 1024:.1f}MB exceeds 10MB limit"
+                )
+        except Exception as e:
+            if "exceeds" in str(e) or "Unsupported" in str(e):
+                raise
+            raise ValueError("Invalid base64 image data")
+        return v
 
 class TicketSaveRequest(BaseModel):
     user_id: str


### PR DESCRIPTION
## Summary
Adds server-side validation for the OCR file upload endpoint to prevent crashes from processing extremely large files or non-image file types.

## Changes
- Add Pydantic `field_validator` for `image_base64` field in `TicketRequest` model
- **MIME type validation**: Only allows PNG, JPEG, TIFF, and PDF (when data URI prefix is present)
- **File size validation**: Max 10MB decoded size
- **Descriptive error messages**: Returns clear 422 validation errors for invalid uploads

## Validation Details
- Parses data URI prefix (`data:image/png;base64,...`) to extract and validate MIME type
- Decodes base64 payload and checks byte length against 10MB limit
- Gracefully handles missing data URI prefix (raw base64 without type info)
- Invalid base64 data is caught and returns a clear error

## Testing
- Upload valid PNG/JPEG → accepted
- Upload 15MB image → 422 error with size message
- Upload .exe as base64 → 422 error with type message
- Upload invalid base64 → 422 error with "Invalid base64" message
- No image → accepted (empty string passes through)

## Related Issues
Fixes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced image upload validation with stricter format and size enforcement
  * Added support for PNG, JPEG, TIFF, and PDF image formats
  * Enforced 10MB maximum file size limit for uploads
  * Improved error messaging for invalid submissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->