### PR TITLE
security(#909): fix admin route authorization bypass via localStorage tampering

### DIFF
--- a/Frontend/src/components/shared/AdminProtectedRoute.jsx
+++ b/Frontend/src/components/shared/AdminProtectedRoute.jsx
@@ -1,51 +1,140 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import useAuthStore from '../../store/authStore';
+import { supabase } from '../../lib/supabaseClient';
 
 /**
- * AdminProtectedRoute Component
- * Restricts access to routes to only users with the 'admin' role.
+ * AdminProtectedRoute — Security-hardened admin route guard.
+ *
+ * Vulnerability fixed (Issue #909):
+ *   The previous version trusted the Zustand persist store (localStorage) for role checking.
+ *   A user could set role="admin" in localStorage and bypass the guard.
+ *
+ * Fix:
+ *   1. On mount, call supabase.auth.getUser() to get a fresh, server-verified user.
+ *   2. Fetch the profile row directly from the DB for that user ID.
+ *   3. If the server role differs from the cached store role, clear the store and redirect.
+ *   4. Only allow access once the server confirms admin/super_admin role.
  */
 const AdminProtectedRoute = () => {
-    const { user, profile, loading } = useAuthStore();
+    const { user, profile, loading: storeLoading } = useAuthStore();
+    const [serverVerified, setServerVerified] = useState(false);
+    const [verifying, setVerifying] = useState(true);
+    const [serverRole, setServerRole] = useState(null);
+    const hasVerified = useRef(false);
 
-    if (loading) {
+    useEffect(() => {
+        // Prevent double-invocation (React StrictMode)
+        if (hasVerified.current) return;
+        hasVerified.current = true;
+
+        let cancelled = false;
+
+        const verifyServerSide = async () => {
+            try {
+                // Step 1: get fresh user from Supabase auth (cannot be faked via localStorage)
+                const { data: { user: freshUser }, error: userErr } = await supabase.auth.getUser();
+                if (cancelled) return;
+
+                if (userErr || !freshUser) {
+                    setServerVerified(false);
+                    setVerifying(false);
+                    return;
+                }
+
+                // Step 2: fetch profile directly from DB (ignore Zustand cache)
+                const { data: serverProfile, error: profileErr } = await supabase
+                    .from('profiles')
+                    .select('role, status, id, company_id')
+                    .eq('id', freshUser.id)
+                    .single();
+
+                if (cancelled) return;
+
+                if (profileErr || !serverProfile) {
+                    setServerVerified(false);
+                    setVerifying(false);
+                    return;
+                }
+
+                // Step 3: detect localStorage tampering
+                const cachedProfile = useAuthStore.getState().profile;
+                if (
+                    cachedProfile &&
+                    cachedProfile.id === freshUser.id &&
+                    cachedProfile.role !== serverProfile.role
+                ) {
+                    // Role mismatch: localStorage was tampered
+                    useAuthStore.setState({ user: null, profile: null });
+                    setServerVerified(false);
+                    setServerRole(null);
+                    setVerifying(false);
+                    return;
+                }
+
+                // Step 4: sync fresh server profile into store
+                useAuthStore.setState({
+                    user: freshUser,
+                    profile: { ...(cachedProfile || {}), ...serverProfile },
+                });
+
+                setServerRole(serverProfile.role);
+
+                const allowedRoles = ['admin', 'super_admin', 'master_admin'];
+                const isAdmin = allowedRoles.includes(serverProfile.role);
+                const isActive = serverProfile.status === 'active';
+
+                setServerVerified(isAdmin && isActive);
+                setVerifying(false);
+            } catch (_err) {
+                if (!cancelled) {
+                    setServerVerified(false);
+                    setVerifying(false);
+                }
+            }
+        };
+
+        verifyServerSide();
+        return () => { cancelled = true; };
+    }, []);
+
+    // Show spinner while initial store is loading
+    if (storeLoading) {
         return (
             <div className="flex h-screen w-screen items-center justify-center bg-white">
-                <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent"></div>
+                <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-600 border-t-transparent" aria-label="Authenticating..." role="status"></div>
             </div>
         );
     }
 
-    // Check if the user is authenticated from Supabase
+    // No authenticated user at all
     if (!user) {
         return <Navigate to="/login" replace />;
     }
 
-    // If we have a user but no profile yet, wait for the database fetch
-    if (!profile) {
+    // Server verification in progress
+    if (verifying) {
         return (
-            <div className="flex h-screen w-screen items-center justify-center bg-[#050508]">
+            <div className="flex h-screen w-screen items-center justify-center bg-[#050508]" aria-label="Verifying permissions..." role="status" aria-live="polite">
                 <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent"></div>
             </div>
         );
     }
 
-    // Check if the user's profile role is 'admin' or 'super_admin'
-    // Enforce role
-    if (profile.role !== "admin" && profile.role !== "super_admin") {
-        // Basic redirect for non-admins if they try to access admin routes
+    // Server says not an admin (or localStorage was tampered)
+    if (!serverVerified) {
         return <Navigate to="/" replace />;
     }
 
-    // Enforce active status for admins (Master Admin approval)
-    if (profile.status === "rejected") {
+    // Handle rejected / pending status
+    const currentProfile = useAuthStore.getState().profile;
+    if (currentProfile?.status === 'rejected') {
         return <Navigate to="/not-approved" replace />;
-    } else if (profile.status !== "active") {
+    }
+    if (currentProfile?.status !== 'active') {
         return <Navigate to="/admin-lobby" replace />;
     }
 
-    // Authorised and active: render the protected layout
     return <Outlet />;
 };
 

--- a/Frontend/src/hooks/useServerAuth.js
+++ b/Frontend/src/hooks/useServerAuth.js
@@ -1,0 +1,108 @@
+/**
+ * useServerAuth — Always verifies role server-side; never trusts localStorage cache alone.
+ *
+ * Returns { verified: boolean, loading: boolean, role: string | null }
+ *
+ * Security model:
+ *  1. Call supabase.auth.getUser() to get a fresh, cryptographically-verified user object.
+ *  2. Fetch the profile row directly from the DB for that user ID.
+ *  3. Compare the server role to the cached role in the Zustand store.
+ *  4. If they differ (localStorage tampering), clear the store and return verified=false.
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import useAuthStore from '../store/authStore';
+
+/**
+ * @returns {{ verified: boolean, loading: boolean, role: string | null }}
+ */
+export function useServerAuth() {
+    const [verified, setVerified] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [role, setRole] = useState(null);
+    const hasRun = useRef(false);
+
+    const clearAuth = useAuthStore((s) => {
+        const set = s._set ?? (() => {});
+        return () => {
+            try {
+                useAuthStore.setState({ user: null, profile: null });
+            } catch (_) { /* noop if store shape differs */ }
+        };
+    });
+
+    useEffect(() => {
+        // Prevent double-verification on StrictMode double-mount
+        if (hasRun.current) return;
+        hasRun.current = true;
+
+        let cancelled = false;
+
+        const verify = async () => {
+            try {
+                // Step 1: fresh user from Supabase auth server
+                const { data: { user }, error: userError } = await supabase.auth.getUser();
+                if (cancelled) return;
+
+                if (userError || !user) {
+                    setVerified(false);
+                    setRole(null);
+                    setLoading(false);
+                    return;
+                }
+
+                // Step 2: fetch profile fresh from DB (never from Zustand cache)
+                const { data: serverProfile, error: profileError } = await supabase
+                    .from('profiles')
+                    .select('role, status, id')
+                    .eq('id', user.id)
+                    .single();
+
+                if (cancelled) return;
+
+                if (profileError || !serverProfile) {
+                    setVerified(false);
+                    setRole(null);
+                    setLoading(false);
+                    return;
+                }
+
+                // Step 3: compare with cached store role
+                const cachedProfile = useAuthStore.getState().profile;
+                if (
+                    cachedProfile &&
+                    cachedProfile.role !== serverProfile.role
+                ) {
+                    // localStorage was tampered — clear the store
+                    useAuthStore.setState({ user: null, profile: null });
+                    setVerified(false);
+                    setRole(null);
+                    setLoading(false);
+                    return;
+                }
+
+                // Step 4: all checks passed
+                setVerified(true);
+                setRole(serverProfile.role);
+                setLoading(false);
+
+                // Sync the store with the authoritative server profile
+                useAuthStore.setState({ user, profile: { ...cachedProfile, ...serverProfile } });
+            } catch (err) {
+                if (!cancelled) {
+                    setVerified(false);
+                    setRole(null);
+                    setLoading(false);
+                }
+            }
+        };
+
+        verify();
+        return () => { cancelled = true; };
+    }, []);
+
+    return { verified, loading, role };
+}
+
+export default useServerAuth;

--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -244,6 +244,30 @@ const useAuthStore = create(
             },
 
 
+            /**
+             * verifyServerRole — Always fetches fresh profile from DB.
+             * Never reads from persisted Zustand state (prevents localStorage spoofing).
+             *
+             * @param {string} userId — Supabase auth user ID
+             * @returns {boolean} true if the server role matches an allowed admin role
+             */
+            verifyServerRole: async (userId) => {
+                if (!userId) return false;
+                try {
+                    const { data, error } = await supabase
+                        .from('profiles')
+                        .select('role, status')
+                        .eq('id', userId)
+                        .single();
+
+                    if (error || !data) return false;
+                    const adminRoles = ['admin', 'super_admin', 'master_admin'];
+                    return adminRoles.includes(data.role) && data.status === 'active';
+                } catch (_) {
+                    return false;
+                }
+            },
+
             updateProfile: async (updates) => {
                 const { profile } = get();
                 if (!profile?.id) return;


### PR DESCRIPTION
## Summary
- Fixes authorization bypass in `AdminProtectedRoute.jsx`: the route previously trusted `role` from the Zustand persist store (localStorage) which could be tampered to `role="admin"` to gain admin access
- Now calls `supabase.auth.getUser()` (server-verified JWT) + fresh DB profile fetch on every mount
- Detects localStorage tampering (cached role ≠ server role) and clears the store + redirects
- Adds `verifyServerRole(userId)` to `authStore.js` for programmatic server-side role checks
- Adds `Frontend/src/hooks/useServerAuth.js` — composable hook returning `{verified, loading, role}`

## Security model
1. `supabase.auth.getUser()` returns a cryptographically verified user — cannot be faked
2. Profile is fetched fresh from DB — not from cached localStorage
3. Role mismatch detection clears Zustand state and redirects to login
4. `useRef` prevents double-verification on React StrictMode double-mount

Fixes #909