### PR TITLE
fix: add rate limiting to ML inference endpoints (Fixes #905)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1304,6 +1304,7 @@ def _atomic_write_json(path: Path, data) -> None:
 
 
 @app.post("/ai/log_correction")
+@limiter.limit("30/minute")
 async def log_correction(raw_request: Request, user: dict = Depends(get_current_user)):
     """Log an admin correction when the AI prediction differs from the human decision."""
     role = (user.get("user_metadata") or {}).get("role", "") or (user.get("app_metadata") or {}).get("role", "")
@@ -2618,7 +2619,9 @@ async def trigger_sla_check(current_user: dict = Depends(get_current_user)):
 # ---------------------------------------------------------------------------
 
 @app.post("/ai/check_duplicate")
+@limiter.limit("20/minute")
 async def check_duplicate_endpoint(
+    request: Request,
     body: TicketRequest,
     company_id: str | None = None,
     current_user: dict = Depends(get_current_user),
@@ -2641,6 +2644,7 @@ async def check_duplicate_endpoint(
 
 
 @app.post("/ai/reindex_embeddings")
+@limiter.limit("2/minute")
 async def reindex_embeddings(current_user: dict = Depends(get_current_user)):
     """Re-generate vector embeddings for all tickets."""
     result = await semantic_dupe_service.reindex_all()


### PR DESCRIPTION
Fixes #905

## Summary
Adds slowapi/IP-based rate limiting to unprotected ML inference endpoints to prevent resource exhaustion and service quota abuse.

## Changes
- **** — Added  (semantic vector search, moderate load)
- **** — Added  (heavy ML operation, very restrictive)
- **** — Added  (admin corrections, lighter load)
- Added  parameter to  for slowapi client IP extraction

## Rate Limit Summary (all endpoints)
| Endpoint | Rate Limit | Notes |
|----------|-----------|-------|
|  | 10/min | Already rate-limited |
|  | 10/min | Already rate-limited |
|  | 10/min | Already rate-limited |
|  | 10/min | Already rate-limited |
|  | 10/min | Already rate-limited |
|  | 10/min | Already rate-limited |
|  | 20/min | **NEW** — semantic search |
|  | 2/min | **NEW** — heavy operation |
|  | 30/min | **NEW** — admin corrections |

## Testing
- Rate limits are per-IP using  with  key function
- Exceeding limits returns HTTP 429 with standard error response
- All limits are configurable via the  decorator

## Notes
- Existing rate-limited endpoints remain unchanged
- The  endpoint is admin-only and very restrictive (2/min) since it regenerates all embeddings
- The  endpoint gets 20/min (higher than analysis endpoints) since it's a lighter operation