### PR TITLE
fix: sign out recovery session after password reset to invalidate token (Fixes #969)

### DIFF
--- a/Frontend/src/pages/ResetPassword.jsx
+++ b/Frontend/src/pages/ResetPassword.jsx
@@ -44,6 +44,11 @@ function ResetPassword() {
 
             if (error) throw error;
 
+            // Sign out the recovery session to invalidate any cached tokens.
+            // This prevents the reset link from being reused after a successful
+            // password change.
+            await supabase.auth.signOut();
+
             setMessage("Password successfully updated!");
             setTimeout(() => navigate("/login"), 3000);
         } catch (err) {


### PR DESCRIPTION
## Summary

Signs out the recovery session immediately after a successful password update to prevent the reset link from being reused.

## Changes

- **Frontend/src/pages/ResetPassword.jsx**: Added `supabase.auth.signOut()` call after successful `updateUser()` to clear the recovery session and invalidate cached tokens

## Security Impact

Previously, after a user successfully reset their password via the reset link, the recovery session remained active. An attacker who intercepted the reset link (e.g., via browser history, email forwarding, or shared computer) could reuse it to change the password again.

Now, the recovery session is immediately terminated after password update:
- The reset link becomes invalid after first use
- Any cached tokens are cleared
- The user is redirected to login with a clean session

## Testing

1. Request a password reset link
2. Click the link and set a new password
3. Verify redirect to login page
4. Try using the same reset link again — it should fail (no active session)
5. Verify the new password works for login

## Related Issues

Fixes #969
