### PR TITLE
feat: add skeleton loading states to admin dashboard pages

### DIFF
--- a/Frontend/src/admin/pages/AdminAnalytics.jsx
+++ b/Frontend/src/admin/pages/AdminAnalytics.jsx
@@ -16,6 +16,46 @@ import { formatTimelineDate } from "../../utils/dateUtils";
 
 const COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#a855f7', '#ec4899'];
 
+const AdminAnalyticsSkeleton = () => (
+    <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }} className="space-y-10 -m-6 p-6 md:-m-10 md:p-10 animate-pulse">
+        <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+            <div className="space-y-3">
+                <div className="h-8 w-40 bg-slate-200 rounded-full" />
+                <div className="h-4 w-56 bg-slate-100 rounded-full" />
+            </div>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[...Array(4)].map((_, index) => (
+                <div key={index} className="bg-white border border-slate-100 rounded-[1.5rem] p-6 shadow-sm space-y-4">
+                    <div className="flex justify-between items-center">
+                        <div className="h-4 w-24 bg-slate-100 rounded-full" />
+                        <div className="w-10 h-10 bg-emerald-100 rounded-xl" />
+                    </div>
+                    <div className="h-8 w-20 bg-slate-200 rounded-full" />
+                    <div className="h-3 w-32 bg-slate-100 rounded-full" />
+                </div>
+            ))}
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">
+            <div className="lg:col-span-8 space-y-10">
+                <div className="bg-white rounded-[20px] border border-emerald-50 p-6 space-y-6">
+                    <div className="h-5 w-48 bg-slate-200 rounded-full" />
+                    <div className="h-[300px] w-full bg-slate-50 rounded-2xl" />
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <div className="h-64 bg-white rounded-[20px] border border-emerald-50" />
+                    <div className="h-64 bg-white rounded-[20px] border border-emerald-50" />
+                </div>
+            </div>
+            <div className="lg:col-span-4 space-y-6">
+                {[...Array(3)].map((_, index) => (
+                    <div key={index} className="h-32 bg-white rounded-[20px] border border-emerald-50" />
+                ))}
+            </div>
+        </div>
+    </div>
+);
+
 const AdminAnalytics = () => {
     const { profile } = useAuthStore();
     const [tickets, setTickets] = useState([]);
@@ -172,12 +212,7 @@ const AdminAnalytics = () => {
     }, [tickets]);
 
     // Removed tab state - moving to single dashboard layout
-    if (loading) return (
-        <div className="flex flex-col items-center justify-center min-h-[400px]">
-            <Loader2 className="w-10 h-10 text-indigo-600 animate-spin mb-4" />
-            <p className="text-slate-400 font-black uppercase tracking-widest italic text-center">Analyzing ticket data...</p>
-        </div>
-    );
+    if (loading) return <AdminAnalyticsSkeleton />;
 
     return (
         <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }} className="space-y-10 -m-6 p-6 md:-m-10 md:p-10 animate-in fade-in duration-700">

--- a/Frontend/src/admin/pages/AdminAnalytics.jsx
+++ b/Frontend/src/admin/pages/AdminAnalytics.jsx
@@ -17,7 +17,15 @@ import { formatTimelineDate } from "../../utils/dateUtils";
 const COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#a855f7', '#ec4899'];
 
 const AdminAnalyticsSkeleton = () => (
-    <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }} className="space-y-10 -m-6 p-6 md:-m-10 md:p-10 animate-pulse">
+    <div
+        style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }}
+        className="space-y-10 -m-6 p-6 md:-m-10 md:p-10 animate-pulse"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        aria-atomic="true"
+    >
+        <span className="sr-only">Loading analytics...</span>
         <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
             <div className="space-y-3">
                 <div className="h-8 w-40 bg-slate-200 rounded-full" />

--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -17,6 +17,51 @@ import SLABadge from "../components/SLABadge";
 import { formatFullTimestamp } from "../../utils/dateUtils";
 import TicketTimeline from "../../user/components/TicketTimeline";
 
+const AdminTicketDetailSkeleton = () => (
+    <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }} className="-m-6 p-6 md:-m-10 md:p-10 space-y-6 animate-pulse">
+        <div className="bg-white border-b border-emerald-50 shadow-sm p-5 -m-6 mb-6 rounded-b-2xl flex items-center justify-between gap-4">
+            <div className="flex items-center gap-4">
+                <div className="w-10 h-10 bg-slate-100 rounded-xl" />
+                <div className="space-y-3">
+                    <div className="h-4 w-48 bg-slate-200 rounded-full" />
+                    <div className="flex gap-2">
+                        <div className="h-5 w-24 bg-amber-100 rounded-full" />
+                        <div className="h-5 w-28 bg-slate-100 rounded-full" />
+                    </div>
+                </div>
+            </div>
+            <div className="hidden md:flex gap-3">
+                <div className="h-10 w-28 bg-emerald-100 rounded-xl" />
+                <div className="h-10 w-28 bg-slate-100 rounded-xl" />
+            </div>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-2 space-y-6">
+                <div className="bg-white rounded-[2rem] border border-slate-100 p-8 space-y-4">
+                    <div className="h-5 w-56 bg-slate-200 rounded-full" />
+                    <div className="h-4 w-full bg-slate-100 rounded-full" />
+                    <div className="h-4 w-5/6 bg-slate-100 rounded-full" />
+                    <div className="h-32 w-full bg-slate-50 rounded-2xl" />
+                </div>
+                <div className="bg-white rounded-[2rem] border border-slate-100 p-8 space-y-4">
+                    <div className="h-4 w-40 bg-slate-200 rounded-full" />
+                    <div className="h-24 w-full bg-slate-50 rounded-2xl" />
+                </div>
+            </div>
+            <div className="space-y-6">
+                <div className="bg-white rounded-[2rem] border border-slate-100 p-6 space-y-4">
+                    {[...Array(5)].map((_, index) => (
+                        <div key={index} className="flex justify-between gap-4">
+                            <div className="h-3 w-20 bg-slate-100 rounded-full" />
+                            <div className="h-3 w-24 bg-slate-200 rounded-full" />
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
 const AdminTicketDetail = () => {
     const { ticket_id } = useParams();
     const navigate = useNavigate();
@@ -173,12 +218,7 @@ const AdminTicketDetail = () => {
         }, 'resolve');
     };
 
-    if (isLoading) return (
-        <div className="flex flex-col items-center justify-center min-h-[400px]">
-            <Loader2 className="w-10 h-10 text-emerald-600 animate-spin mb-4" />
-            <p className="text-gray-400 font-black uppercase tracking-[0.2em] italic">Accessing Neural Records...</p>
-        </div>
-    );
+    if (isLoading) return <AdminTicketDetailSkeleton />;
 
     if (error) return (
         <div className="flex flex-col items-center justify-center min-h-[400px] text-center space-y-4">

--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -18,7 +18,15 @@ import { formatFullTimestamp } from "../../utils/dateUtils";
 import TicketTimeline from "../../user/components/TicketTimeline";
 
 const AdminTicketDetailSkeleton = () => (
-    <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }} className="-m-6 p-6 md:-m-10 md:p-10 space-y-6 animate-pulse">
+    <div
+        style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }}
+        className="-m-6 p-6 md:-m-10 md:p-10 space-y-6 animate-pulse"
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        aria-atomic="true"
+    >
+        <span className="sr-only">Loading ticket details...</span>
         <div className="bg-white border-b border-emerald-50 shadow-sm p-5 -m-6 mb-6 rounded-b-2xl flex items-center justify-between gap-4">
             <div className="flex items-center gap-4">
                 <div className="w-10 h-10 bg-slate-100 rounded-xl" />

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -27,7 +27,8 @@ import SLABadge from "../components/SLABadge";
 import { formatTimelineDate } from "../../utils/dateUtils";
 
 const AdminTicketsSkeleton = () => (
-    <div className="animate-pulse">
+    <div className="animate-pulse" role="status" aria-live="polite" aria-atomic="true">
+        <span className="sr-only">Loading tickets...</span>
         {[...Array(6)].map((_, rowIndex) => (
             <div key={rowIndex} className="grid grid-cols-[90px_180px_260px_120px_140px_120px_120px_100px_80px] gap-4 px-6 py-5 border-b border-slate-50 items-center">
                 <div className="h-4 bg-emerald-100 rounded-full" />
@@ -296,7 +297,7 @@ const AdminTickets = () => {
             </div>
 
             {/* 3. High-Density Data Terminal */}
-            <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]">
+            <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]" aria-busy={loading}>
                 {loading && (
                     <div className="absolute inset-0 bg-white/80 backdrop-blur-[2px] z-10 overflow-hidden">
                         <div className="px-6 py-5 border-b border-slate-100 bg-slate-50/80">

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -26,6 +26,33 @@ import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
 import { formatTimelineDate } from "../../utils/dateUtils";
 
+const AdminTicketsSkeleton = () => (
+    <div className="animate-pulse">
+        {[...Array(6)].map((_, rowIndex) => (
+            <div key={rowIndex} className="grid grid-cols-[90px_180px_260px_120px_140px_120px_120px_100px_80px] gap-4 px-6 py-5 border-b border-slate-50 items-center">
+                <div className="h-4 bg-emerald-100 rounded-full" />
+                <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-slate-100 rounded-lg" />
+                    <div className="space-y-2 flex-1">
+                        <div className="h-3 bg-slate-100 rounded-full" />
+                        <div className="h-2 bg-slate-100 rounded-full w-2/3" />
+                    </div>
+                </div>
+                <div className="space-y-2">
+                    <div className="h-3 bg-slate-100 rounded-full" />
+                    <div className="h-2 bg-slate-100 rounded-full w-1/2" />
+                </div>
+                <div className="h-7 bg-amber-100 rounded-xl" />
+                <div className="h-8 bg-slate-100 rounded-full" />
+                <div className="h-4 bg-emerald-100 rounded-full" />
+                <div className="h-7 bg-slate-100 rounded-xl" />
+                <div className="h-6 bg-slate-100 rounded-full" />
+                <div className="h-9 bg-slate-900/10 rounded-xl" />
+            </div>
+        ))}
+    </div>
+);
+
 const AdminTickets = () => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -271,8 +298,11 @@ const AdminTickets = () => {
             {/* 3. High-Density Data Terminal */}
             <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]">
                 {loading && (
-                    <div className="absolute inset-0 bg-white/60 backdrop-blur-[2px] z-10 flex items-center justify-center">
-                        <Loader2 className="w-10 h-10 text-emerald-600 animate-spin" />
+                    <div className="absolute inset-0 bg-white/80 backdrop-blur-[2px] z-10 overflow-hidden">
+                        <div className="px-6 py-5 border-b border-slate-100 bg-slate-50/80">
+                            <div className="h-3 w-32 bg-slate-200 rounded-full animate-pulse" />
+                        </div>
+                        <AdminTicketsSkeleton />
                     </div>
                 )}
 


### PR DESCRIPTION
## Summary
- Add layout-matching skeleton loading states for Admin Tickets, Ticket Detail, and Analytics pages.
- Replace spinner-only loading with Tailwind nimate-pulse placeholders that mirror tables, detail cards, KPI cards, and charts.
- Keep the implementation dependency-free and scoped to the dashboard pages requested in #998.

Fixes #998

## Test plan
- npm run build
- npx eslint src/admin/pages/AdminTickets.jsx src/admin/pages/AdminTicketDetail.jsx src/admin/pages/AdminAnalytics.jsx --quiet
- git diff --check

Note: full 
pm run lint still reports pre-existing unrelated lint issues outside these files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced loading experience with animated skeleton placeholders across admin pages, replacing centered spinners.
  * Analytics page shows a structured skeleton layout during data load.
  * Ticket Detail page displays an animated placeholder while fetching data.
  * Tickets page uses skeleton rows and a blurred backdrop overlay for improved visual feedback and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->