### PR TITLE
fix: add rate limiting to /ai/analyze_stream and invalidate Supabase session on logout (Fixes #992, #988)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from contextlib import asynccontextmanager
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, Response
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
@@ -892,7 +892,8 @@ async def analyze_only(request_body: TicketRequest):
     )
 
 @app.post("/ai/analyze_stream")
-async def analyze_stream(request_body: TicketRequest):
+@limiter.limit("10/minute")
+async def analyze_stream(request_body: TicketRequest, request: Request):
     """
     REAL-TIME SSE ENDPOINT: Streams the AI progress to the frontend dynamically.
     """
@@ -1201,7 +1202,14 @@ async def auth_signup(body: SignupBody, response: Response):
     return {"user": user_payload, "message": "Signup complete"}
 
 @app.post("/auth/logout")
-async def auth_logout(response: Response):
+async def auth_logout(response: Response, request: Request):
+    # Invalidate the Supabase session server-side before clearing cookies
+    token = extract_token(request)
+    if token and supabase:
+        try:
+            supabase.auth.sign_out()
+        except Exception:
+            pass  # Best-effort: still clear cookies even if sign_out fails
     _clear_session_cookies(response)
     return {"ok": True}
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1206,6 +1206,18 @@ async def auth_logout(response: Response, request: Request):
     # Invalidate the Supabase session server-side before clearing cookies
     _logout_logger = logging.getLogger(__name__)
     token = extract_token(request)
+    if not token and supabase:
+        # Access token may have expired but refresh cookie could still be valid.
+        # Use it to obtain a fresh access JWT so we can revoke server-side.
+        raw_refresh = request.cookies.get(REFRESH_COOKIE)
+        if raw_refresh:
+            try:
+                refreshed = supabase.auth.refresh_session(refresh_token=raw_refresh)
+                session = getattr(refreshed, "session", None)
+                if session and getattr(session, "access_token", None):
+                    token = session.access_token
+            except Exception as exc:
+                _logout_logger.warning("Refresh session for logout revocation failed: %s", exc)
     if token and supabase:
         try:
             # Use admin API to revoke refresh tokens server-side

--- a/backend/main.py
+++ b/backend/main.py
@@ -1204,12 +1204,15 @@ async def auth_signup(body: SignupBody, response: Response):
 @app.post("/auth/logout")
 async def auth_logout(response: Response, request: Request):
     # Invalidate the Supabase session server-side before clearing cookies
+    _logout_logger = logging.getLogger(__name__)
     token = extract_token(request)
     if token and supabase:
         try:
-            supabase.auth.sign_out()
-        except Exception:
-            pass  # Best-effort: still clear cookies even if sign_out fails
+            # Use admin API to revoke refresh tokens server-side
+            supabase.auth.admin.sign_out(jwt=token)
+        except Exception as exc:
+            _logout_logger.warning("Server-side session revocation failed: %s", exc)
+            # Best-effort: still clear cookies even if admin sign_out fails
     _clear_session_cookies(response)
     return {"ok": True}
 


### PR DESCRIPTION
## Summary

Fixes two security issues: missing rate limiting on the streaming AI endpoint and logout not invalidating Supabase sessions.

## Changes

### Rate limiting on `/ai/analyze_stream` (Fixes #992)
- Added `@limiter.limit("10/minute")` decorator to `analyze_stream` endpoint
- Added `request: Request` parameter for slowapi compatibility
- Previously, the streaming endpoint had no rate limit while `/ai/analyze_ticket` had 10/minute, allowing complete bypass

### Supabase session invalidation on logout (Fixes #988)
- Added `supabase.auth.sign_out()` call in `/auth/logout` before clearing cookies
- Previously, only browser cookies were cleared — the Supabase JWT remained valid until natural expiry (~1 hour)
- Best-effort pattern: sign_out failure doesn't prevent cookie cleanup
- Added `Response` to fastapi imports

## Testing

- Rate limiting: Send 11+ requests to `/ai/analyze_stream` — should get HTTP 429 after 10
- Logout: After `/auth/logout`, the previous access token should no longer work for authenticated endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting added to AI analysis requests to maintain service performance (10 requests per minute) and help ensure fair usage.

* **Bug Fixes**
  * Logout flow improved to attempt server-side session revocation when possible, derive missing tokens when available, and always clear access/refresh cookies to ensure a more reliable sign-out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->