### PR TITLE
fix: use correct id field for realtime ticket UPDATE/DELETE events (Fixes #736)

### DIFF
--- a/Frontend/src/hooks/useRealtimeNotifications.js
+++ b/Frontend/src/hooks/useRealtimeNotifications.js
@@ -32,11 +32,11 @@ const useTicketsRealtime = () => {
                     }
 
                     if (eventType === 'UPDATE') {
-                        updateTicket(newRecord.ticket_id, newRecord);
+                        updateTicket(newRecord.id, newRecord);
                     }
 
                     if (eventType === 'DELETE') {
-                        removeTicket(oldRecord.ticket_id);
+                        removeTicket(oldRecord.id);
                     }
                 }
             )


### PR DESCRIPTION
## Summary
Fixes the Supabase realtime subscription to use the correct `id` field instead of `ticket_id` for UPDATE and DELETE events, which were being silently ignored.

## Changes
- `Frontend/src/hooks/useRealtimeNotifications.js`: Change `newRecord.ticket_id` to `newRecord.id` for UPDATE events
- `Frontend/src/hooks/useRealtimeNotifications.js`: Change `oldRecord.ticket_id` to `oldRecord.id` for DELETE events

## Problem
The Supabase realtime payload uses `id` as the primary key field, but the code was looking for `ticket_id`. This caused all UPDATE and DELETE events to be silently ignored since the lookup returned `undefined`, breaking live ticket state synchronization.

## Related Issues
Fixes #736