### PR TITLE
fix(ui): persist company size dropdown selection across reloads

### DIFF
--- a/Frontend/src/pages/ContactSales.jsx
+++ b/Frontend/src/pages/ContactSales.jsx
@@ -14,12 +14,15 @@ export default function ContactSales() {
         email: '',
         company: '',
         phone: '',
-        company_size: '50-200',
+        company_size: localStorage.getItem('contact_company_size') || '50-200',
         message: ''
     });
 
     const handleChange = (e) => {
         setFormData({ ...formData, [e.target.name]: e.target.value });
+        if (e.target.name === 'company_size') {
+            localStorage.setItem('contact_company_size', e.target.value);
+        }
     };
 
     const handleSubmit = async (e) => {


### PR DESCRIPTION
## Description

This PR fixes the bug reported in #362 where the 'Company Size' dropdown on the Contact Sales page (`ContactSales.jsx`) loses its selected value and reverts to the default ('50-200') upon browser refresh.

### Changes Made:
- Initialized `company_size` in the `formData` state to restore from `localStorage` (falling back to '50-200' if not present).
- Updated the `handleChange` function to save the new selection to `localStorage` whenever the user changes the `company_size` dropdown.

## Related Issues
Closes #362

*(Note: Reward payout address is 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Contact Sales form now remembers your previously selected company size. When you return to the form, your last selection is automatically restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->