### PR TITLE
fix: route PATCH /tickets/{ticket_id} to Supabase instead of in-memory store (Fixes #989)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -682,8 +682,19 @@ async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
 
+    # Verify the ticket exists and the caller owns it
+    existing = supabase.table("tickets").select("id, owner_id").eq("id", ticket_id).execute()
+    if not existing.data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    ticket_owner = existing.data[0].get("owner_id")
+    user_id = user.get("id")
+    user_role = user.get("user_metadata", {}).get("role", "")
+    if ticket_owner and ticket_owner != user_id and user_role != "admin":
+        raise HTTPException(status_code=403, detail="Not authorized to update this ticket")
+
     # Remove fields that shouldn't be updated directly
-    protected_fields = {"id", "ticket_id", "created_at", "company_id"}
+    protected_fields = {"id", "ticket_id", "created_at", "company_id", "owner_id"}
     sanitized = {k: v for k, v in updates.items() if k not in protected_fields}
 
     if not sanitized:

--- a/backend/main.py
+++ b/backend/main.py
@@ -676,19 +676,23 @@ async def create_ticket(ticket: TicketRecord):
     return ticket
 
 
-@app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict):
-    """Partially update a ticket's fields (e.g., status, viewed_at)."""
-    for i, ticket in enumerate(TICKETS_DB):
-        if str(ticket.ticket_id) == str(ticket_id):
-            # Convert to dict, update, then back to model
-            ticket_dict = ticket.dict()
-            ticket_dict.update(updates)
-            updated_ticket = TicketRecord(**ticket_dict)
-            TICKETS_DB[i] = updated_ticket
-            return updated_ticket
-    
-    raise HTTPException(status_code=404, detail="Ticket not found")
+@app.patch("/tickets/{ticket_id}")
+async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
+    """Partially update a ticket's fields (e.g., status, priority, assigned_team)."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    # Remove fields that shouldn't be updated directly
+    protected_fields = {"id", "ticket_id", "created_at", "company_id"}
+    sanitized = {k: v for k, v in updates.items() if k not in protected_fields}
+
+    if not sanitized:
+        raise HTTPException(status_code=400, detail="No valid fields to update")
+
+    res = supabase.table("tickets").update(sanitized).eq("id", ticket_id).execute()
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return res.data[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #989

## Summary
The `PATCH /tickets/{ticket_id}` endpoint was writing to an in-memory Python list (`TICKETS_DB`) instead of Supabase. All ticket updates were silently lost on restart and invisible to GET endpoints.

## Changes
- **Supabase persistence:** Replaced in-memory `TICKETS_DB` lookup with `supabase.table('tickets').update()` so changes survive restarts
- **Authentication:** Added `Depends(get_current_user)` to require auth
- **Field protection:** Sanitize updates to prevent overwriting `id`, `ticket_id`, `created_at`, `company_id`
- **Validation:** Return 400 if no valid fields remain after sanitization

## Testing
- PATCH now updates the Supabase record directly
- GET endpoints immediately reflect the updated values
- Protected fields cannot be overwritten
- Unauthenticated requests return 401/403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication requirement for all ticket update operations to enhance security.
  * Critical ticket fields (ID, creation date, company ID) are now protected from modification.

* **Improvements**
  * Enhanced system reliability through improved data persistence mechanisms.
  * Better error handling with clearer feedback when update operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->