### PR TITLE
fix: add pagination to ticket list to prevent browser freeze on large datasets

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -139,6 +139,10 @@ const AdminTickets = () => {
             if (categoryFilter !== 'All') query = query.eq('category', categoryFilter);
             if (priorityFilter !== 'All') query = query.eq('priority', priorityFilter.toLowerCase());
             if (teamFilter !== 'All') query = query.eq('assigned_team', teamFilter);
+            if (searchQuery) {
+                const escaped = searchQuery.replace(/%/g, '\\%').replace(/_/g, '\\_');
+                query = query.or(`subject.ilike.%${escaped}%,description.ilike.%${escaped}%,summary.ilike.%${escaped}%`);
+            }
 
             const start = pageNum * PAGE_SIZE;
             const end = start + PAGE_SIZE - 1;
@@ -178,7 +182,7 @@ const AdminTickets = () => {
 
     useEffect(() => {
         fetchInitialData();
-    }, [statusFilter, categoryFilter, priorityFilter, teamFilter]);
+    }, [statusFilter, categoryFilter, priorityFilter, teamFilter, searchQuery]);
 
     useEffect(() => {
         const channelSla = supabase
@@ -300,16 +304,7 @@ const AdminTickets = () => {
 
     const filteredTickets = useMemo(() => {
         let result = tickets;
-        if (searchQuery) {
-            const q = searchQuery.toLowerCase();
-            result = result.filter(t =>
-                String(t.id).includes(q) ||
-                (t.subject || '').toLowerCase().includes(q) ||
-                (t.summary || '').toLowerCase().includes(q) ||
-                (t.description || '').toLowerCase().includes(q) ||
-                (t.profiles?.full_name || '').toLowerCase().includes(q)
-            );
-        }
+        // Search is now server-side via Supabase .or() filter in fetchTickets
         if (languageFilter !== 'All') {
             result = result.filter(t => {
                 const translated = t.detected_language && t.detected_language.toLowerCase() !== 'en';
@@ -326,7 +321,7 @@ const AdminTickets = () => {
             result = result.filter(t => (t.tags || []).length > 0 && tagFilters.every(tag => (t.tags || []).includes(tag)));
         }
         return result;
-    }, [tickets, searchQuery, languageFilter, slaAtRisk, tagFilters]);
+    }, [tickets, languageFilter, slaAtRisk, tagFilters]);
 
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();


### PR DESCRIPTION
Fixes #968

## Summary
The ticket list endpoint returned all tickets in a single response, causing browser freeze for helpdesks with thousands of tickets. This PR adds server-side pagination to both the backend API and admin dashboard frontend.

## Changes

### Backend (`backend/main.py`)
- Added `page` (1-indexed) and `page_size` (1-200, default 50) query parameters to `GET /tickets`
- Added Supabase count query for total ticket count
- Returns paginated response with `data` and `pagination` metadata (`page`, `page_size`, `total`, `total_pages`)

### Frontend (`Frontend/src/admin/pages/AdminTickets.jsx`)
- Added Supabase `.range()` pagination (page size 50) to ticket fetch
- Added count query to display total ticket count
- Added pagination controls: previous/next buttons, page indicator, showing range
- Auto-reset to page 1 when any filter changes

## Testing
- Backend: `GET /tickets?page=1&page_size=25` returns first 25 tickets with pagination metadata
- Frontend: Pagination controls appear when total > 50 tickets, prev/next buttons navigate pages
- Filter changes reset to page 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side pagination for the admin ticket list with previous/next controls and a “Showing X–Y of Z” count.
  * Server-side search so results and counts reflect filters/search.
* **Behavior Changes**
  * Filters and search reset the page to the first page; live updates respect pagination and search.
* **API**
  * Tickets endpoint now returns pagination metadata alongside ticket data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->