### PR TITLE
feat(#911): add global keyboard shortcuts system for admin dashboard

### DIFF
--- a/Frontend/src/admin/components/KeyboardShortcutsModal.jsx
+++ b/Frontend/src/admin/components/KeyboardShortcutsModal.jsx
@@ -1,0 +1,144 @@
+/**
+ * KeyboardShortcutsModal — Displays all keyboard shortcuts in a clean grid layout.
+ * Grouped into: Navigation, UI.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import { X, Keyboard } from 'lucide-react';
+import ShortcutBadge from './ShortcutBadge';
+import { SHORTCUT_GROUPS } from '../../hooks/useKeyboardShortcuts';
+import { useFocusTrap } from '../../hooks/useAccessibility';
+
+/**
+ * @param {{ isOpen: boolean, onClose: function }} props
+ */
+const KeyboardShortcutsModal = ({ isOpen, onClose }) => {
+    const { containerRef } = useFocusTrap(isOpen, onClose);
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Keyboard shortcuts"
+            style={{
+                position: 'fixed',
+                inset: 0,
+                zIndex: 9999,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '16px',
+            }}
+        >
+            {/* Backdrop */}
+            <div
+                aria-hidden="true"
+                onClick={onClose}
+                style={{
+                    position: 'absolute',
+                    inset: 0,
+                    background: 'rgba(0, 0, 0, 0.7)',
+                    backdropFilter: 'blur(4px)',
+                }}
+            />
+
+            {/* Modal panel */}
+            <div
+                ref={containerRef}
+                style={{
+                    position: 'relative',
+                    background: '#0f1f12',
+                    border: '1px solid #1e3a21',
+                    borderRadius: '16px',
+                    width: '100%',
+                    maxWidth: '520px',
+                    maxHeight: '80vh',
+                    overflowY: 'auto',
+                    boxShadow: '0 24px 48px rgba(0,0,0,0.6)',
+                    padding: '24px',
+                }}
+            >
+                {/* Header */}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                        <div style={{ background: '#10b981', borderRadius: '8px', padding: '6px', display: 'flex' }}>
+                            <Keyboard size={16} color="#fff" />
+                        </div>
+                        <h2 style={{ fontSize: '16px', fontWeight: 700, color: '#e2e8f0', margin: 0 }}>
+                            Keyboard Shortcuts
+                        </h2>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        aria-label="Close keyboard shortcuts"
+                        style={{
+                            background: 'transparent',
+                            border: '1px solid #1e3a21',
+                            borderRadius: '8px',
+                            padding: '6px',
+                            cursor: 'pointer',
+                            color: '#6b7280',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                        }}
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+
+                {/* Shortcut groups */}
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>
+                    {SHORTCUT_GROUPS.map((group) => (
+                        <section key={group.group} aria-label={group.group}>
+                            <h3
+                                style={{
+                                    fontSize: '10px',
+                                    fontWeight: 700,
+                                    color: '#10b981',
+                                    textTransform: 'uppercase',
+                                    letterSpacing: '0.1em',
+                                    marginBottom: '10px',
+                                    paddingBottom: '6px',
+                                    borderBottom: '1px solid #1e3a21',
+                                }}
+                            >
+                                {group.group}
+                            </h3>
+
+                            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                                {group.shortcuts.map((shortcut, i) => (
+                                    <li
+                                        key={i}
+                                        style={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'space-between',
+                                            padding: '8px 12px',
+                                            borderRadius: '8px',
+                                            background: '#152218',
+                                        }}
+                                    >
+                                        <span style={{ fontSize: '13px', color: '#cbd5e1' }}>
+                                            {shortcut.description}
+                                        </span>
+                                        <ShortcutBadge keys={shortcut.keys} />
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+
+                {/* Footer hint */}
+                <p style={{ marginTop: '20px', fontSize: '11px', color: '#4b5563', textAlign: 'center' }}>
+                    Press <ShortcutBadge keys={['?']} /> to toggle this panel
+                </p>
+            </div>
+        </div>
+    );
+};
+
+export default KeyboardShortcutsModal;

--- a/Frontend/src/admin/components/ShortcutBadge.jsx
+++ b/Frontend/src/admin/components/ShortcutBadge.jsx
@@ -1,0 +1,56 @@
+/**
+ * ShortcutBadge — Renders a keyboard shortcut combination badge.
+ * e.g. ["G", "D"] → renders two key bubbles: [G] then [D]
+ * e.g. ["?"]       → renders [?]
+ */
+
+import React from 'react';
+
+const KEY_STYLE = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: '24px',
+    height: '22px',
+    padding: '0 6px',
+    background: '#1e3a21',
+    border: '1px solid #2d5230',
+    borderRadius: '5px',
+    fontSize: '11px',
+    fontWeight: 700,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    color: '#a7f3d0',
+    lineHeight: 1,
+    boxShadow: '0 1px 0 #152218',
+    flexShrink: 0,
+};
+
+const THEN_STYLE = {
+    fontSize: '10px',
+    color: '#6b7280',
+    margin: '0 2px',
+};
+
+/**
+ * @param {{ keys: string[], className?: string }} props
+ */
+const ShortcutBadge = ({ keys = [], className = '' }) => {
+    if (!keys || keys.length === 0) return null;
+
+    return (
+        <span
+            className={`shortcut-badge ${className}`}
+            aria-label={`Shortcut: ${keys.join(' then ')}`}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '3px' }}
+        >
+            {keys.map((key, i) => (
+                <React.Fragment key={i}>
+                    {i > 0 && <span style={THEN_STYLE} aria-hidden="true">then</span>}
+                    <kbd style={KEY_STYLE}>{key}</kbd>
+                </React.Fragment>
+            ))}
+        </span>
+    );
+};
+
+export default ShortcutBadge;

--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -1,22 +1,45 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import KeyboardShortcutsModal from '../components/KeyboardShortcutsModal';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 
 /**
  * AdminLayout Component
  * Master framework for the administrative zone.
  * Enforces a fixed-sidebar architecture with a centered, high-density content terminal.
+ * Integrates global keyboard shortcuts (Issue #911).
  */
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const [isShortcutsModalOpen, setShortcutsModalOpen] = useState(false);
+    const searchInputRef = useRef(null);
+
+    const handleFocusSearch = useCallback(() => {
+        const searchEl =
+            searchInputRef.current ||
+            document.querySelector('input[placeholder*="earch"], input[type="search"]');
+        searchEl?.focus();
+    }, []);
+
+    const handleCloseModal = useCallback(() => {
+        setShortcutsModalOpen(false);
+        setIsMobileNavOpen(false);
+    }, []);
+
+    useKeyboardShortcuts({
+        onOpenHelp: () => setShortcutsModalOpen((prev) => !prev),
+        onCloseModal: handleCloseModal,
+        onFocusSearch: handleFocusSearch,
+    });
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
             {/* Master Navigation Column (Responsive) */}
-            <div 
+            <div
                 className={`hidden md:block flex-shrink-0 relative z-40 transition-all duration-300`}
                 style={{ width: isSidebarCollapsed ? '80px' : '260px' }}
             >
@@ -26,10 +49,11 @@ const AdminLayout = () => {
             {/* Viewport Execution Layer */}
             <div className="flex-1 flex flex-col min-w-0 relative h-full">
                 {/* Global Command Header */}
-                <AdminHeader 
-                    onMobileNavToggle={() => setIsMobileNavOpen(!isMobileNavOpen)} 
+                <AdminHeader
+                    onMobileNavToggle={() => setIsMobileNavOpen(!isMobileNavOpen)}
                     isSidebarCollapsed={isSidebarCollapsed}
                     onToggleSidebar={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+                    searchInputRef={searchInputRef}
                 />
 
                 {/* Operational Workspace */}
@@ -43,6 +67,12 @@ const AdminLayout = () => {
 
             {/* Real-time System Notifications */}
             <NotificationToast />
+
+            {/* Keyboard Shortcuts Help Modal */}
+            <KeyboardShortcutsModal
+                isOpen={isShortcutsModalOpen}
+                onClose={() => setShortcutsModalOpen(false)}
+            />
 
             {/* Mobile Nav Overlay (Emergency protocols) */}
             {isMobileNavOpen && (

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,156 @@
+/**
+ * useKeyboardShortcuts — Global keyboard shortcut system for the admin dashboard.
+ *
+ * Supports:
+ *  - Single-key shortcuts (e.g. ? → help modal, / → focus search, Escape → close)
+ *  - Chord shortcuts (two-key sequences with 1 second timeout, e.g. g+d → /admin/dashboard)
+ *  - Skips all shortcuts when focus is inside an input / textarea / select / [contenteditable]
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const CHORD_TIMEOUT_MS = 1000;
+
+/**
+ * Check whether focus is currently inside a text-entry element.
+ * Shortcuts must not fire while the user is typing.
+ */
+function isTypingTarget(element) {
+    if (!element) return false;
+    const tag = element.tagName?.toLowerCase();
+    const editable = element.getAttribute?.('contenteditable') === 'true';
+    return (
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        editable
+    );
+}
+
+/**
+ * Navigation chord map: first key "g" → second key → route.
+ */
+const NAV_CHORD_MAP = {
+    d: '/admin/dashboard',
+    t: '/admin/tickets',
+    u: '/admin/users',
+    a: '/admin/analytics',
+    s: '/admin/scorecard',
+    p: '/admin/profile',
+};
+
+/**
+ * useKeyboardShortcuts
+ *
+ * @param {object} options
+ *   onOpenHelp      — called when "?" is pressed
+ *   onCloseModal    — called when Escape is pressed
+ *   onFocusSearch   — called when "/" is pressed
+ */
+export function useKeyboardShortcuts({
+    onOpenHelp,
+    onCloseModal,
+    onFocusSearch,
+} = {}) {
+    const navigate = useNavigate();
+    const pendingChord = useRef(null);        // first key of a chord sequence
+    const chordTimer = useRef(null);          // timeout to reset pending chord
+
+    const clearChord = useCallback(() => {
+        pendingChord.current = null;
+        if (chordTimer.current) {
+            clearTimeout(chordTimer.current);
+            chordTimer.current = null;
+        }
+    }, []);
+
+    const handleKeyDown = useCallback(
+        (e) => {
+            // Never fire shortcuts when the user is typing
+            if (isTypingTarget(document.activeElement)) return;
+
+            // Never fire shortcuts when modifier keys are held (except Shift for ?)
+            if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+            const key = e.key;
+
+            // --- Chord resolution (second key of a sequence) ---
+            if (pendingChord.current) {
+                const firstKey = pendingChord.current;
+                clearChord();
+
+                if (firstKey === 'g') {
+                    const route = NAV_CHORD_MAP[key.toLowerCase()];
+                    if (route) {
+                        e.preventDefault();
+                        navigate(route);
+                    }
+                }
+                return;
+            }
+
+            // --- Single-key shortcuts ---
+            switch (key) {
+                case 'g':
+                    // Begin a chord sequence — wait for second key
+                    pendingChord.current = 'g';
+                    chordTimer.current = setTimeout(clearChord, CHORD_TIMEOUT_MS);
+                    break;
+
+                case '?':
+                    e.preventDefault();
+                    onOpenHelp?.();
+                    break;
+
+                case 'Escape':
+                    onCloseModal?.();
+                    break;
+
+                case '/':
+                    e.preventDefault();
+                    onFocusSearch?.();
+                    break;
+
+                default:
+                    break;
+            }
+        },
+        [navigate, onOpenHelp, onCloseModal, onFocusSearch, clearChord]
+    );
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            clearChord();
+        };
+    }, [handleKeyDown, clearChord]);
+}
+
+/**
+ * SHORTCUT_GROUPS — definition array used to render the help modal.
+ */
+export const SHORTCUT_GROUPS = [
+    {
+        group: 'Navigation',
+        shortcuts: [
+            { keys: ['G', 'D'], description: 'Go to Dashboard' },
+            { keys: ['G', 'T'], description: 'Go to Tickets' },
+            { keys: ['G', 'U'], description: 'Go to Users' },
+            { keys: ['G', 'A'], description: 'Go to Analytics' },
+            { keys: ['G', 'S'], description: 'Go to Scorecard' },
+            { keys: ['G', 'P'], description: 'Go to Profile' },
+        ],
+    },
+    {
+        group: 'UI',
+        shortcuts: [
+            { keys: ['?'], description: 'Open keyboard shortcuts help' },
+            { keys: ['Esc'], description: 'Close modal / sidebar' },
+            { keys: ['/'], description: 'Focus search input' },
+        ],
+    },
+];
+
+export default useKeyboardShortcuts;


### PR DESCRIPTION
## Summary
- Adds `Frontend/src/hooks/useKeyboardShortcuts.js` — global keyboard shortcut hook with chord support (g+d → dashboard, etc.), single-key shortcuts (? → help, / → search, Esc → close), and automatic skip when typing in inputs
- Adds `Frontend/src/admin/components/ShortcutBadge.jsx` — renders key combination badges like [G] then [D]
- Adds `Frontend/src/admin/components/KeyboardShortcutsModal.jsx` — modal showing all shortcuts grouped by Navigation / UI with focus trap
- Updates `Frontend/src/admin/layout/AdminLayout.jsx` — integrates `useKeyboardShortcuts` and `KeyboardShortcutsModal`

## Shortcuts
| Keys | Action |
|------|--------|
| G → D | Go to Dashboard |
| G → T | Go to Tickets |
| G → U | Go to Users |
| G → A | Go to Analytics |
| G → S | Go to Scorecard |
| G → P | Go to Profile |
| ? | Toggle shortcuts help |
| / | Focus search input |
| Esc | Close modal/sidebar |

Fixes #911