### PR TITLE
fix: resolve TOCTOU race condition in duplicate detection (Fixes #906)

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -309,8 +309,10 @@ class DuplicateService:
 
         import torch
 
-        # Stack stored embeddings into a single tensor for vectorized operations
-        embeddings = [stored_emb for _, stored_emb, _ in self._tickets]
+        # Use the snapshot consistently to avoid TOCTOU race conditions.
+        # Previously this accessed self._tickets directly, which could be
+        # mutated by another thread between the snapshot and this line.
+        embeddings = [stored_emb for _, stored_emb, _ in tickets_snapshot]
         stacked_embeddings = torch.stack(embeddings)
 
         # Compute cosine similarity between query and all stored embeddings in one operation
@@ -320,7 +322,7 @@ class DuplicateService:
         best_score_tensor, best_index_tensor = torch.max(similarity_matrix, dim=1)
         best_score = best_score_tensor.item()
         best_index = best_index_tensor.item()
-        best_id = self._tickets[best_index][0]
+        best_id = tickets_snapshot[best_index][0]
 
         is_dup = best_score >= active_threshold
 


### PR DESCRIPTION
Fixes #906

## Summary
Resolves a TOCTOU (Time of Check to Time of Use) race condition in the duplicate detection service that could cause data loss and inconsistent state during concurrent ticket creation.

## Problem
In `DuplicateService.check_duplicate()`, a snapshot of `self._tickets` was taken under the lock at line 298-299, but then the actual similarity computation at line 313 accessed `self._tickets` directly **without the lock**. This created a race condition:

```
Thread A: snapshot = list(self._tickets)  # takes snapshot
Thread B: self._tickets.append(...)       # modifies list
Thread A: embeddings = [emb for ... in self._tickets]  # uses LIVE list, not snapshot!
```

This could cause:
- Index out of bounds if `self._tickets` shrinks between snapshot and access
- Wrong ticket ID returned if list order changes
- Inconsistent similarity scores

## Fix
Changed two lines to use `tickets_snapshot` consistently instead of `self._tickets`:

```python
# Before (BUGGY):
embeddings = [stored_emb for _, stored_emb, _ in self._tickets]
best_id = self._tickets[best_index][0]

# After (FIXED):
embeddings = [stored_emb for _, stored_emb, _ in tickets_snapshot]
best_id = tickets_snapshot[best_index][0]
```

## Testing
- The existing `threading.Lock` pattern is preserved
- Snapshot is now used consistently throughout the method
- No functional changes to the similarity computation logic