### PR TITLE
Fix: Resolve AdminTicketDetail crash and AutoResolveChat XSS

### DIFF
--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -19,6 +19,7 @@ import TicketTimeline from "../../user/components/TicketTimeline";
 import TicketAuditTimeline from "../components/TicketAuditTimeline";
 import TicketTagManager from '../../components/TicketTagManager';
 import TagChip from '../../components/TagChip';
+import { safeDisplayText } from "../../utils/sanitizeText";
 
 const AdminTicketDetail = () => {
     const { ticket_id } = useParams();

--- a/Frontend/src/user/pages/AutoResolveChat.jsx
+++ b/Frontend/src/user/pages/AutoResolveChat.jsx
@@ -10,6 +10,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import useTicketStore from '../../store/ticketStore';
 import { Card, CardContent } from "../../components/ui/card";
 import { askAI } from '../../services/aiAssistant';
@@ -343,6 +344,7 @@ const AutoResolveChat = () => {
                                                 {msg.role === 'bot' ? (
                                                     <ReactMarkdown
                                                         remarkPlugins={[remarkGfm]}
+                                                        rehypePlugins={[rehypeSanitize]}
                                                         components={{
                                                             ul: ({ ...props }) => <ul className="list-disc ml-4 space-y-2 mb-3" {...props} />,
                                                             ol: ({ ...props }) => <ol className="list-decimal ml-4 space-y-2 mb-3" {...props} />,


### PR DESCRIPTION
Fixes #858

This PR addresses the critical frontend bugs reported in issue #858:

1. **AdminTicketDetail Crash**: Added the missing import for \safeDisplayText\ from \../../utils/sanitizeText\ to prevent the \ReferenceError\ when the component renders.
2. **AutoResolveChat XSS**: Added \ehype-sanitize\ to the \ReactMarkdown\ component to prevent potential cross-site scripting attacks from AI-generated markdown content.

💳 **Payment Details**:
- Method: USDC
- Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
- Network: Base