### PR TITLE
devops(#900): multi-stage Dockerfile, Kubernetes manifests, and docker-compose

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,36 +1,90 @@
-# Use an official Python runtime as a parent image
-FROM python:3.10-slim
+# =============================================================================
+# Multi-stage Dockerfile for HELPDESK.AI Backend (Issue #900)
+# Stage 1 (builder): Install all dependencies including torch/transformers
+# Stage 2 (production): Copy only needed files, non-root user, health check
+# Base: python:3.11-slim-bookworm
+# =============================================================================
 
-LABEL version="1.1.1" rebuild_trigger="2026-03-08-2032"
+# ---------------------------------------------------------------------------
+# Stage 1: builder — install all Python dependencies
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS builder
 
-# Set the working directory to /app
-WORKDIR /app
+# Prevent Python from writing .pyc files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
-# Install system dependencies required for EasyOCR and OpenCV
-RUN apt-get update && apt-get install -y \
+WORKDIR /build
+
+# Install system build deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
     libgl1 \
     libglib2.0-0 \
-    git \
+    libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the requirements file into the container
+# Copy requirements first for layer caching
 COPY requirements.txt .
 
-# Install dependencies (no-cache-dir keeps the docker image smaller)
-RUN pip install --no-cache-dir -r requirements.txt
+# Install Python dependencies into a virtualenv for clean copy to production stage
+RUN python -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
-# Copy all the remaining files into the container as a 'backend' directory
-# This allows absolute imports like 'from backend.services...' to work perfectly
-COPY . /app/backend
+# Pre-compile Python source to bytecode for faster startup
+COPY . /build/backend
+RUN /opt/venv/bin/python -m compileall -q /build/backend || true
 
-# Tell Python where to look for modules (so it can find the 'backend' folder)
-ENV PYTHONPATH=/app
 
-# Expose port 7860 (Hugging Face Spaces default)
+# ---------------------------------------------------------------------------
+# Stage 2: production — minimal runtime image
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS production
+
+LABEL maintainer="HELPDESK.AI Team" \
+      version="1.2.0" \
+      description="AI Helpdesk Backend — production image"
+
+# Runtime-only system libraries (no build tools)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    libglib2.0-0 \
+    libgomp1 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user for security
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid 1001 --no-create-home --shell /bin/false appuser
+
+# Copy virtualenv from builder (no dev tools)
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Set working directory
+WORKDIR /app
+
+# Copy compiled application code
+COPY --from=builder /build/backend /app/backend
+
+# Set Python path so `from backend.xxx import ...` works
+ENV PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Switch to non-root user
+USER appuser
+
+# Expose application port (Hugging Face Spaces default)
 EXPOSE 7860
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
-    CMD ["python", "backend/healthcheck.py"]
+# Health check using the healthcheck.py script (K8s liveness probe compatible)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD ["python", "/app/backend/healthcheck.py"]
 
-# Run the FastAPI server via Uvicorn
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860"]
+# Default command — override PORT env var for non-HF deployments
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860", "--workers", "1"]

--- a/backend/healthcheck.py
+++ b/backend/healthcheck.py
@@ -1,25 +1,102 @@
+"""
+Healthcheck script — compatible with K8s liveness/readiness probes and Docker HEALTHCHECK.
+
+Exit codes:
+  0 — healthy
+  1 — unhealthy
+
+Probes:
+  - Liveness: GET /health  — fast check, exits 0 if API responds 2xx
+  - Readiness: GET /ready  — checks all service statuses
+
+Usage:
+  python backend/healthcheck.py [--liveness | --readiness]
+  Default: uses HEALTHCHECK_URL env var (falls back to /health for liveness)
+
+Environment variables:
+  HEALTHCHECK_URL           — full URL to probe (default: http://127.0.0.1:7860/health)
+  HEALTHCHECK_TIMEOUT_SECONDS — HTTP timeout in seconds (default: 5)
+  HEALTHCHECK_MODE          — "liveness" or "readiness" (default: "liveness")
+"""
+
 import os
 import sys
+import json
 import urllib.error
 import urllib.request
 from urllib.parse import urlparse
 
 
+_BASE_URL = os.environ.get("HEALTHCHECK_BASE_URL", "http://127.0.0.1:7860")
+
+_MODE_ENDPOINTS = {
+    "liveness": "/health",
+    "readiness": "/ready",
+}
+
+
+def _get_url() -> str:
+    """Build the probe URL from env vars or command-line args."""
+    explicit = os.environ.get("HEALTHCHECK_URL", "")
+    if explicit:
+        return explicit
+
+    mode = os.environ.get("HEALTHCHECK_MODE", "liveness")
+    if "--readiness" in sys.argv:
+        mode = "readiness"
+    elif "--liveness" in sys.argv:
+        mode = "liveness"
+
+    endpoint = _MODE_ENDPOINTS.get(mode, "/health")
+    return f"{_BASE_URL.rstrip('/')}{endpoint}"
+
+
+def _get_timeout() -> float:
+    try:
+        return float(os.environ.get("HEALTHCHECK_TIMEOUT_SECONDS", "5"))
+    except (TypeError, ValueError):
+        return 5.0
+
+
 def main() -> int:
-    url = os.environ.get("HEALTHCHECK_URL", "http://127.0.0.1:7860/ready")
-    parsed_url = urlparse(url)
-    if parsed_url.scheme not in {"http", "https"}:
+    url = _get_url()
+    timeout = _get_timeout()
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        print(f"[healthcheck] ERROR: Invalid URL scheme in '{url}'", file=sys.stderr)
         return 1
 
     try:
-        timeout = float(os.environ.get("HEALTHCHECK_TIMEOUT_SECONDS", "3"))
-    except (TypeError, ValueError):
-        timeout = 3.0
+        req = urllib.request.Request(url, method="GET")
+        req.add_header("User-Agent", "helpdesk-healthcheck/1.0")
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            status = response.status
+            if 200 <= status < 300:
+                # For readiness probe: parse body to check all services
+                if "/ready" in url:
+                    try:
+                        body = json.loads(response.read())
+                        if body.get("status") not in ("ready", "ok"):
+                            print(
+                                f"[healthcheck] NOT READY: {body.get('status')} — checks: {body.get('checks')}",
+                                file=sys.stderr,
+                            )
+                            return 1
+                    except Exception:
+                        pass  # Treat as healthy if body can't be parsed
+                return 0
+            print(f"[healthcheck] HTTP {status} from {url}", file=sys.stderr)
+            return 1
 
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as response:
-            return 0 if 200 <= response.status < 300 else 1
-    except (TimeoutError, urllib.error.URLError, OSError):
+    except urllib.error.HTTPError as exc:
+        print(f"[healthcheck] HTTP error {exc.code} from {url}", file=sys.stderr)
+        return 1
+    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        print(f"[healthcheck] Connection error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"[healthcheck] Unexpected error: {exc}", file=sys.stderr)
         return 1
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+version: "3.9"
+
+# Local development stack for HELPDESK.AI
+# Usage: docker compose up --build
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: production
+    image: helpdesk-ai-backend:local
+    container_name: helpdesk_backend
+    restart: unless-stopped
+    ports:
+      - "7860:7860"
+    environment:
+      - ALLOW_DEGRADED_STARTUP=1
+      - ENV=development
+      - PYTHONPATH=/app
+      - SUPABASE_URL=${SUPABASE_URL:-}
+      - SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY:-}
+      - TICKET_ENCRYPTION_KEY=${TICKET_ENCRYPTION_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:-}
+      - REDIS_URL=redis://redis:6379/0
+      - RATE_LIMIT_AI=${RATE_LIMIT_AI:-10/minute}
+      - RATE_LIMIT_AUTH=${RATE_LIMIT_AUTH:-5/minute}
+    volumes:
+      - model_cache:/app/backend/models
+      - ticket_data:/app/backend/data
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "/app/backend/healthcheck.py"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    networks:
+      - helpdesk_net
+
+  redis:
+    image: redis:7-alpine
+    container_name: helpdesk_redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    command: redis-server --save 60 1 --loglevel warning
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - redis_data:/data
+    networks:
+      - helpdesk_net
+
+volumes:
+  model_cache:
+  ticket_data:
+  redis_data:
+
+networks:
+  helpdesk_net:
+    driver: bridge

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: helpdesk-ai-config
+  namespace: helpdesk
+data:
+  ALLOW_DEGRADED_STARTUP: "0"
+  REDIS_URL: "redis://redis-svc:6379/0"
+  ENV: "production"
+  REQUIRE_SUPABASE: "true"
+  AUTO_CLOSE_DAYS: "7"
+  RATE_LIMIT_AI: "10/minute"
+  RATE_LIMIT_TICKETS: "30/minute"
+  RATE_LIMIT_AUTH: "5/minute"

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helpdesk-ai-backend
+  namespace: helpdesk
+  labels:
+    app: helpdesk-ai-backend
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: helpdesk-ai-backend
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: helpdesk-ai-backend
+        tier: backend
+    spec:
+      # Spread replicas across nodes for HA
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: helpdesk-ai-backend
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+      containers:
+        - name: backend
+          image: ghcr.io/helpdesk-ai/backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 7860
+              name: http
+              protocol: TCP
+          env:
+            - name: ALLOW_DEGRADED_STARTUP
+              valueFrom:
+                configMapKeyRef:
+                  name: helpdesk-ai-config
+                  key: ALLOW_DEGRADED_STARTUP
+            - name: REDIS_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: helpdesk-ai-config
+                  key: REDIS_URL
+            - name: SUPABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: helpdesk-ai-secrets
+                  key: SUPABASE_URL
+            - name: SUPABASE_SERVICE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: helpdesk-ai-secrets
+                  key: SUPABASE_SERVICE_KEY
+            - name: TICKET_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: helpdesk-ai-secrets
+                  key: TICKET_ENCRYPTION_KEY
+            - name: SLACK_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: helpdesk-ai-secrets
+                  key: SLACK_WEBHOOK_URL
+                  optional: true
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 7860
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 7860
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - name: model-cache
+              mountPath: /app/backend/models
+      volumes:
+        - name: model-cache
+          emptyDir: {}
+      restartPolicy: Always

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,38 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: helpdesk-ai-backend-hpa
+  namespace: helpdesk
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: helpdesk-ai-backend
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: helpdesk-ai-ingress
+  namespace: helpdesk
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "20m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "120"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "120"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - api.helpdesk.ai
+      secretName: helpdesk-ai-tls
+  rules:
+    - host: api.helpdesk.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: helpdesk-ai-backend-svc
+                port:
+                  number: 8000

--- a/k8s/secret.yaml.template
+++ b/k8s/secret.yaml.template
@@ -1,0 +1,23 @@
+# =============================================================================
+# K8s Secret Template — DO NOT commit with real values.
+# Create the secret using:
+#   kubectl create secret generic helpdesk-ai-secrets \
+#     --from-literal=SUPABASE_URL=https://your-project.supabase.co \
+#     --from-literal=SUPABASE_SERVICE_KEY=your_service_role_key \
+#     --from-literal=TICKET_ENCRYPTION_KEY=your_32_byte_hex_key \
+#     --from-literal=SLACK_WEBHOOK_URL=https://hooks.slack.com/... \
+#     -n helpdesk
+# =============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: helpdesk-ai-secrets
+  namespace: helpdesk
+type: Opaque
+stringData:
+  SUPABASE_URL: "REPLACE_WITH_SUPABASE_URL"
+  SUPABASE_SERVICE_KEY: "REPLACE_WITH_SERVICE_ROLE_KEY"
+  TICKET_ENCRYPTION_KEY: "REPLACE_WITH_32_BYTE_HEX_KEY"
+  SLACK_WEBHOOK_URL: "REPLACE_WITH_SLACK_WEBHOOK_OR_LEAVE_EMPTY"
+  TEAMS_WEBHOOK_URL: "REPLACE_WITH_TEAMS_WEBHOOK_OR_LEAVE_EMPTY"
+  GEMINI_API_KEY: "REPLACE_WITH_GEMINI_API_KEY"

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: helpdesk-ai-backend-svc
+  namespace: helpdesk
+  labels:
+    app: helpdesk-ai-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: helpdesk-ai-backend
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 7860
+      protocol: TCP


### PR DESCRIPTION
## Summary
- Rewrites `backend/Dockerfile` as a two-stage build: **builder** (installs deps, compiles bytecode) → **production** (copies only needed files, non-root user `appuser:1001`, proper WORKDIR, health check)
- Adds `k8s/deployment.yaml` — 2 replicas, rolling update, resource limits (CPU 500m–2, RAM 1Gi–4Gi), liveness/readiness probes at `/health` and `/ready`, topology spread constraints
- Adds `k8s/service.yaml` — ClusterIP exposing port 8000→7860
- Adds `k8s/hpa.yaml` — HPA min 2/max 10, CPU 70% + Memory 80% targets with scale-down stabilization
- Adds `k8s/ingress.yaml` — TLS via cert-manager, nginx timeout/body-size annotations
- Adds `k8s/configmap.yaml` — non-secret env vars
- Adds `k8s/secret.yaml.template` — placeholder template (no real values)
- Adds `docker-compose.yml` — local dev with backend + redis services, healthchecks
- Improves `backend/healthcheck.py` — K8s-compatible, supports `--liveness`/`--readiness` flags, parses `/ready` body for detailed check

Fixes #900