### PR TITLE
security(#908): remove hardcoded Supabase key from MobileApp

### DIFF
--- a/MobileApp/.env.example
+++ b/MobileApp/.env.example
@@ -1,0 +1,12 @@
+# MobileApp Environment Variables — Copy this file to .env and fill in real values.
+# NEVER commit .env to version control.
+
+# Supabase project URL (get from Supabase Dashboard > Settings > API)
+EXPO_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+
+# Supabase anonymous key (public, safe for client-side use)
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
+
+# Optional: override for internal tooling that uses the non-EXPO prefix
+SUPABASE_URL=https://your-project-id.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key_here

--- a/MobileApp/.gitignore
+++ b/MobileApp/.gitignore
@@ -30,7 +30,9 @@ yarn-error.*
 .DS_Store
 *.pem
 
-# local env files
+# local env files — NEVER commit real Supabase credentials
+.env
+.env.*
 .env*.local
 
 # typescript

--- a/MobileApp/eas.json
+++ b/MobileApp/eas.json
@@ -10,6 +10,10 @@
     },
     "preview": {
       "channel": "preview",
+      "env": {
+        "EXPO_PUBLIC_SUPABASE_URL": "REPLACE_WITH_SUPABASE_URL",
+        "EXPO_PUBLIC_SUPABASE_ANON_KEY": "REPLACE_WITH_ANON_KEY"
+      },
       "android": {
         "buildType": "app-bundle"
       }
@@ -23,7 +27,11 @@
     },
     "production": {
       "channel": "production",
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_SUPABASE_URL": "REPLACE_WITH_PRODUCTION_SUPABASE_URL",
+        "EXPO_PUBLIC_SUPABASE_ANON_KEY": "REPLACE_WITH_PRODUCTION_ANON_KEY"
+      }
     }
   },
   "submit": {

--- a/MobileApp/src/lib/supabase.js
+++ b/MobileApp/src/lib/supabase.js
@@ -2,8 +2,17 @@ import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const supabaseUrl = 'https://aejuenhqciagpntcqoir.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzIzODQwNzgsImV4cCI6MjA4Nzk2MDA3OH0.-OxgEW5t4alPGlzV_JZDRZcLsQbbMap6jiWjfAVkMMY';
+// Read Supabase credentials from Expo public env vars — set via .env or eas.json
+// NEVER hardcode URLs or keys directly in source code.
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    '[Supabase] EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY must be set. ' +
+    'Copy MobileApp/.env.example to MobileApp/.env and fill in the required values.'
+  );
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey, {
   auth: {

--- a/backend/tests/test_env_security.py
+++ b/backend/tests/test_env_security.py
@@ -1,0 +1,201 @@
+"""
+Security tests: scan source files for hardcoded credential patterns.
+Fails if any file contains hardcoded Supabase anon keys (JWT prefix "eyJ"),
+hardcoded Supabase URLs embedded in code (not in .env.example or templates),
+or passwords/secrets in source.
+
+This test should run in CI to prevent credential leaks.
+"""
+
+import sys
+import os
+import re
+import unittest
+import fnmatch
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+# Files/patterns that are explicitly allowed to reference credentials
+# (templates, examples, test files, git-ignored env files)
+ALLOWED_PATTERNS = [
+    "*.env.example",
+    "*.env.template",
+    "test_env_security.py",  # this file
+    "*.md",
+    ".env",
+    ".env.*",
+    "*.lock",
+    "package-lock.json",
+    "*.png", "*.jpg", "*.ico", "*.svg", "*.woff", "*.ttf",
+    "*.pyc",
+    "SECURITY.md",
+]
+
+# Directories to skip entirely
+SKIP_DIRS = {
+    "node_modules", ".git", "__pycache__", ".expo", "dist",
+    "web-build", "build", ".venv", "venv", "env",
+    "backend/models",  # binary model files
+}
+
+# Patterns that indicate hardcoded credentials
+CREDENTIAL_PATTERNS = [
+    # Supabase anon key prefix (JWT HS256)
+    (
+        re.compile(r'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+'),
+        "Hardcoded Supabase JWT / anon key detected",
+    ),
+    # Supabase project URLs embedded as string literals in source (not env vars)
+    # Matches patterns like: 'https://xxxx.supabase.co' (in quotes, not a variable assignment to be read from env)
+    (
+        re.compile(r'''(?:const|var|let)\s+\w+\s*=\s*['"][^'"]+\.supabase\.co['"]'''),
+        "Hardcoded Supabase URL in variable assignment (use env var instead)",
+    ),
+    # Generic password assignment patterns
+    (
+        re.compile(r'''(?:password|passwd|secret)\s*=\s*['"][^'"]{8,}['"]''', re.IGNORECASE),
+        "Possible hardcoded password/secret detected",
+    ),
+]
+
+# Source file extensions to scan
+SCAN_EXTENSIONS = {".js", ".ts", ".jsx", ".tsx", ".py", ".json", ".yaml", ".yml", ".env"}
+
+
+def _should_skip(path: Path) -> bool:
+    """Return True if this path should be excluded from scanning."""
+    parts = path.parts
+    for skip in SKIP_DIRS:
+        skip_parts = tuple(skip.split("/"))
+        for i in range(len(parts) - len(skip_parts) + 1):
+            if parts[i:i + len(skip_parts)] == skip_parts:
+                return True
+
+    for pat in ALLOWED_PATTERNS:
+        if fnmatch.fnmatch(path.name, pat):
+            return True
+
+    return False
+
+
+def _scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """
+    Scan a single file for credential patterns.
+    Returns list of (line_number, matched_text, reason).
+    """
+    hits = []
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return hits
+
+    lines = content.splitlines()
+    for i, line in enumerate(lines, start=1):
+        for pattern, reason in CREDENTIAL_PATTERNS:
+            if pattern.search(line):
+                hits.append((i, line.strip()[:120], reason))
+    return hits
+
+
+def collect_violations() -> list[tuple[str, int, str, str]]:
+    """
+    Walk the project tree and collect all credential pattern violations.
+    Returns list of (relative_path, line_num, matched_text, reason).
+    """
+    violations = []
+    for path in PROJECT_ROOT.rglob("*"):
+        if path.is_dir():
+            continue
+        if path.suffix not in SCAN_EXTENSIONS:
+            continue
+        rel = path.relative_to(PROJECT_ROOT)
+        if _should_skip(rel):
+            continue
+
+        hits = _scan_file(path)
+        for line_num, text, reason in hits:
+            violations.append((str(rel), line_num, text, reason))
+
+    return violations
+
+
+class TestNoHardcodedCredentials(unittest.TestCase):
+    """Security scan: verify no hardcoded credentials exist in source files."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.violations = collect_violations()
+
+    def test_no_hardcoded_jwt_tokens(self):
+        jwt_violations = [
+            v for v in self.violations if "JWT" in v[3] or "anon key" in v[3]
+        ]
+        if jwt_violations:
+            msg = "Hardcoded JWT/Supabase anon keys found:\n"
+            for path, line, text, reason in jwt_violations:
+                msg += f"  {path}:{line} — {reason}\n    {text}\n"
+            self.fail(msg)
+
+    def test_no_hardcoded_supabase_urls(self):
+        url_violations = [
+            v for v in self.violations if "Supabase URL" in v[3]
+        ]
+        if url_violations:
+            msg = "Hardcoded Supabase URLs found:\n"
+            for path, line, text, reason in url_violations:
+                msg += f"  {path}:{line} — {reason}\n    {text}\n"
+            self.fail(msg)
+
+    def test_mobile_app_supabase_lib_uses_env_vars(self):
+        supabase_lib = PROJECT_ROOT / "MobileApp" / "src" / "lib" / "supabase.js"
+        if not supabase_lib.exists():
+            self.skipTest("MobileApp/src/lib/supabase.js not found")
+        content = supabase_lib.read_text(encoding="utf-8")
+        # Must use process.env, not hardcoded strings
+        self.assertIn("process.env", content,
+                      "MobileApp/src/lib/supabase.js must read credentials from process.env")
+        # Must NOT contain the leaked key prefix
+        self.assertNotIn("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", content,
+                         "Hardcoded JWT found in MobileApp/src/lib/supabase.js")
+
+    def test_env_example_exists_for_mobile_app(self):
+        env_example = PROJECT_ROOT / "MobileApp" / ".env.example"
+        self.assertTrue(env_example.exists(),
+                        "MobileApp/.env.example must exist as a template for developers")
+
+    def test_env_example_contains_required_vars(self):
+        env_example = PROJECT_ROOT / "MobileApp" / ".env.example"
+        if not env_example.exists():
+            self.skipTest(".env.example not found")
+        content = env_example.read_text(encoding="utf-8")
+        for var in ["EXPO_PUBLIC_SUPABASE_URL", "EXPO_PUBLIC_SUPABASE_ANON_KEY"]:
+            self.assertIn(var, content, f"{var} must be documented in .env.example")
+
+    def test_mobile_gitignore_ignores_env_files(self):
+        gitignore = PROJECT_ROOT / "MobileApp" / ".gitignore"
+        if not gitignore.exists():
+            self.skipTest("MobileApp/.gitignore not found")
+        content = gitignore.read_text(encoding="utf-8")
+        self.assertTrue(
+            ".env" in content or ".env.*" in content,
+            "MobileApp/.gitignore must exclude .env files"
+        )
+
+    def test_eas_json_uses_placeholder_not_real_key(self):
+        eas_json = PROJECT_ROOT / "MobileApp" / "eas.json"
+        if not eas_json.exists():
+            self.skipTest("MobileApp/eas.json not found")
+        content = eas_json.read_text(encoding="utf-8")
+        # eas.json should not contain the leaked JWT
+        self.assertNotIn(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            content,
+            "eas.json must not contain a hardcoded JWT/anon key"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Removes hardcoded Supabase URL and anon key from `MobileApp/src/lib/supabase.js`; replaces with `process.env.EXPO_PUBLIC_SUPABASE_URL` and `process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY`
- Adds `MobileApp/.env.example` — template documenting required env vars
- Updates `MobileApp/.gitignore` to exclude `.env` and `.env.*` files
- Updates `MobileApp/eas.json` with `env` sections for preview and production builds (with placeholder values)
- Adds `backend/tests/test_env_security.py` — automated security scan test that fails if JWT tokens or hardcoded Supabase URLs are found in source files

## Security fix
The leaked key `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` has been removed from `supabase.js`. Developers must now set credentials in `.env` (git-ignored).

Fixes #908