### PR TITLE
feat: Add dark mode CSS variables and theme toggle support

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,48 @@
+:root {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f9fafb;
+  --bg-card: #ffffff;
+  --text-primary: #111827;
+  --text-secondary: #6b7280;
+  --border-color: #e5e7eb;
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --danger: #ef4444;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --shadow: 0 1px 3px rgba(0,0,0,0.12);
+}
+
+[data-theme="dark"] {
+  --bg-primary: #0f172a;
+  --bg-secondary: #1e293b;
+  --bg-card: #1e293b;
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
+  --border-color: #334155;
+  --accent: #818cf8;
+  --accent-hover: #6366f1;
+  --danger: #f87171;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --shadow: 0 1px 3px rgba(0,0,0,0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-card: #1e293b;
+    --text-primary: #f1f5f9;
+    --text-secondary: #94a3b8;
+    --border-color: #334155;
+    --accent: #818cf8;
+    --accent-hover: #6366f1;
+  }
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,0 +1,33 @@
+/**
+ * Theme Toggle — HELPDESK.AI
+ * Manages dark/light mode with localStorage persistence.
+ */
+(function () {
+  const STORAGE_KEY = "helpdesk-theme";
+
+  function getPreferred() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem(STORAGE_KEY, theme);
+    const btn = document.getElementById("theme-toggle-btn");
+    if (btn) btn.textContent = theme === "dark" ? "Light Mode" : "Dark Mode";
+  }
+
+  // Apply immediately to prevent flash
+  applyTheme(getPreferred());
+
+  document.addEventListener("DOMContentLoaded", function () {
+    const btn = document.getElementById("theme-toggle-btn");
+    if (btn) {
+      btn.addEventListener("click", function () {
+        const current = document.documentElement.getAttribute("data-theme");
+        applyTheme(current === "dark" ? "light" : "dark");
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary

Adds CSS custom properties for dark mode theming and a theme utility script. The user's preference is persisted in localStorage and respects `prefers-color-scheme`.

cc @ritesh-1918