### PR TITLE
fix(utils): resolve Safari date parsing issue by normalizing ISO strings

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -8,9 +8,17 @@ export const formatTimelineDate = (dateStr) => {
     
     // Ensure the date string is interpreted as UTC if it's an ISO string from DB
     let date;
-    if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
-        // If it's a raw string without TZ, assume it was intended as UTC from our backend
-        date = new Date(dateStr + 'Z');
+    if (typeof dateStr === 'string') {
+        // Fix for older Safari browsers where "YYYY-MM-DD HH:MM:SS" causes Invalid Date
+        // We replace the space with 'T' before parsing.
+        dateStr = dateStr.replace(/^(\d{4}-\d{2}-\d{2})\s(\d{2}:\d{2}:\d{2}(?:\.\d+)?)/, '$1T$2');
+        
+        if (!dateStr.includes('Z') && !dateStr.includes('+')) {
+            // If it's a raw string without TZ, assume it was intended as UTC from our backend
+            date = new Date(dateStr + 'Z');
+        } else {
+            date = new Date(dateStr);
+        }
     } else {
         date = new Date(dateStr);
     }


### PR DESCRIPTION
## Description

This PR fixes the ticket timeline date parsing discrepancies observed on older Safari browsers, as outlined in #642.

### Changes Made:
- Updated `Frontend/src/utils/dateUtils.js` to normalize incoming date strings by converting space-separated formats (`YYYY-MM-DD HH:MM:SS`) into strict ISO-8601 strings (using a `T` separator) before passing them to the native `Date` constructor. Safari historically returns `Invalid Date` for timestamps missing the `T` separator.
- Ensured the fix acts as a seamless pre-processor, preserving all downstream UTC normalization and timezone logic.

## Related Issues
Closes #642

---
*Payout Address (Solana):* `6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date string parsing to ensure consistent and reliable date display across different browsers, particularly in timeline views where date formatting is critical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->