### PR TITLE
test: add DuplicateService check_duplicate unit tests

### DIFF
--- a/backend/tests/test_duplicate_service.py
+++ b/backend/tests/test_duplicate_service.py
@@ -1,0 +1,109 @@
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+class _Score:
+    def __init__(self, value):
+        self._value = value
+
+    def item(self):
+        return self._value
+
+
+class _FakeUtil:
+    @staticmethod
+    def cos_sim(left, right):
+        left_tokens = set(str(left).lower().split())
+        right_tokens = set(str(right).lower().split())
+        if not left_tokens or not right_tokens:
+            return _Score(0.0)
+        return _Score(len(left_tokens & right_tokens) / len(left_tokens | right_tokens))
+
+
+class _FakeSentenceTransformer:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def encode(self, text, convert_to_tensor=True):
+        return text
+
+
+fake_sentence_transformers = types.ModuleType("sentence_transformers")
+fake_sentence_transformers.SentenceTransformer = _FakeSentenceTransformer
+fake_sentence_transformers.util = _FakeUtil
+sys.modules.setdefault("sentence_transformers", fake_sentence_transformers)
+
+duplicate_service = importlib.import_module("backend.services.duplicate_service")
+DuplicateService = duplicate_service.DuplicateService
+
+
+class DuplicateServiceCheckDuplicateTests(unittest.TestCase):
+    def make_service(self):
+        service = DuplicateService()
+        service.storage_file = str(ROOT / "backend" / "data" / "test_case_history_cache.json")
+        service._loaded = True
+        service._load_failed = False
+        service.model = _FakeSentenceTransformer()
+        return service
+
+    def test_returns_no_duplicate_when_no_tickets_are_indexed(self):
+        service = self.make_service()
+
+        result = service.check_duplicate("password reset fails")
+
+        self.assertEqual(
+            result,
+            {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "similarity": 0.0,
+            },
+        )
+
+    def test_detects_best_duplicate_above_default_threshold(self):
+        service = self.make_service()
+        service._tickets = [
+            ("ticket-low", "billing invoice request", "billing invoice request"),
+            ("ticket-high", "password reset fails login", "password reset fails login"),
+        ]
+
+        result = service.check_duplicate("password reset fails login")
+
+        self.assertTrue(result["is_duplicate"])
+        self.assertEqual(result["duplicate_ticket_id"], "ticket-high")
+        self.assertEqual(result["similarity"], 1.0)
+
+    def test_threshold_override_can_suppress_lower_similarity_match(self):
+        service = self.make_service()
+        service._tickets = [
+            ("ticket-1", "password reset fails login", "password reset fails login"),
+        ]
+
+        result = service.check_duplicate("password reset broken", threshold=0.95)
+
+        self.assertFalse(result["is_duplicate"])
+        self.assertIsNone(result["duplicate_ticket_id"])
+        self.assertLess(result["similarity"], 0.95)
+
+    def test_returns_no_duplicate_when_model_is_unavailable(self):
+        service = DuplicateService()
+        service._loaded = False
+        service._load_failed = True
+
+        result = service.check_duplicate("anything")
+
+        self.assertFalse(result["is_duplicate"])
+        self.assertIsNone(result["duplicate_ticket_id"])
+        self.assertEqual(result["similarity"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes ritesh-1918/HELPDESK.AI#297

## Summary

Adds focused unit tests for `DuplicateService.check_duplicate` without requiring sentence-transformers model downloads.

## What changed

- Adds `backend/tests/test_duplicate_service.py`.
- Stubs `sentence_transformers.SentenceTransformer` and `util.cos_sim`.
- Covers no indexed tickets, best duplicate selection, threshold override behavior, and degraded/unavailable model behavior.

## Validation

`python -m unittest backend.tests.test_duplicate_service`

Result: `Ran 4 tests in 0.001s - OK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suite for duplicate detection functionality, with coverage for: identifying duplicates above default threshold, suppressing matches with custom thresholds, handling unavailable models, and validating behavior with empty indexed data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->