### PR TITLE
Fix: Make Navbar sticky during scrolling

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -112,7 +112,7 @@ html {
 }
 
 body{
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Dark Mode Global Overrides */

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -112,6 +112,7 @@ html {
 }
 
 body{
+  overflow-x: hidden;
   overflow-x: clip;
 }
 


### PR DESCRIPTION
Fixes #856
Fixes #876

This PR resolves the issue where the Navbar would disappear when scrolling down the page.

**Changes:**
- Replaced \overflow-x: hidden\ with \overflow-x: clip\ on the \ody\ element in \Frontend/src/index.css\. 
- **Why**: Using \overflow-x: hidden\ creates a clipping context that completely breaks \position: sticky\ for all descendant elements in CSS. Using \overflow-x: clip\ achieves the desired horizontal overflow prevention without breaking the sticky positioning of the \TopNav\ component.

💳 **Payment Details**:
- Method: USDC
- Address: 0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2
- Network: Base