### PR TITLE
Fix Safari timeline date parsing

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "prepare": "husky install",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "jest",
+    "test:dates": "node --test tests/*.test.js"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -4,149 +4,105 @@
  * Handles Safari's strict ISO-8601 parsing requirements.
  */
 
+const normalizeTimezone = (rawTimezone) => {
+    if (!rawTimezone) return 'Z';
+    if (rawTimezone === 'Z') return rawTimezone;
+    return rawTimezone.includes(':')
+        ? rawTimezone
+        : `${rawTimezone.slice(0, 3)}:${rawTimezone.slice(3)}`;
+};
+
 /**
- * Normalize date string for cross-browser compatibility.
- * Safari is stricter than Chrome/Firefox about date formats.
- * @param {string} dateStr - Raw date string from database
- * @returns {Date|null} - Parsed Date object or null if invalid
+ * Normalize date input for cross-browser compatibility.
+ * Safari rejects some timestamp shapes that Chrome accepts, especially
+ * space-separated timestamps and high-precision Supabase microseconds.
+ *
+ * @param {string|number|Date} dateInput
+ * @returns {Date|null}
  */
-const parseDate = (dateStr) => {
-    if (!dateStr) return null;
+export const parseDate = (dateInput) => {
+    if (!dateInput) return null;
 
-    // If already a Date object, return it
-    if (dateStr instanceof Date) {
-        return isNaN(dateStr.getTime()) ? null : dateStr;
-    }
-    return dateStr;
-  }
-
-    // Convert to string if needed
-    const str = String(dateStr).trim();
-    if (!str) return null;
-
-    // Support epoch timestamps (milliseconds or seconds)
-    if (/^\d+$/.test(str)) {
-        const num = parseInt(str, 10);
-        // If > 1e12, treat as milliseconds; otherwise seconds
-        const ms = num > 1e12 ? num : num * 1000;
-        const epochDate = new Date(ms);
-        return isNaN(epochDate.getTime()) ? null : epochDate;
+    if (dateInput instanceof Date) {
+        return Number.isNaN(dateInput.getTime()) ? null : dateInput;
     }
 
-    // Normalize common problematic formats for Safari
-    let normalized = str
-        // Replace space between date and time with 'T' (Safari requires 'T')
-        .replace(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})/, '$1T$2')
-        // Replace slashes with dashes (2024/01/01 -> 2024-01-01)
-        .replace(/^(\d{4})\/(\d{1,2})\/(\d{1,2})/, '$1-$2-$3')
-        // Add leading zeros to month/day if needed (2024-1-1 -> 2024-01-01)
-        .replace(/^(\d{4})-(\d{1})-(\d{1})/, '$1-0$2-0$3')
-        .replace(/^(\d{4})-(\d{2})-(\d{1})/, '$1-$2-0$3')
-        .replace(/^(\d{4})-(\d{1})-(\d{2})/, '$1-0$2-$3');
-
-    // Try parsing the normalized string
-    let date = new Date(normalized);
-
-    // If that fails, try adding 'Z' for UTC interpretation
-    if (isNaN(date.getTime())) {
-        // Check if it's a date without timezone info
-        if (!normalized.includes('Z') && !normalized.includes('+') && !normalized.includes('-', 10)) {
-            date = new Date(normalized + 'Z');
-        }
+    if (typeof dateInput === 'number') {
+        const epochDate = new Date(dateInput > 1e12 ? dateInput : dateInput * 1000);
+        return Number.isNaN(epochDate.getTime()) ? null : epochDate;
     }
 
-    // If still fails, try manual parsing for common formats
-    if (isNaN(date.getTime())) {
-        // Try parsing YYYY-MM-DD HH:MM:SS format
-        const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/);
-        if (match) {
-            const [, year, month, day, hour, minute, second = '0'] = match;
-            date = new Date(Date.UTC(
-                parseInt(year, 10),
-                parseInt(month, 10) - 1,
-                parseInt(day, 10),
-                parseInt(hour, 10),
-                parseInt(minute, 10),
-                parseInt(second, 10)
-            ));
-        }
+    const raw = String(dateInput).trim();
+    if (!raw) return null;
+
+    if (/^\d+$/.test(raw)) {
+        const epoch = Number(raw);
+        const epochDate = new Date(epoch > 1e12 ? epoch : epoch * 1000);
+        return Number.isNaN(epochDate.getTime()) ? null : epochDate;
     }
 
-    // Final validation
-    if (isNaN(date.getTime())) {
-        return null;
+    const isoLikeMatch = raw.match(
+        /^(\d{4}-\d{2}-\d{2})(?:[T\s](\d{2}:\d{2}:\d{2})(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/
+    );
+
+    if (isoLikeMatch) {
+        const [, datePart, timePart = '00:00:00', fraction = '', rawTimezone] = isoLikeMatch;
+        const milliseconds = fraction
+            ? `.${fraction.slice(1, 4).padEnd(3, '0')}`
+            : '';
+        const normalized = `${datePart}T${timePart}${milliseconds}${normalizeTimezone(rawTimezone)}`;
+        const parsed = new Date(normalized);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
     }
 
-    return date;
+    const slashDateMatch = raw.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})$/);
+    if (slashDateMatch) {
+        const [, year, month, day] = slashDateMatch;
+        const normalized = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}T00:00:00.000Z`;
+        const parsed = new Date(normalized);
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    const direct = new Date(raw);
+    return Number.isNaN(direct.getTime()) ? null : direct;
 };
 
 export const formatTimelineDate = (dateStr) => {
     const date = parseDate(dateStr);
     if (!date) return 'Invalid Date';
 
-export const formatTimelineDate = (dateStr) => {
-  const normalized = normalizeDateString(dateStr);
-  if (!normalized) return null;
-
-  const date = new Date(normalized);
-  if (isNaN(date.getTime())) return 'Invalid Date';
-
-  return date.toLocaleString(undefined, {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: true,
-  });
+    return date.toLocaleString(undefined, {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+    });
 };
 
-/**
- * Returns the user's current timezone abbreviation (e.g. "IST", "PST").
- * Falls back to 'Local' when the Intl API is unavailable (very old browsers).
- *
- * @returns {string}
- */
 export const getTimeZoneAbbr = () => {
-  try {
-    return (
-      new Intl.DateTimeFormat('en-US', {
-        timeZoneName: 'short',
-      })
-        .formatToParts(new Date())
-        .find(part => part.type === 'timeZoneName')?.value || 'UTC';
+    try {
+        return (
+            new Intl.DateTimeFormat('en-US', {
+                timeZoneName: 'short',
+            })
+                .formatToParts(new Date())
+                .find((part) => part.type === 'timeZoneName')?.value || 'UTC'
+        );
     } catch (_e) {
         return 'UTC';
     }
 };
 
-/**
- * Formats a date with its timezone abbreviation appended.
- * Falls back to 'Processing...' when dateStr is falsy.
- *
- * @param {string|Date|null|undefined} dateStr
- * @returns {string}
- */
 export const formatFullTimestamp = (dateStr) => {
-  const formatted = formatTimelineDate(dateStr);
-  if (!formatted) return 'Processing...';
-  return `${formatted} (${getTimeZoneAbbr()})`;
+    const formatted = formatTimelineDate(dateStr);
+    if (!formatted) return 'Processing...';
+    return `${formatted} (${getTimeZoneAbbr()})`;
 };
 
-/**
- * Check if a date string is valid
- * @param {string} dateStr - Date string to validate
- * @returns {boolean} - True if the date is valid
- */
-export const isValidDate = (dateStr) => {
-    return parseDate(dateStr) !== null;
-};
+export const isValidDate = (dateStr) => parseDate(dateStr) !== null;
 
-/**
- * Get relative time string (e.g., "2 hours ago")
- * @param {string} dateStr - Date string
- * @returns {string} - Relative time string
- */
 export const getRelativeTime = (dateStr) => {
     const date = parseDate(dateStr);
     if (!date) return 'Unknown';

--- a/Frontend/tests/dateUtils.test.js
+++ b/Frontend/tests/dateUtils.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseDate, formatTimelineDate } from '../src/utils/dateUtils.js';
+
+test('parseDate accepts Supabase timestamps with microseconds', () => {
+    const parsed = parseDate('2026-06-01T12:34:56.123456+00:00');
+
+    assert.ok(parsed instanceof Date);
+    assert.equal(parsed.toISOString(), '2026-06-01T12:34:56.123Z');
+});
+
+test('parseDate normalizes timestamps with a space separator', () => {
+    const parsed = parseDate('2026-06-01 12:34:56');
+
+    assert.ok(parsed instanceof Date);
+    assert.equal(parsed.toISOString(), '2026-06-01T12:34:56.000Z');
+});
+
+test('formatTimelineDate returns Invalid Date for unparsable values', () => {
+    assert.equal(formatTimelineDate('not-a-date'), 'Invalid Date');
+});


### PR DESCRIPTION
Fixes #912

## Summary
- normalize Supabase timestamps before constructing `Date` objects so Safari can parse space-separated and microsecond timestamps reliably
- preserve the existing date utility surface (`formatTimelineDate`, `formatFullTimestamp`, `isValidDate`, `getRelativeTime`) while routing them through the normalized parser
- add focused regression coverage for microsecond timestamps, space-separated timestamps, and invalid inputs

## Testing
- `npm run test:dates`

## Notes
- `npm run build` currently fails on the base `gssoc` branch because `Frontend/vite.config.js` already has a syntax error near line 83 (`Expected ")" but found "}"`). This PR does not touch that file.