### PR TITLE
[BOUNTY] [level:intermediate] Fix Ticket Timeline Date Parsing Discrepancies on Older Safari Web Browsers

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -1,19 +1,43 @@
 /**
  * Unified Date Utility for HELPDESK.AI
- * Fixes timezone shift issues by explicitly forcing local display.
+ * Fixes timezone shift and Safari parsing issues by normalizing
+ * ISO-8601 timestamps before passing to the Date constructor.
  */
+
+/**
+ * Normalize a date string for cross-browser (Safari/Firefox/Chrome) compatibility.
+ *
+ * Safari fails to parse ISO-8601 strings that use a space instead of 'T'
+ * between date and time, or strings with trailing 'Z' + space, or certain
+ * fractional second formats. This function normalizes to a format that
+ * every modern browser understands.
+ */
+const normalizeDateString = (dateStr) => {
+    if (!dateStr || typeof dateStr !== 'string') return dateStr;
+
+    let normalized = dateStr.trim();
+
+    // Replace space separator with 'T' (Safari fails on space-separated ISO)
+    // e.g., "2024-01-15 10:30:00" → "2024-01-15T10:30:00"
+    if (normalized.includes(' ') && !normalized.includes('T')) {
+        normalized = normalized.replace(' ', 'T');
+    }
+
+    // Ensure timezone info: if no timezone suffix, assume UTC
+    // ISO strings from Supabase often arrive as without TZ
+    const hasTZ = /[Z+-]\d{0,2}(:\d{2})?$/.test(normalized);
+    if (!hasTZ) {
+        normalized += 'Z';
+    }
+
+    return normalized;
+};
 
 export const formatTimelineDate = (dateStr) => {
     if (!dateStr) return null;
-    
-    // Ensure the date string is interpreted as UTC if it's an ISO string from DB
-    let date;
-    if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
-        // If it's a raw string without TZ, assume it was intended as UTC from our backend
-        date = new Date(dateStr + 'Z');
-    } else {
-        date = new Date(dateStr);
-    }
+
+    const normalized = normalizeDateString(dateStr);
+    const date = new Date(normalized);
 
     if (isNaN(date.getTime())) return 'Invalid Date';
 


### PR DESCRIPTION
## What

Adds a `normalizeDateString()` helper to `Frontend/src/utils/dateUtils.js` that normalizes ISO-8601 timestamps before passing them to the `Date` constructor, fixing cross-browser compatibility on older Safari browsers.

### Root cause

Safari (particularly versions before Safari 15) fails to parse ISO-8601 date strings that:
1. Use a **space separator** between date and time instead of `T` (e.g., `"2024-01-15 10:30:00"`)
2. Have **no timezone indicator** (e.g., raw Supabase timestamps like `"2024-01-15T10:30:00"` without `Z`)

Chrome and Firefox handle these gracefully, but Safari returns `Invalid Date`.

### Fix

- `normalizeDateString()` replaces space separators with `T`
- Appends `Z` (UTC) when no timezone suffix is detected
- Empty/null/corrupt values fall through to the existing `"Invalid Date"` / `null` handling in `formatTimelineDate()`

## Why

The Ticket Timeline in the admin dashboard shows blank or `"Invalid Date"` text for Safari users. Since Supabase timestamps come in various ISO-8601 formats, normalizing before `new Date()` ensures consistent parsing across Chrome, Firefox, and Safari.

## Testing

The fix is a pure function — verified that:
- `formatTimelineDate("2024-01-15 10:30:00")` now parses correctly in Safari
- `formatTimelineDate("2024-01-15T10:30:00")` (no timezone) parses as UTC
- `formatTimelineDate(null)` returns `null`
- `formatTimelineDate("")` returns `null`
- All existing Chrome/Firefox behavior is preserved

Closes #642