### PR TITLE
fix: resolve TOCTOU race condition in DuplicateService (Fixes #737)

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -1,10 +1,16 @@
 """
 Duplicate Detection Service
 Uses sentence-transformers all-MiniLM-L6-v2 to detect similar tickets.
+
+Thread-safety: all mutable state is guarded by a threading.Lock to prevent
+TOCTOU race conditions in save_to_disk() and list mutation in add_ticket().
 """
 
-import uuid
+import json
 import os
+import tempfile
+import threading
+import uuid
 from sentence_transformers import SentenceTransformer, util
 
 SIMILARITY_THRESHOLD = 0.70
@@ -19,6 +25,8 @@ class DuplicateService:
         self._tickets: list[tuple[str, object, str]] = []
         self.storage_file = os.path.join(os.path.dirname(__file__), "..", "data", "case_history_cache.json")
         os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
+        # Lock for thread-safe access to _tickets and storage_file
+        self._lock = threading.Lock()
 
     def is_available(self) -> bool:
         """Check if the model is available for duplicate detection."""
@@ -43,10 +51,11 @@ class DuplicateService:
             
             if os.path.exists(self.storage_file):
                 print(f"[DuplicateService] Syncing previous ticket history from {self.storage_file}...")
-                import json
                 try:
                     with open(self.storage_file, "r") as f:
                         data = json.load(f)
+                        if not isinstance(data, list):
+                            data = []
                         for item in data:
                             text = item["text"]
                             embedding = self.model.encode(text, convert_to_tensor=True)
@@ -66,35 +75,60 @@ class DuplicateService:
                 raise
 
     def save_to_disk(self, ticket_id: str, text: str):
-        """Append a new ticket to the JSON storage."""
-        import json
-        data = []
-        try:
-            os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
-            if os.path.exists(self.storage_file):
-                with open(self.storage_file, "r") as f:
-                    try:
-                        data = json.load(f)
-                        if not isinstance(data, list):
+        """Append a new ticket to the JSON storage atomically.
+
+        Uses a lock to prevent TOCTOU race conditions where concurrent reads
+        could overwrite each other's writes. Writes to a temp file first, then
+        renames for atomicity.
+        """
+        with self._lock:
+            data = []
+            try:
+                os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
+                if os.path.exists(self.storage_file):
+                    with open(self.storage_file, "r") as f:
+                        try:
+                            data = json.load(f)
+                            if not isinstance(data, list):
+                                data = []
+                        except (json.JSONDecodeError, ValueError):
                             data = []
-                    except:
-                        data = []
-            
-            data.append({"ticket_id": ticket_id, "text": text})
-            with open(self.storage_file, "w") as f:
-                json.dump(data, f, indent=2)
-            print(f"[DuplicateService] Indexed ticket {ticket_id} to case history.")
-        except Exception as e:
-            print(f"[DuplicateService] Failed to save to disk: {e}")
+                
+                data.append({"ticket_id": ticket_id, "text": text})
+
+                # Atomic write: write to temp file, then rename
+                dir_name = os.path.dirname(self.storage_file)
+                with tempfile.NamedTemporaryFile(
+                    mode="w", dir=dir_name, suffix=".tmp", delete=False
+                ) as tmp:
+                    json.dump(data, tmp, indent=2)
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                    tmp_name = tmp.name
+
+                os.replace(tmp_name, self.storage_file)
+                print(f"[DuplicateService] Indexed ticket {ticket_id} to case history.")
+            except Exception as e:
+                print(f"[DuplicateService] Failed to save to disk: {e}")
+                # Clean up temp file if rename failed
+                try:
+                    if 'tmp_name' in locals() and os.path.exists(tmp_name):
+                        os.unlink(tmp_name)
+                except OSError:
+                    pass
 
     def add_ticket(self, ticket_id: str, text: str):
-        """Add a ticket to the in-memory store and persist to disk."""
+        """Add a ticket to the in-memory store and persist to disk.
+
+        Thread-safe: lock prevents interleaved appends to _tickets.
+        """
         self.load()
         if not self.is_available():
             print(f"[DuplicateService] DEGRADED: Skipping embedding for ticket {ticket_id} (model not available)")
             return
         embedding = self.model.encode(text, convert_to_tensor=True)
-        self._tickets.append((ticket_id, embedding, text))
+        with self._lock:
+            self._tickets.append((ticket_id, embedding, text))
         self.save_to_disk(ticket_id, text)
 
     def check_duplicate(self, text: str, threshold: float = None) -> dict:
@@ -126,7 +160,11 @@ class DuplicateService:
         # Use provided threshold or default to global constant
         active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD
 
-        if not self._tickets:
+        # Take a snapshot of tickets under lock to avoid mutation during iteration
+        with self._lock:
+            tickets_snapshot = list(self._tickets)
+
+        if not tickets_snapshot:
             return {
                 "is_duplicate": False,
                 "duplicate_ticket_id": None,
@@ -138,7 +176,7 @@ class DuplicateService:
         best_score = 0.0
         best_id = None
 
-        for ticket_id, stored_emb, _ in self._tickets:
+        for ticket_id, stored_emb, _ in tickets_snapshot:
             score = util.cos_sim(query_embedding, stored_emb).item()
             if score > best_score:
                 best_score = score


### PR DESCRIPTION
## Summary
Fixes the TOCTOU (time-of-check-time-of-use) race condition in `DuplicateService` that could cause data loss and inconsistent state under concurrent requests.

## Changes

### Problem 1 — Non-atomic file write
`save_to_disk()` read the entire JSON file, appended an entry, and wrote it back. Two concurrent requests could both read the same initial state, and the second write would overwrite the first, losing a ticket permanently.

**Fix:** Added `threading.Lock` around the read-modify-write cycle and use atomic file writes (write to temp file + `os.replace()`).

### Problem 2 — Unsafe in-memory list mutation
`self._tickets.append()` was not thread-safe. Under concurrent FastAPI requests, appends could interleave.

**Fix:** All mutations to `self._tickets` are now guarded by the same `threading.Lock`.

### Problem 3 — Mutation during iteration
`check_duplicate()` iterated over `self._tickets` directly, which could fail if another thread modified the list during iteration.

**Fix:** `check_duplicate()` now takes a snapshot of the list under lock before iterating.

## Testing
- Verify duplicate detection still works correctly
- Test concurrent requests don't lose tickets
- Confirm atomic file writes (no partial JSON on crash)

## Related Issues
Fixes #737