### PR TITLE
fix: add settings state and updateSettings action to adminStore (Fixes #735)

### DIFF
--- a/Frontend/src/store/adminStore.js
+++ b/Frontend/src/store/adminStore.js
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { DEFAULT_ADMIN_SETTINGS } from '../utils/adminSettingsPersistence';
 
 const useAdminStore = create(
     persist(
@@ -15,6 +16,10 @@ const useAdminStore = create(
             },
             updateProfile: (updates) => set((state) => ({
                 adminProfile: { ...state.adminProfile, ...updates }
+            })),
+            settings: { ...DEFAULT_ADMIN_SETTINGS },
+            updateSettings: (updates) => set((state) => ({
+                settings: { ...state.settings, ...updates }
             })),
         }),
         {

--- a/Frontend/src/utils/adminSettingsPersistence.js
+++ b/Frontend/src/utils/adminSettingsPersistence.js
@@ -1,0 +1,47 @@
+export const DEFAULT_ADMIN_SETTINGS = {
+    aiConfidenceThreshold: 0.8,
+    duplicateSensitivity: 0.85,
+    enableAutoResolve: false,
+    autoCloseDays: 7,
+    emailNotifications: false,
+    adminAlerts: false,
+    digestEnabled: false,
+    digestAdminEmail: "",
+};
+
+export const resolveCompanyId = (profile, user) => {
+    return (
+        profile?.company_id ||
+        profile?.companyId ||
+        user?.user_metadata?.company_id ||
+        user?.user_metadata?.companyId ||
+        null
+    );
+};
+
+export const settingsFromSystemSettingsRow = (row, fallback = DEFAULT_ADMIN_SETTINGS) => {
+    if (!row) return fallback;
+
+    return {
+        aiConfidenceThreshold: row.ai_confidence_threshold ?? fallback.aiConfidenceThreshold,
+        duplicateSensitivity: row.duplicate_sensitivity ?? fallback.duplicateSensitivity,
+        enableAutoResolve: row.enable_auto_resolve ?? fallback.enableAutoResolve,
+        autoCloseDays: row.auto_close_days ?? fallback.autoCloseDays,
+        emailNotifications: row.email_notifications ?? fallback.emailNotifications,
+        adminAlerts: row.admin_alerts ?? fallback.adminAlerts,
+        digestEnabled: row.digest_enabled ?? fallback.digestEnabled,
+        digestAdminEmail: row.digest_admin_email ?? fallback.digestAdminEmail,
+    };
+};
+
+export const settingsToSystemSettingsRow = (settings, companyId) => ({
+    company_id: companyId,
+    ai_confidence_threshold: Number(settings.aiConfidenceThreshold),
+    duplicate_sensitivity: Number(settings.duplicateSensitivity),
+    enable_auto_resolve: Boolean(settings.enableAutoResolve),
+    auto_close_days: Number(settings.autoCloseDays),
+    email_notifications: Boolean(settings.emailNotifications),
+    admin_alerts: Boolean(settings.adminAlerts),
+    digest_enabled: Boolean(settings.digestEnabled),
+    digest_admin_email: settings.digestAdminEmail || null,
+});

--- a/Frontend/src/utils/adminSettingsPersistence.test.js
+++ b/Frontend/src/utils/adminSettingsPersistence.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    DEFAULT_ADMIN_SETTINGS,
+    resolveCompanyId,
+    settingsFromSystemSettingsRow,
+    settingsToSystemSettingsRow,
+} from './adminSettingsPersistence.js';
+
+test('maps a system_settings row into admin UI settings', () => {
+    const settings = settingsFromSystemSettingsRow({
+        ai_confidence_threshold: 0.7,
+        duplicate_sensitivity: 0.9,
+        enable_auto_resolve: true,
+        auto_close_days: 14,
+        email_notifications: true,
+        admin_alerts: false,
+    });
+
+    assert.deepEqual(settings, {
+        aiConfidenceThreshold: 0.7,
+        duplicateSensitivity: 0.9,
+        enableAutoResolve: true,
+        autoCloseDays: 14,
+        emailNotifications: true,
+        adminAlerts: false,
+    });
+});
+
+test('preserves fallback values when database columns are absent', () => {
+    const settings = settingsFromSystemSettingsRow({}, DEFAULT_ADMIN_SETTINGS);
+
+    assert.deepEqual(settings, DEFAULT_ADMIN_SETTINGS);
+});
+
+test('maps admin UI settings into an upsert payload', () => {
+    const row = settingsToSystemSettingsRow({
+        aiConfidenceThreshold: '0.75',
+        duplicateSensitivity: 0.8,
+        enableAutoResolve: 1,
+        autoCloseDays: '3',
+        emailNotifications: false,
+        adminAlerts: true,
+    }, 'company-123');
+
+    assert.deepEqual(row, {
+        company_id: 'company-123',
+        ai_confidence_threshold: 0.75,
+        duplicate_sensitivity: 0.8,
+        enable_auto_resolve: true,
+        auto_close_days: 3,
+        email_notifications: false,
+        admin_alerts: true,
+    });
+});
+
+test('resolves company id from profile before auth metadata', () => {
+    const companyId = resolveCompanyId(
+        { company_id: 'profile-company' },
+        { user_metadata: { company_id: 'metadata-company' } },
+    );
+
+    assert.equal(companyId, 'profile-company');
+});


### PR DESCRIPTION
## Summary
Adds settings state management to the admin Zustand store with default values for AI confidence, duplicate sensitivity, auto-resolve, and notification preferences.

## Changes
- Add `DEFAULT_ADMIN_SETTINGS` import from new `adminSettingsPersistence` utility
- Add `settings` state to adminStore with sensible defaults
- Add `updateSettings` action for partial settings updates
- Include `adminSettingsPersistence.js` utility with helper functions for settings conversion
- Include test file for the persistence utility

## Related Issues
Fixes #735