### PR TITLE
fix: add authentication to /tickets and /ai/log_correction (#786, #785)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -544,27 +544,34 @@ async def get_tickets(
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
 
-    # Resolve company_id from user profile if not explicitly provided
+    # SECURITY: Always resolve company_id from authenticated user profile.
+    # Ignore any client-provided company_id to prevent cross-tenant data leaks.
+    user_id = user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=403, detail="User ID not found in token")
+
+    try:
+        profile_res = (
+            supabase.table("profiles")
+            .select("company_id")
+            .eq("id", user_id)
+            .single()
+            .execute()
+        )
+        profile = profile_res.data or {}
+        company_id = profile.get("company_id")
+    except Exception:
+        raise HTTPException(status_code=403, detail="Unable to resolve tenant for this user")
+
     if not company_id:
-        user_id = user.get("id")
-        if user_id:
-            try:
-                profile_res = (
-                    supabase.table("profiles")
-                    .select("company_id")
-                    .eq("id", user_id)
-                    .single()
-                    .execute()
-                )
-                profile = profile_res.data or {}
-                company_id = profile.get("company_id")
-            except Exception:
-                pass  # Fall through to unfiltered query
+        raise HTTPException(status_code=403, detail="No company assigned to this user")
 
-    query = supabase.table("tickets").select("*").order("created_at", desc=True)
-    if company_id:
-        query = query.eq("company_id", company_id)
-
+    query = (
+        supabase.table("tickets")
+        .select("*")
+        .eq("company_id", company_id)
+        .order("created_at", desc=True)
+    )
     res = query.execute()
     return res.data
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -475,8 +475,8 @@ async def analyze_bug(request: BugReportAnalysisRequest):
 CORRECTIONS_LOG_PATH = Path(__file__).parent / "data" / "corrections_log.json"
 
 @app.post("/ai/log_correction")
-async def log_correction(raw_request: Request):
-    """Log an admin correction when the AI prediction differs from the human decision."""
+async def log_correction(raw_request: Request, user: dict = Depends(get_current_user)):
+    """Log an admin correction when the AI prediction differs from the human decision. Requires authentication."""
     try:
         body = await raw_request.json()
     except Exception as e:
@@ -536,15 +536,35 @@ async def log_correction(raw_request: Request):
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
-    """Fetch persistent tickets from Supabase."""
+async def get_tickets(
+    company_id: str | None = None,
+    user: dict = Depends(get_current_user),
+):
+    """Fetch persistent tickets from Supabase. Requires authentication."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    # Resolve company_id from user profile if not explicitly provided
+    if not company_id:
+        user_id = user.get("id")
+        if user_id:
+            try:
+                profile_res = (
+                    supabase.table("profiles")
+                    .select("company_id")
+                    .eq("id", user_id)
+                    .single()
+                    .execute()
+                )
+                profile = profile_res.data or {}
+                company_id = profile.get("company_id")
+            except Exception:
+                pass  # Fall through to unfiltered query
+
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
     if company_id:
         query = query.eq("company_id", company_id)
-        
+
     res = query.execute()
     return res.data
 


### PR DESCRIPTION
## Summary
Fixes #786 and #785 — Adds authentication to two unprotected endpoints that expose sensitive data.

## Changes

### GET /tickets (#786)
- Added `Depends(get_current_user)` requirement
- Auto-resolves `company_id` from user profile when not explicitly provided
- Prevents unauthenticated enumeration of all tickets across tenants

### POST /ai/log_correction (#785)
- Added `Depends(get_current_user)` requirement
- Prevents fabricated correction data from polluting the training dataset

## Security Impact
- **Before:** Anyone could enumerate all tickets via `GET /tickets` and submit fake corrections via `POST /ai/log_correction`
- **After:** Both endpoints require valid session cookies (Supabase auth)

## Testing
- Unauthenticated requests to `GET /tickets` now return 401
- Unauthenticated requests to `POST /ai/log_correction` now return 401
- Authenticated requests continue to work as before
- Company-scoped ticket filtering works automatically from user profile

Fixes #786
Fixes #785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API endpoints for AI corrections and ticket retrieval now require authentication
  * Ticket retrieval results are filtered by user's company for improved data isolation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ritesh-1918/HELPDESK.AI/pull/791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->