### PR TITLE
feat: add interactive keyboard shortcuts for admin dashboard navigation (Fixes #911)

### DIFF
--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -1,17 +1,39 @@
-import React, { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useState, useCallback } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import KeyboardLegend from '../../components/KeyboardLegend';
 
 /**
  * AdminLayout Component
  * Master framework for the administrative zone.
  * Enforces a fixed-sidebar architecture with a centered, high-density content terminal.
+ *
+ * Includes keyboard shortcuts for rapid navigation (press ? to see all shortcuts).
  */
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const navigate = useNavigate();
+
+    // Keyboard shortcut: create new ticket navigates to tickets page
+    const handleNewTicket = useCallback(() => {
+        navigate('/admin/tickets');
+    }, [navigate]);
+
+    // Keyboard shortcut: refresh reloads the current page
+    const handleRefresh = useCallback(() => {
+        window.location.reload();
+    }, []);
+
+    // Register keyboard shortcuts
+    const { showLegend, closeLegend } = useKeyboardShortcuts({
+        enabled: true,
+        onNewTicket: handleNewTicket,
+        onRefresh: handleRefresh,
+    });
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
@@ -43,6 +65,9 @@ const AdminLayout = () => {
 
             {/* Real-time System Notifications */}
             <NotificationToast />
+
+            {/* Keyboard Shortcuts Legend Modal */}
+            <KeyboardLegend isOpen={showLegend} onClose={closeLegend} />
 
             {/* Mobile Nav Overlay (Emergency protocols) */}
             {isMobileNavOpen && (

--- a/Frontend/src/components/KeyboardLegend.jsx
+++ b/Frontend/src/components/KeyboardLegend.jsx
@@ -15,10 +15,18 @@ import { SHORTCUT_LIST } from '../hooks/useKeyboardShortcuts';
  */
 export default function KeyboardLegend({ isOpen, onClose }) {
   const overlayRef = useRef(null);
+  const closeButtonRef = useRef(null);
+  const previousFocusRef = useRef(null);
 
-  // Close on click outside
+  // Focus trap and keyboard handling
   useEffect(() => {
     if (!isOpen) return;
+
+    // Store previously focused element
+    previousFocusRef.current = document.activeElement;
+
+    // Focus close button when modal opens
+    closeButtonRef.current?.focus();
 
     function handleClickOutside(e) {
       if (overlayRef.current && e.target === overlayRef.current) {
@@ -26,8 +34,47 @@ export default function KeyboardLegend({ isOpen, onClose }) {
       }
     }
 
+    function handleKeyDown(e) {
+      // Close on Escape
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      // Trap Tab/Shift+Tab within modal
+      if (e.key === 'Tab') {
+        const focusableElements = overlayRef.current?.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusableElements || focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          // Shift+Tab: if on first element, move to last
+          if (document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          // Tab: if on last element, move to first
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    }
+
     document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+      // Restore focus to previously focused element
+      previousFocusRef.current?.focus();
+    };
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
@@ -85,6 +132,7 @@ export default function KeyboardLegend({ isOpen, onClose }) {
             ⌨️ Keyboard Shortcuts
           </h2>
           <button
+            ref={closeButtonRef}
             onClick={onClose}
             aria-label="Close"
             style={{

--- a/Frontend/src/components/KeyboardLegend.jsx
+++ b/Frontend/src/components/KeyboardLegend.jsx
@@ -1,0 +1,205 @@
+/**
+ * KeyboardLegend Modal
+ *
+ * Displays available keyboard shortcuts in a modal overlay.
+ * Triggered by pressing "?" or programmatically.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { SHORTCUT_LIST } from '../hooks/useKeyboardShortcuts';
+
+/**
+ * @param {Object} props
+ * @param {boolean} props.isOpen - Whether the modal is visible
+ * @param {Function} props.onClose - Callback when modal should close
+ */
+export default function KeyboardLegend({ isOpen, onClose }) {
+  const overlayRef = useRef(null);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(e) {
+      if (overlayRef.current && e.target === overlayRef.current) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      role="dialog"
+      aria-label="Keyboard shortcuts"
+      aria-modal="true"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        backdropFilter: 'blur(4px)',
+      }}
+    >
+      <div
+        style={{
+          background: '#1e293b',
+          color: '#f1f5f9',
+          borderRadius: '12px',
+          padding: '24px 32px',
+          maxWidth: '520px',
+          width: '90%',
+          maxHeight: '80vh',
+          overflowY: 'auto',
+          boxShadow: '0 20px 60px rgba(0, 0, 0, 0.4)',
+          border: '1px solid #334155',
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '20px',
+            borderBottom: '1px solid #334155',
+            paddingBottom: '12px',
+          }}
+        >
+          <h2
+            style={{
+              margin: 0,
+              fontSize: '18px',
+              fontWeight: 700,
+              color: '#f1f5f9',
+            }}
+          >
+            ⌨️ Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#94a3b8',
+              cursor: 'pointer',
+              fontSize: '20px',
+              padding: '4px 8px',
+              borderRadius: '4px',
+            }}
+            onMouseEnter={(e) => (e.target.style.color = '#f1f5f9')}
+            onMouseLeave={(e) => (e.target.style.color = '#94a3b8')}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Shortcut groups */}
+        {SHORTCUT_LIST.map((group) => (
+          <div key={group.group} style={{ marginBottom: '16px' }}>
+            <h3
+              style={{
+                fontSize: '12px',
+                fontWeight: 600,
+                textTransform: 'uppercase',
+                letterSpacing: '0.08em',
+                color: '#6366f1',
+                marginBottom: '8px',
+              }}
+            >
+              {group.group}
+            </h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              {group.shortcuts.map((shortcut) => (
+                <div
+                  key={shortcut.description}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '6px 0',
+                  }}
+                >
+                  <span style={{ color: '#94a3b8', fontSize: '14px' }}>
+                    {shortcut.description}
+                  </span>
+                  <span style={{ display: 'flex', gap: '4px' }}>
+                    {shortcut.keys.map((key, idx) => (
+                      <React.Fragment key={idx}>
+                        {idx > 0 && (
+                          <span
+                            style={{
+                              color: '#64748b',
+                              fontSize: '12px',
+                              alignSelf: 'center',
+                            }}
+                          >
+                            then
+                          </span>
+                        )}
+                        <kbd
+                          style={{
+                            display: 'inline-block',
+                            padding: '3px 8px',
+                            fontSize: '12px',
+                            fontWeight: 600,
+                            fontFamily: 'monospace',
+                            color: '#f1f5f9',
+                            background: '#334155',
+                            border: '1px solid #475569',
+                            borderRadius: '4px',
+                            boxShadow: '0 1px 2px rgba(0, 0, 0, 0.2)',
+                            minWidth: '24px',
+                            textAlign: 'center',
+                          }}
+                        >
+                          {key}
+                        </kbd>
+                      </React.Fragment>
+                    ))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {/* Footer hint */}
+        <div
+          style={{
+            marginTop: '16px',
+            paddingTop: '12px',
+            borderTop: '1px solid #334155',
+            fontSize: '12px',
+            color: '#64748b',
+            textAlign: 'center',
+          }}
+        >
+          Press <kbd style={kbdStyle}>?</kbd> to toggle this legend
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const kbdStyle = {
+  display: 'inline-block',
+  padding: '2px 6px',
+  fontSize: '11px',
+  fontWeight: 600,
+  fontFamily: 'monospace',
+  color: '#f1f5f9',
+  background: '#334155',
+  border: '1px solid #475569',
+  borderRadius: '3px',
+  margin: '0 2px',
+};

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -76,8 +76,7 @@ export function useKeyboardShortcuts({
   const focusSearch = useCallback(() => {
     const searchInput =
       document.querySelector('input[type="search"]') ||
-      document.querySelector('input[placeholder*="search" i]') ||
-      document.querySelector('input[placeholder*="Search" i]');
+      document.querySelector('input[placeholder*="search" i]');
     if (searchInput) {
       searchInput.focus();
       searchInput.select();

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,201 @@
+/**
+ * useKeyboardShortcuts Hook
+ *
+ * Provides keyboard shortcuts for rapid admin dashboard navigation
+ * and a keyboard legend helper modal.
+ *
+ * Shortcuts:
+ *   ?           — Toggle keyboard shortcuts legend
+ *   g d         — Go to Dashboard
+ *   g t         — Go to Tickets
+ *   g u         — Go to Users
+ *   g a         — Go to Analytics
+ *   g s         — Go to Settings
+ *   g p         — Go to Profile
+ *   Esc         — Close modal / cancel action
+ *   n           — Create new ticket (when not in input)
+ *   r           — Refresh current view
+ *   /           — Focus search input
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// Route map for navigation shortcuts
+const ADMIN_ROUTES = {
+  d: '/admin',
+  t: '/admin/tickets',
+  u: '/admin/users',
+  a: '/admin/analytics',
+  s: '/admin/settings',
+  p: '/admin/profile',
+};
+
+/**
+ * Check if the active element is an input field where shortcuts should not fire.
+ */
+function isInputFocused() {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  return (
+    tag === 'input' ||
+    tag === 'textarea' ||
+    tag === 'select' ||
+    el.isContentEditable
+  );
+}
+
+/**
+ * useKeyboardShortcuts
+ *
+ * @param {Object} options
+ * @param {boolean} options.enabled - Whether shortcuts are active (default: true)
+ * @param {Function} options.onNewTicket - Callback for "new ticket" action
+ * @param {Function} options.onRefresh - Callback for "refresh" action
+ * @returns {{ showLegend: boolean, toggleLegend: Function, closeLegend: Function }}
+ */
+export function useKeyboardShortcuts({
+  enabled = true,
+  onNewTicket,
+  onRefresh,
+} = {}) {
+  const [showLegend, setShowLegend] = useState(false);
+  const navigate = useNavigate();
+  const pendingKeyRef = useRef(null);
+  const pendingTimerRef = useRef(null);
+
+  const toggleLegend = useCallback(() => {
+    setShowLegend((prev) => !prev);
+  }, []);
+
+  const closeLegend = useCallback(() => {
+    setShowLegend(false);
+  }, []);
+
+  const focusSearch = useCallback(() => {
+    const searchInput =
+      document.querySelector('input[type="search"]') ||
+      document.querySelector('input[placeholder*="search" i]') ||
+      document.querySelector('input[placeholder*="Search" i]');
+    if (searchInput) {
+      searchInput.focus();
+      searchInput.select();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleKeyDown(e) {
+      // Always allow Escape
+      if (e.key === 'Escape') {
+        if (showLegend) {
+          setShowLegend(false);
+          e.preventDefault();
+          return;
+        }
+        // Blur any focused element
+        if (document.activeElement) {
+          document.activeElement.blur();
+        }
+        return;
+      }
+
+      // Don't fire shortcuts when typing in inputs
+      if (isInputFocused()) return;
+
+      // Don't fire when modifier keys are held (except Shift for ?)
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const key = e.key.toLowerCase();
+
+      // Handle two-key sequences (g + ...)
+      if (pendingKeyRef.current === 'g') {
+        clearTimeout(pendingTimerRef.current);
+        pendingKeyRef.current = null;
+
+        if (ADMIN_ROUTES[key]) {
+          e.preventDefault();
+          navigate(ADMIN_ROUTES[key]);
+          return;
+        }
+        // If not a valid second key, fall through
+      }
+
+      // Single-key shortcuts
+      switch (key) {
+        case '?':
+          e.preventDefault();
+          toggleLegend();
+          break;
+
+        case 'g':
+          // Start two-key sequence
+          pendingKeyRef.current = 'g';
+          pendingTimerRef.current = setTimeout(() => {
+            pendingKeyRef.current = null;
+          }, 1000);
+          break;
+
+        case 'n':
+          e.preventDefault();
+          if (onNewTicket) onNewTicket();
+          break;
+
+        case 'r':
+          e.preventDefault();
+          if (onRefresh) onRefresh();
+          else window.location.reload();
+          break;
+
+        case '/':
+          e.preventDefault();
+          focusSearch();
+          break;
+
+        default:
+          break;
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      if (pendingTimerRef.current) {
+        clearTimeout(pendingTimerRef.current);
+      }
+    };
+  }, [enabled, showLegend, navigate, toggleLegend, onNewTicket, onRefresh, focusSearch]);
+
+  return {
+    showLegend,
+    toggleLegend,
+    closeLegend,
+  };
+}
+
+/**
+ * Keyboard shortcut definitions for display in the legend modal.
+ */
+export const SHORTCUT_LIST = [
+  { group: 'Navigation', shortcuts: [
+    { keys: ['g', 'd'], description: 'Go to Dashboard' },
+    { keys: ['g', 't'], description: 'Go to Tickets' },
+    { keys: ['g', 'u'], description: 'Go to Users' },
+    { keys: ['g', 'a'], description: 'Go to Analytics' },
+    { keys: ['g', 's'], description: 'Go to Settings' },
+    { keys: ['g', 'p'], description: 'Go to Profile' },
+  ]},
+  { group: 'Actions', shortcuts: [
+    { keys: ['n'], description: 'Create new ticket' },
+    { keys: ['r'], description: 'Refresh current view' },
+    { keys: ['/'], description: 'Focus search' },
+  ]},
+  { group: 'General', shortcuts: [
+    { keys: ['?'], description: 'Toggle this legend' },
+    { keys: ['Esc'], description: 'Close modal / unfocus' },
+  ]},
+];
+
+export default useKeyboardShortcuts;


### PR DESCRIPTION
## Summary
Adds keyboard shortcuts for rapid admin dashboard navigation. Press `?` to see all available shortcuts.

## Changes
- Added `useKeyboardShortcuts` hook with configurable shortcuts
- Added `KeyboardLegend` modal component showing all shortcuts
- Integrated keyboard shortcuts into `AdminLayout`
- Added ARIA roles for accessibility

## Keyboard Shortcuts
| Key | Action |
|-----|--------|
| `?` | Show keyboard shortcuts legend |
| `n` | Create new ticket |
| `r` | Refresh current page |
| `Escape` | Close modals |

## Testing
- Manual testing of all keyboard shortcuts
- Verified accessibility with screen reader simulation
- Tested modal open/close behavior

## Related Issues
Fixes #911

## Screenshots
The keyboard shortcuts legend modal appears when pressing `?`:
![Keyboard Legend Modal](https://via.placeholder.com/400x300?text=Keyboard+Legend+Modal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support throughout the admin interface for quick access to common actions.
  * View keyboard legend by pressing "?" to discover available shortcuts.
  * Shortcuts include: "g" for navigation, "n" for new ticket, "r" for refresh, and "/" to focus search.
  * Keyboard shortcuts intelligently disable when typing in input fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->