### PR TITLE
fix: add pagination, batch insert, dry-run, and env guards to seed script (Fixes #826)

### DIFF
--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -9,11 +9,11 @@ Run this script after applying the 20260531_add_company_settings.sql migration.
 
 Usage:
     cd backend
-    python scripts/seed_company_settings.py
+    python scripts/seed_company_settings.py [--dry-run]
 
 This script:
-- Queries unique companies from tickets table
-- Creates default system_settings record for each
+- Queries unique companies from tickets table (with pagination)
+- Creates default system_settings record for each (batch insert)
 - Sets default values:
     - auto_close_enabled: true
     - auto_close_days: 7
@@ -24,10 +24,10 @@ This script:
 
 import os
 import sys
+import argparse
 import logging
 from datetime import datetime, timezone
 
-from supabase import create_client
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -40,144 +40,219 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# Pagination page size (Supabase default is 1000)
+PAGE_SIZE = 1000
 
-def seed_company_settings():
-    """Main function to seed company settings for all companies."""
-    
-    # Initialize Supabase client
-    supabase = create_client(
-        os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-    )
-    
+
+def _build_client():
+    """Build a shared Supabase client with env-var validation.
+
+    Raises:
+        EnvironmentError: If required env vars are missing.
+    """
+    from supabase import create_client
+
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+
+    if not url or not key:
+        raise EnvironmentError(
+            "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set in the environment. "
+            "Check your .env file or export them before running this script."
+        )
+
+    return create_client(url, key)
+
+
+def _fetch_all_pages(supabase, table: str, columns: str) -> list[dict]:
+    """Fetch all rows from a table using range-based pagination.
+
+    Supabase defaults to 1 000 rows per request. This helper loops until
+    every page has been consumed so no rows are silently truncated.
+
+    Args:
+        supabase: Authenticated Supabase client.
+        table: Table name to query.
+        columns: Comma-separated column names for .select().
+
+    Returns:
+        Complete list of matching rows.
+    """
+    all_rows: list[dict] = []
+    offset = 0
+
+    while True:
+        response = (
+            supabase.table(table)
+            .select(columns)
+            .range(offset, offset + PAGE_SIZE - 1)
+            .execute()
+        )
+        page = response.data or []
+        all_rows.extend(page)
+
+        if len(page) < PAGE_SIZE:
+            # Last page (or empty)
+            break
+        offset += PAGE_SIZE
+
+    return all_rows
+
+
+def seed_company_settings(dry_run: bool = False) -> dict:
+    """Seed system_settings for all companies found in the tickets table.
+
+    Args:
+        dry_run: If True, log intended inserts without writing to the database.
+
+    Returns:
+        Dict with status and counts.
+    """
+    supabase = _build_client()
+
     logger.info("Starting company settings seed script...")
-    
+    if dry_run:
+        logger.info("[DRY RUN] No changes will be written to the database.")
+
     try:
-        # Step 1: Get all unique companies from tickets table
+        # Step 1: Get all unique companies from tickets table (paginated)
         logger.info("Fetching all unique companies from tickets table...")
-        
-        companies_response = supabase.table("tickets").select(
-            "company_id", count="exact"
-        ).execute()
-        
-        if not companies_response.data:
+
+        all_tickets = _fetch_all_pages(supabase, "tickets", "company_id")
+        if not all_tickets:
             logger.warning("No tickets found. Database may be empty.")
             return {"status": "no_tickets", "created_count": 0}
-        
-        # Extract unique company IDs
-        companies = {}
-        for ticket in companies_response.data:
-            company_id = ticket.get("company_id")
-            if company_id and company_id not in companies:
-                companies[company_id] = True
-        
-        unique_companies = list(companies.keys())
+
+        unique_companies = list({
+            t["company_id"]
+            for t in all_tickets
+            if t.get("company_id")
+        })
         logger.info(f"Found {len(unique_companies)} unique companies")
-        
-        # Step 2: Get existing system_settings to avoid duplicates
+
+        # Step 2: Get existing system_settings to avoid duplicates (paginated)
         logger.info("Fetching existing system_settings...")
-        
-        existing_response = supabase.table("system_settings").select(
-            "company_id"
-        ).execute()
-        
-        existing_companies = set()
-        if existing_response.data:
-            for setting in existing_response.data:
-                existing_companies.add(setting.get("company_id"))
-        
+
+        existing_rows = _fetch_all_pages(supabase, "system_settings", "company_id")
+        existing_companies = {
+            s["company_id"]
+            for s in existing_rows
+            if s.get("company_id")
+        }
         logger.info(f"Found {len(existing_companies)} existing system_settings")
-        
+
         # Step 3: Determine which companies need settings created
-        companies_to_create = [c for c in unique_companies if c not in existing_companies]
+        companies_to_create = [
+            c for c in unique_companies if c not in existing_companies
+        ]
         logger.info(f"Need to create settings for {len(companies_to_create)} companies")
-        
+
         if not companies_to_create:
             logger.info("All companies already have settings. Nothing to do.")
             return {"status": "complete", "created_count": 0}
-        
-        # Step 4: Create default settings for each company
-        created_count = 0
-        error_count = 0
-        
-        for company_id in companies_to_create:
-            try:
-                # Create default settings record
-                supabase.table("system_settings").insert({
-                    "company_id": company_id,
-                    "auto_close_enabled": True,
-                    "auto_close_days": 7,
-                    "email_notifications": True,
-                    "admin_alerts": True,
-                    "digest_frequency": "daily"
-                }).execute()
-                
-                created_count += 1
-                logger.debug(f"Created settings for company {company_id}")
-                
-            except Exception as e:
-                error_count += 1
-                logger.error(f"Failed to create settings for company {company_id}: {str(e)}")
-        
-        # Step 5: Verify results
-        logger.info(f"Seed complete: {created_count} created, {error_count} errors")
-        
-        if error_count == 0:
-            logger.info("All company settings successfully created!")
-            return {"status": "success", "created_count": created_count}
-        else:
-            logger.warning(f"Seed completed with {error_count} errors")
-            return {"status": "partial", "created_count": created_count, "error_count": error_count}
-    
+
+        # Step 4: Batch insert default settings
+        now = datetime.now(timezone.utc).isoformat()
+        records = [
+            {
+                "company_id": company_id,
+                "auto_close_enabled": True,
+                "auto_close_days": 7,
+                "email_notifications": True,
+                "admin_alerts": True,
+                "digest_frequency": "daily",
+                "created_at": now,
+            }
+            for company_id in companies_to_create
+        ]
+
+        if dry_run:
+            logger.info(f"[DRY RUN] Would insert {len(records)} system_settings records:")
+            for r in records[:10]:
+                logger.info(f"  - {r['company_id']}")
+            if len(records) > 10:
+                logger.info(f"  ... and {len(records) - 10} more")
+            return {"status": "dry_run", "would_create": len(records)}
+
+        # Single batch insert instead of N individual inserts
+        logger.info(f"Inserting {len(records)} system_settings records...")
+        supabase.table("system_settings").insert(records).execute()
+
+        logger.info(f"Seed complete: {len(records)} created")
+        return {"status": "success", "created_count": len(records)}
+
+    except EnvironmentError:
+        raise
     except Exception as e:
         logger.error(f"Fatal error during seed: {str(e)}")
         return {"status": "error", "message": str(e)}
 
 
-def verify_seed():
-    """Verify that seed was successful."""
-    
+def verify_seed(supabase=None) -> bool:
+    """Verify that seed was successful.
+
+    Args:
+        supabase: Optional pre-built client. If None, creates a new one.
+
+    Returns:
+        True if all companies have settings, False otherwise.
+    """
+    if supabase is None:
+        supabase = _build_client()
+
     logger.info("Verifying seed results...")
-    
-    supabase = create_client(
-        os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
-    )
-    
+
     try:
-        # Get counts
-        companies_response = supabase.table("tickets").select(
-            "company_id", count="exact"
-        ).execute()
-        
-        settings_response = supabase.table("system_settings").select(
-            "company_id", count="exact"
-        ).execute()
-        
-        companies_count = len(set(t["company_id"] for t in companies_response.data if t.get("company_id")))
-        settings_count = len(set(s["company_id"] for s in settings_response.data if s.get("company_id")))
-        
-        logger.info(f"Verification: {companies_count} unique companies, {settings_count} system_settings")
-        
+        # Paginated fetch for both tables
+        all_tickets = _fetch_all_pages(supabase, "tickets", "company_id")
+        all_settings = _fetch_all_pages(supabase, "system_settings", "company_id")
+
+        companies_count = len({
+            t["company_id"] for t in all_tickets if t.get("company_id")
+        })
+        settings_count = len({
+            s["company_id"] for s in all_settings if s.get("company_id")
+        })
+
+        logger.info(
+            f"Verification: {companies_count} unique companies, "
+            f"{settings_count} system_settings"
+        )
+
         if companies_count == settings_count:
             logger.info("✓ Verification passed: All companies have settings!")
             return True
         else:
-            logger.warning(f"✗ Verification failed: {companies_count - settings_count} companies missing settings")
+            missing = companies_count - settings_count
+            logger.warning(f"✗ Verification failed: {missing} companies missing settings")
             return False
-    
+
     except Exception as e:
         logger.error(f"Verification failed: {str(e)}")
         return False
 
 
-if __name__ == "__main__":
+def main():
+    parser = argparse.ArgumentParser(
+        description="Seed default system_settings for all companies."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log intended inserts without writing to the database.",
+    )
+    args = parser.parse_args()
+
     # Run seed
-    result = seed_company_settings()
-    
+    result = seed_company_settings(dry_run=args.dry_run)
+
+    if args.dry_run:
+        logger.info("Dry run complete. No changes were made.")
+        sys.exit(0)
+
     # Verify
     verified = verify_seed()
-    
+
     # Exit with appropriate code
     if verified and result.get("status") in ["success", "complete"]:
         logger.info("Seed script completed successfully!")
@@ -185,3 +260,7 @@ if __name__ == "__main__":
     else:
         logger.error("Seed script completed with issues")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #826

## Summary
Fixes 7 bugs/improvements in `seed_company_settings.py`:
1. **Silent data truncation** — added range-based pagination via `_fetch_all_pages()`
2. **N+1 inserts** — replaced per-row loop with single `batch insert(records)`
3. **Duplicate client** — shared `_build_client()` used by both seed and verify
4. **No dry-run** — added `--dry-run` CLI flag via argparse
5. **Unused count param** — removed `count="exact"` from select calls
6. **Missing env guard** — clear `EnvironmentError` if env vars unset
7. **Missing created_at** — explicit timestamp in insert payload

## Changes
- `_fetch_all_pages(table, columns)` — range-based pagination helper
- `_build_client()` — env-var validated Supabase client factory
- `seed_company_settings(dry_run=False)` — batch insert with dry-run support
- `verify_seed()` — paginated verification
- `main()` — argparse CLI entrypoint

## Testing
```bash
# Syntax check
python3 -c "import py_compile; py_compile.compile('backend/scripts/seed_company_settings.py', doraise=True)"

# Dry run (no DB changes)
python backend/scripts/seed_company_settings.py --dry-run
```