### PR TITLE
CRITICAL: Fix missing import crash in AdminTicketDetail + add XSS sanitization to AI chat (Fixes #858)

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -37,6 +37,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
     "recharts": "^3.7.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "source-map": "^0.7.6",
     "tailwind-merge": "^3.5.0",

--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -19,6 +19,7 @@ import TicketTimeline from "../../user/components/TicketTimeline";
 import TicketAuditTimeline from "../components/TicketAuditTimeline";
 import TicketTagManager from '../../components/TicketTagManager';
 import TagChip from '../../components/TagChip';
+import { safeDisplayText } from "../../utils/sanitizeText";
 
 const AdminTicketDetail = () => {
     const { ticket_id } = useParams();

--- a/Frontend/src/user/pages/AutoResolveChat.jsx
+++ b/Frontend/src/user/pages/AutoResolveChat.jsx
@@ -10,6 +10,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import useTicketStore from '../../store/ticketStore';
 import { Card, CardContent } from "../../components/ui/card";
 import { askAI } from '../../services/aiAssistant';
@@ -343,6 +344,7 @@ const AutoResolveChat = () => {
                                                 {msg.role === 'bot' ? (
                                                     <ReactMarkdown
                                                         remarkPlugins={[remarkGfm]}
+                                                        rehypePlugins={[rehypeSanitize]}
                                                         components={{
                                                             ul: ({ ...props }) => <ul className="list-disc ml-4 space-y-2 mb-3" {...props} />,
                                                             ol: ({ ...props }) => <ol className="list-decimal ml-4 space-y-2 mb-3" {...props} />,


### PR DESCRIPTION
## CRITICAL + Frontend Stability & Security Issues

### Issue 1: CRITICAL - Missing Import Causes Runtime Crash in AdminTicketDetail

**File:** `Frontend/src/admin/pages/AdminTicketDetail.jsx`

The component uses `safeDisplayText()` on lines 202, 203, and 206 but the function is never imported from `../../utils/sanitizeText`. This causes a `ReferenceError` at runtime, completely breaking the admin ticket detail page.

**Fix:** Added `import { safeDisplayText } from "../../utils/sanitizeText";`

---

### Issue 2: HIGH - AI Chat Renders Unsanitized Markdown (XSS Vector)

**File:** `Frontend/src/user/pages/AutoResolveChat.jsx` (lines 344-362)

`ReactMarkdown` renders AI-generated responses without `rehype-sanitize`. If the AI model ever returns HTML with event handlers (`onerror`, `onload`), script tags, or other dangerous content, it could execute in the user's browser leading to stored XSS. AI-generated content is unpredictable and could be manipulated via prompt injection.

**Fix:** Added `rehype-sanitize` plugin to the `rehypePlugins` array on the `ReactMarkdown` instance, with custom component overrides preserved for styling.

---

**Branch with fixes:** `fix/frontend-critical-crashes-and-secrets`
#858 