### PR TITLE
🔒 SECURITY FIX: Authorization bypass via client-side persisted profile cache (Fixes #909)

### DIFF
--- a/Frontend/src/components/shared/AdminProtectedRoute.jsx
+++ b/Frontend/src/components/shared/AdminProtectedRoute.jsx
@@ -1,15 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import useAuthStore from '../../store/authStore';
+import { supabase } from '../../lib/supabaseClient';
 
 /**
  * AdminProtectedRoute Component
  * Restricts access to routes to only users with the 'admin' role.
+ * 
+ * SECURITY: Forces server-side role verification on every mount.
+ * Never trusts client-side persisted role from localStorage.
  */
 const AdminProtectedRoute = () => {
     const { user, profile, loading } = useAuthStore();
+    const [serverRole, setServerRole] = useState(null);
+    const [verifying, setVerifying] = useState(true);
 
-    if (loading) {
+    // SERVER-SIDE ROLE VERIFICATION — runs on every mount
+    useEffect(() => {
+        let cancelled = false;
+
+        const verifyRole = async () => {
+            if (!user?.id) {
+                setVerifying(false);
+                return;
+            }
+
+            try {
+                // Direct DB check — bypasses any client-side cache
+                const { data, error } = await supabase
+                    .from('profiles')
+                    .select('role, status')
+                    .eq('id', user.id)
+                    .single();
+
+                if (!cancelled) {
+                    if (error || !data) {
+                        console.warn("Server role verification failed:", error?.message);
+                        setServerRole(null);
+                    } else {
+                        console.log("Server-verified role:", data.role);
+                        setServerRole(data);
+                    }
+                    setVerifying(false);
+                }
+            } catch (err) {
+                if (!cancelled) {
+                    console.error("Role verification error:", err);
+                    setServerRole(null);
+                    setVerifying(false);
+                }
+            }
+        };
+
+        verifyRole();
+        return () => { cancelled = true; };
+    }, [user?.id]);
+
+    // Show spinner while initial auth load or server verification
+    if (loading || verifying) {
         return (
             <div className="flex h-screen w-screen items-center justify-center bg-white">
                 <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent"></div>
@@ -31,17 +79,24 @@ const AdminProtectedRoute = () => {
         );
     }
 
-    // Check if the user's profile role is 'admin' or 'super_admin'
-    // Enforce role
-    if (profile.role !== "admin" && profile.role !== "super_admin") {
-        // Basic redirect for non-admins if they try to access admin routes
+    // SERVER-SIDE ROLE CHECK: Use server-verified role from DB, not client-side cache
+    if (!serverRole) {
+        return (
+            <div className="flex h-screen w-screen items-center justify-center bg-[#050508]">
+                <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent"></div>
+            </div>
+        );
+    }
+
+    // Check if the server-verified role is 'admin' or 'super_admin'
+    if (serverRole.role !== "admin" && serverRole.role !== "super_admin") {
         return <Navigate to="/" replace />;
     }
 
-    // Enforce active status for admins (Master Admin approval)
-    if (profile.status === "rejected") {
+    // Enforce active status (server-verified)
+    if (serverRole.status === "rejected") {
         return <Navigate to="/not-approved" replace />;
-    } else if (profile.status !== "active") {
+    } else if (serverRole.status !== "active") {
         return <Navigate to="/admin-lobby" replace />;
     }
 

--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -21,13 +21,19 @@ const useAuthStore = create(
                 const currentProfile = get().profile;
 
                 // 1. Resolve FROM METADATA or PERSISTED state
-                // Priority 1: If we have a persisted session for THIS user and it's active, keep it 
-                // to prevent temporary lobbies during refresh/tab switching.
+                // SECURITY FIX: Never trust persisted role without server verification.
+                // Instead, use persisted profile ONLY for UI (name, email) while
+                // forcing a blocking server-side role resolution before granting access.
                 if (currentProfile && currentProfile.id === user.id && currentProfile.status === 'active') {
-                    console.log("Active profile retained from state.");
-                    // Background fetch to ensure session is still valid/synced
-                    get()._syncProfile(user.id);
-                    return currentProfile;
+                    console.log("Profile found in cache. Verifying role with server...");
+                    // BLOCKING server-side role check — must complete before returning
+                    const serverProfile = await get()._syncProfile(user.id);
+                    if (serverProfile) {
+                        console.log("Server-verified profile loaded.");
+                        return serverProfile;
+                    }
+                    // If server check fails, fall through to metadata resolution
+                    console.warn("Server profile check failed. Falling back to metadata.");
                 }
 
                 // Priority 2: Use Auth Metadata (Instant fallback)


### PR DESCRIPTION
## 🔒 Fixes #909 — [BOUNTY] [level:critical] Authorization bypass via client-side persisted profile cache

### Vulnerability Summary
The authStore persisted the user profile to localStorage via Zustand's persist middleware. The `getProfile()` function returned the persisted profile **immediately** before the server re-verification completed (fire-and-forget `_syncProfile` call). This allowed an attacker to:
1. Log in as a regular user
2. Edit localStorage to change `role` from `"user"` to `"admin"`
3. Refresh the page
4. Get admin access before the server could verify

### Changes Made

#### `authStore.js`
- Changed `_syncProfile()` call from fire-and-forget to **blocking `await`**
- Never returns persisted profile until server confirms the role
- If server check fails, falls through to metadata resolution instead of trusting cache

#### `AdminProtectedRoute.jsx`
- Added `useEffect`-based **server-side role verification** on every mount
- Direct DB query to `profiles` table bypasses any client-side cache
- Shows loading spinner while server verification is in progress
- All route decisions now based on **server-verified** role, never client cache

### Checklist
- [x] Starred the repository
- [x] Forked the repository
- [x] Followed the Project Admin (ritesh-1918)
- [x] Target branch is `gssoc`
- [x] No breaking changes to existing functionality

Closes #909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened admin route protection through real-time server-side verification of user permissions.
  * Improved access level validation to ensure current authorization and account status are properly verified.
  * Enhanced loading feedback to inform users when access verification is in progress.
  * Fixed potential issues with outdated cached permission data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->