### PR TITLE
test: add unit tests for OCRService (Fixes #428)

### DIFF
--- a/backend/tests/test_ocr_service.py
+++ b/backend/tests/test_ocr_service.py
@@ -117,8 +117,8 @@ class TestGetReader:
         original = ocr_mod._reader
         mock_reader = MagicMock()
         ocr_mod._reader = mock_reader
-
-        result = ocr_mod._get_reader()
-        assert result is mock_reader
-
-        ocr_mod._reader = original
+        try:
+            result = ocr_mod._get_reader()
+            assert result is mock_reader
+        finally:
+            ocr_mod._reader = original

--- a/backend/tests/test_ocr_service.py
+++ b/backend/tests/test_ocr_service.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for OCRService.
+Tests cover: extract_text with various inputs, data URI handling,
+padding correction, error handling, and degraded mode.
+"""
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def service():
+    from backend.services.ocr_service import OCRService
+    return OCRService()
+
+
+@pytest.fixture()
+def mock_reader():
+    """Provide a mock EasyOCR reader."""
+    with patch("backend.services.ocr_service._get_reader") as mock_get:
+        reader = MagicMock()
+        mock_get.return_value = reader
+        yield reader
+
+
+class TestExtractText:
+    def test_empty_input(self, service):
+        assert service.extract_text("") == ""
+
+    def test_none_input(self, service):
+        assert service.extract_text(None) == ""
+
+    def test_basic_extraction(self, service, mock_reader):
+        mock_reader.readtext.return_value = ["Hello", "World"]
+        b64 = base64.b64encode(b"fake image").decode()
+        result = service.extract_text(b64)
+        assert result == "Hello World"
+        mock_reader.readtext.assert_called_once()
+
+    def test_strips_data_uri_prefix(self, service, mock_reader):
+        mock_reader.readtext.return_value = ["text"]
+        data_uri = "data:image/png;base64," + base64.b64encode(b"img").decode()
+        result = service.extract_text(data_uri)
+        assert result == "text"
+
+    def test_handles_missing_padding(self, service, mock_reader):
+        """Base64 strings without padding should be handled."""
+        mock_reader.readtext.return_value = ["ok"]
+        # Create a base64 string that needs padding
+        raw = base64.b64encode(b"test").decode()
+        # Remove padding chars
+        unpadded = raw.rstrip("=")
+        result = service.extract_text(unpadded)
+        assert result == "ok"
+
+    def test_joins_multiple_results(self, service, mock_reader):
+        mock_reader.readtext.return_value = ["line1", "line2", "line3"]
+        b64 = base64.b64encode(b"img").decode()
+        result = service.extract_text(b64)
+        assert result == "line1 line2 line3"
+
+    def test_empty_readtext_result(self, service, mock_reader):
+        mock_reader.readtext.return_value = []
+        b64 = base64.b64encode(b"img").decode()
+        result = service.extract_text(b64)
+        assert result == ""
+
+    def test_exception_returns_empty(self, service, mock_reader):
+        mock_reader.readtext.side_effect = RuntimeError("OCR failed")
+        b64 = base64.b64encode(b"bad").decode()
+        result = service.extract_text(b64)
+        assert result == ""
+
+    def test_readtext_called_with_detail_0(self, service, mock_reader):
+        mock_reader.readtext.return_value = ["text"]
+        b64 = base64.b64encode(b"img").decode()
+        service.extract_text(b64)
+        call_args = mock_reader.readtext.call_args
+        assert call_args[1]["detail"] == 0
+        assert call_args[1]["paragraph"] is True
+
+
+class TestGetReader:
+    def test_lazy_initialization(self):
+        """_get_reader should initialize EasyOCR on first call."""
+        import backend.services.ocr_service as ocr_mod
+
+        # Reset global state
+        original = ocr_mod._reader
+        ocr_mod._reader = None
+
+        # easyocr is imported inside _get_reader, so we mock the import
+        mock_easyocr = MagicMock()
+        mock_reader_instance = MagicMock()
+        mock_easyocr.Reader.return_value = mock_reader_instance
+
+        import sys
+        saved = sys.modules.get("easyocr")
+        sys.modules["easyocr"] = mock_easyocr
+        try:
+            reader = ocr_mod._get_reader()
+            assert reader is mock_reader_instance
+            mock_easyocr.Reader.assert_called_once_with(["en"], gpu=False)
+        finally:
+            ocr_mod._reader = original
+            if saved is not None:
+                sys.modules["easyocr"] = saved
+            else:
+                sys.modules.pop("easyocr", None)
+
+    def test_caches_reader(self):
+        """_get_reader should return the same instance on subsequent calls."""
+        import backend.services.ocr_service as ocr_mod
+
+        original = ocr_mod._reader
+        mock_reader = MagicMock()
+        ocr_mod._reader = mock_reader
+
+        result = ocr_mod._get_reader()
+        assert result is mock_reader
+
+        ocr_mod._reader = original


### PR DESCRIPTION
Fixes #428

## Summary

Adds unit tests for `OCRService` in `backend/services/ocr_service.py`. All 11 tests pass with EasyOCR mocked.

## Changes

- Created `backend/tests/test_ocr_service.py` with 11 test cases
- Tests `extract_text()`: empty input, basic extraction, data URI stripping, base64 padding, multi-line joining, error handling, paragraph mode
- Tests `_get_reader()`: lazy initialization, caching behavior
- All heavy dependencies mocked — no EasyOCR download required

## Testing

```bash
python -m pytest backend/tests/test_ocr_service.py -v
```

Result: 11 passed in 0.17s

## Test Coverage

| Category | Tests | Description |
|----------|-------|-------------|
| extract_text | 9 | Empty, None, basic, data URI, padding, multi-line, empty result, exception, readtext args |
| _get_reader | 2 | Lazy init, caching |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for text extraction functionality, covering input validation across encoding formats, error handling with appropriate fallbacks, output concatenation, and empty result handling
  * Verifies OCR reader initialization with lazy instantiation and instance caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->