### PR TITLE
fix: enforce server-side role verification in admin route (Fixes #909)

### DIFF
--- a/Frontend/src/components/shared/AdminProtectedRoute.jsx
+++ b/Frontend/src/components/shared/AdminProtectedRoute.jsx
@@ -1,15 +1,79 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import useAuthStore from '../../store/authStore';
+import { API_CONFIG } from '../../config';
+
+const BACKEND_URL = API_CONFIG.BACKEND_URL;
 
 /**
  * AdminProtectedRoute Component
  * Restricts access to routes to only users with the 'admin' role.
+ *
+ * SECURITY: Role is verified server-side via /auth/me/role on every mount.
+ * Client-side profile.role from Zustand/localStorage is NEVER trusted for
+ * authorization decisions — it is only used for UI display (e.g. nav items).
  */
 const AdminProtectedRoute = () => {
-    const { user, profile, loading, isCheckingSession } = useAuthStore();
+    const { user, loading, isCheckingSession } = useAuthStore();
+    const [serverRole, setServerRole] = useState(null);
+    const [serverStatus, setServerStatus] = useState(null);
+    const [verifying, setVerifying] = useState(true);
+    const [error, setError] = useState(null);
 
-    if (loading || isCheckingSession) {
+    // Verify role from the database on every mount / user change
+    useEffect(() => {
+        if (!user) {
+            setVerifying(false);
+            return;
+        }
+
+        let cancelled = false;
+
+        const verifyRole = async () => {
+            setVerifying(true);
+            setError(null);
+            try {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), 5000);
+                const res = await fetch(`${BACKEND_URL}/auth/me/role`, {
+                    method: 'GET',
+                    credentials: 'include',
+                    headers: { Accept: 'application/json' },
+                    signal: controller.signal,
+                });
+                clearTimeout(timeout);
+
+                if (cancelled) return;
+
+                if (!res.ok) {
+                    setServerRole(null);
+                    setServerStatus(null);
+                    setError('Unable to verify admin access');
+                    return;
+                }
+
+                const body = await res.json();
+                if (!cancelled) {
+                    setServerRole(body.role);
+                    setServerStatus(body.status);
+                }
+            } catch (e) {
+                if (!cancelled) {
+                    setServerRole(null);
+                    setServerStatus(null);
+                    setError('Unable to verify admin access');
+                }
+            } finally {
+                if (!cancelled) setVerifying(false);
+            }
+        };
+
+        verifyRole();
+        return () => { cancelled = true; };
+    }, [user]);
+
+    // Show spinner while checking session or verifying role
+    if (loading || isCheckingSession || verifying) {
         return (
             <div className="flex h-screen w-screen items-center justify-center bg-white">
                 <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent"></div>
@@ -17,35 +81,29 @@ const AdminProtectedRoute = () => {
         );
     }
 
-    // Check if the user is authenticated from Supabase
+    // Not authenticated
     if (!user) {
         return <Navigate to="/login" replace />;
     }
 
-    // If we have a user but no profile yet, wait for the database fetch
-    if (!profile || profile.role === undefined) {
-        return (
-            <div className="flex h-screen w-screen items-center justify-center bg-[#050508]">
-                <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent"></div>
-            </div>
-        );
+    // Server-side verification failed
+    if (error) {
+        return <Navigate to="/" replace />;
     }
 
-    // Check if the user's profile role is 'admin' or 'super_admin'
-    // Enforce role
-    if (profile.role !== "admin" && profile.role !== "super_admin") {
-        // Basic redirect for non-admins if they try to access admin routes
+    // Authorize based on SERVER-VERIFIED role (not client-side profile)
+    if (serverRole !== 'admin' && serverRole !== 'super_admin') {
         return <Navigate to="/" replace />;
     }
 
     // Enforce active status for admins (Master Admin approval)
-    if (profile.status === "rejected") {
+    if (serverStatus === 'rejected') {
         return <Navigate to="/not-approved" replace />;
-    } else if (profile.status !== "active") {
+    } else if (serverStatus !== 'active') {
         return <Navigate to="/admin-lobby" replace />;
     }
 
-    // Authorised and active: render the protected layout
+    // Authorized and active: render the protected layout
     return <Outlet />;
 };
 

--- a/backend/auth_cookie.py
+++ b/backend/auth_cookie.py
@@ -177,3 +177,35 @@ async def auth_logout(request: Request, response: Response):
 @router.get("/me")
 async def auth_me(user: dict = Depends(get_current_user)):
     return {"user": user}
+
+
+@router.get("/me/role")
+async def auth_me_role(user: dict = Depends(get_current_user)):
+    """Return the authoritative role and status from the database profiles table.
+
+    This endpoint is the single source of truth for authorization decisions.
+    Client-side caches (localStorage, Zustand persist) must NOT be trusted for
+    role-based access control — always call this endpoint instead.
+    """
+    from supabase import create_client as _create_client
+
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_ANON_KEY")
+    if not url or not key:
+        raise HTTPException(status_code=503, detail="Auth backend not configured")
+
+    user_id = user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid user session")
+
+    try:
+        client = _create_client(url, key)
+        result = client.table("profiles").select("role, status").eq("id", user_id).single().execute()
+        data = getattr(result, "data", None) or {}
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Profile lookup failed: {exc}") from exc
+
+    return {
+        "role": data.get("role", "user"),
+        "status": data.get("status", "pending_email_verification"),
+    }


### PR DESCRIPTION
Fixes #909

## Summary
Remove client-side role caching trust and enforce synchronous server-side role resolution for admin route access.

## Root Cause
The `AdminProtectedRoute` component trusted `profile.role` from the Zustand store (which persists to localStorage). An attacker could tamper with localStorage to inject `role: 'admin'` and bypass the client-side authorization check.

## Changes

### Backend (`auth_cookie.py`)
- **New endpoint `GET /auth/me/role`**: Queries the database `profiles` table for the authoritative `role` and `status`. This is the single source of truth for authorization decisions.

### Frontend (`AdminProtectedRoute.jsx`)
- **Server-side role verification**: On every mount, the component calls `/auth/me/role` to get the authoritative role from the database
- **No client-side trust**: `profile.role` from Zustand/localStorage is NEVER used for authorization — only for UI display
- **Abort controller**: 5-second timeout prevents indefinite loading on backend failure
- **Graceful degradation**: If the server verification fails, the user is redirected (not granted access)

## Security Model
```
Before: localStorage profile.role → AdminProtectedRoute → render admin UI
After:  /auth/me/role (DB query) → AdminProtectedRoute → render admin UI
```

## Testing
- Verify admin users can still access admin routes
- Verify non-admin users are redirected to /
- Verify tampered localStorage does not grant admin access
- Verify backend failure results in redirect (not access grant)