### PR TITLE
fix: add axios auth interceptor for automatic token injection (Fixes #749)

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import apiClient from './apiClient';
 import { MOCK_TICKETS } from './mockData';
 import { API_CONFIG } from '../config';
 
@@ -70,7 +70,7 @@ export const api = {
   predictTicket: async (issueText, imageBase64 = "") => {
     try {
       // ALWAYS call the real backend for prediction if possible
-      const response = await axios.post(`${API_BASE_URL}/ai/analyze_ticket`, {
+      const response = await apiClient.post('/ai/analyze_ticket', {
         text: issueText,
         image_base64: imageBase64,
         image_text: ""
@@ -120,7 +120,7 @@ export const api = {
 
   logCorrection: async (correctionPayload) => {
     try {
-      await axios.post(`${API_BASE_URL}/ai/log_correction`, correctionPayload);
+      await apiClient.post('/ai/log_correction', correctionPayload);
     } catch (error) {
       // Non-fatal: log but don't break the UI flow
       console.warn("[Correction Log] Failed to save correction:", error);

--- a/Frontend/src/services/apiClient.js
+++ b/Frontend/src/services/apiClient.js
@@ -1,0 +1,107 @@
+/**
+ * Axios instance with automatic Supabase auth token injection.
+ *
+ * - Attaches the current Supabase access token to every request.
+ * - Handles 401 responses with automatic token refresh.
+ * - Dispatches a custom event on session expiry so the app can react.
+ *
+ * Usage:
+ *   import apiClient from './apiClient';
+ *   const res = await apiClient.get('/ai/analyze_ticket');
+ */
+
+import axios from 'axios';
+import { supabase } from '../lib/supabaseClient';
+import { API_CONFIG } from '../config';
+
+const apiClient = axios.create({
+  baseURL: API_CONFIG.BACKEND_URL,
+  timeout: 30000,
+});
+
+// ---------------------------------------------------------------------------
+// Request interceptor — attach Supabase access token
+// ---------------------------------------------------------------------------
+apiClient.interceptors.request.use(
+  async (config) => {
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session?.access_token) {
+        config.headers.Authorization = `Bearer ${session.access_token}`;
+      }
+    } catch (err) {
+      // Non-fatal: proceed without token; backend will return 401
+      console.warn('[apiClient] Failed to get session for auth header:', err);
+    }
+    return config;
+  },
+  (error) => Promise.reject(error),
+);
+
+// ---------------------------------------------------------------------------
+// Response interceptor — handle 401 with refresh + session expiry
+// ---------------------------------------------------------------------------
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+function subscribeTokenRefresh(cb) {
+  refreshSubscribers.push(cb);
+}
+
+function onRefreshed(newToken) {
+  refreshSubscribers.forEach((cb) => cb(newToken));
+  refreshSubscribers = [];
+}
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // If 401 and we haven't already retried this request
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      if (isRefreshing) {
+        // Queue this request until the refresh completes
+        return new Promise((resolve) => {
+          subscribeTokenRefresh((newToken) => {
+            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+            resolve(apiClient(originalRequest));
+          });
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const { data: { session }, error: refreshError } =
+          await supabase.auth.refreshSession();
+
+        if (refreshError || !session) {
+          throw refreshError || new Error('Session refresh returned no session');
+        }
+
+        isRefreshing = false;
+        onRefreshed(session.access_token);
+
+        originalRequest.headers.Authorization = `Bearer ${session.access_token}`;
+        return apiClient(originalRequest);
+      } catch (refreshErr) {
+        isRefreshing = false;
+        refreshSubscribers = [];
+
+        // Dispatch event so the app can redirect to login, show toast, etc.
+        window.dispatchEvent(new CustomEvent('auth:session-expired', {
+          detail: { reason: refreshErr.message },
+        }));
+
+        return Promise.reject(refreshErr);
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+export default apiClient;

--- a/Frontend/src/user/pages/TicketTracking.jsx
+++ b/Frontend/src/user/pages/TicketTracking.jsx
@@ -8,7 +8,7 @@ import useTicketStore from "../../store/ticketStore";
 import useAuthStore from "../../store/authStore";
 import { Card, CardContent } from "../../components/ui/card";
 import TicketTimeline from "../components/TicketTimeline";
-import axios from 'axios';
+import apiClient from '../../services/apiClient';
 import { API_CONFIG } from '../../config';
 
 const TicketTracking = () => {
@@ -68,7 +68,7 @@ const TicketTracking = () => {
                     routing_confidence: aiTicket.confidence
                 };
 
-                const res = await axios.post(`${API_CONFIG.BACKEND_URL}/tickets/save`, savePayload);
+                const res = await apiClient.post('/tickets/save', savePayload);
 
                 if (res.data?.ticket_id) {
                     const newTicket = { ...aiTicket, id: res.data.ticket_id, ticket_id: res.data.ticket_id, status };


### PR DESCRIPTION
## Summary
Adds automatic Supabase auth token injection to all API requests via an axios interceptor, fixing the 401 errors that occur when backend auth is enforced.

## Changes
- **New file: `Frontend/src/services/apiClient.js`** — Axios instance with:
  - Request interceptor that attaches the current Supabase access token as a Bearer header
  - Response interceptor that handles 401s with automatic token refresh
  - Queues concurrent requests during refresh to avoid race conditions
  - Dispatches `auth:session-expired` custom event on refresh failure
- **Updated `Frontend/src/services/api.js`** — Replaced plain `axios` with `apiClient`
- **Updated `Frontend/src/user/pages/TicketTracking.jsx`** — Replaced plain `axios` with `apiClient`

## Testing
- All existing API calls now automatically include the auth token
- 401 responses trigger automatic token refresh before retrying
- Session expiry dispatches a DOM event that the app can listen to for redirect/login

## Related Issues
Fixes #749