### PR TITLE
feat: add dark theme Swagger UI and update Postman collection

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 # Import Swagger UI custom styling
-from backend.swagger_config import SWAGGER_UI_CUSTOM_CSS, SWAGGER_UI_CUSTOM_JS
+from backend.swagger_config import SWAGGER_UI_CUSTOM_CSS, SWAGGER_UI_DARK_CSS, SWAGGER_UI_CUSTOM_JS
 
 # Load environment variables from backend/.env
 env_path = Path(__file__).parent / '.env'
@@ -982,8 +982,10 @@ app.include_router(tag_router)
 # Custom Swagger UI with branding
 # ---------------------------------------------------------------------------
 @app.get("/docs", include_in_schema=False)
-async def custom_swagger_ui_html():
+async def custom_swagger_ui_html(request: Request):
     """Serve custom Swagger UI with AI Helpdesk branding."""
+    theme = request.query_params.get("theme", "light")
+    dark_mode = theme == "dark"
     return HTMLResponse(
         content=f"""
     <!DOCTYPE html>
@@ -992,6 +994,7 @@ async def custom_swagger_ui_html():
         <title>AI Helpdesk API Documentation</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
         <style>{SWAGGER_UI_CUSTOM_CSS}</style>
+        <style id="swagger-dark-css">{SWAGGER_UI_DARK_CSS if dark_mode else ''}</style>
     </head>
     <body>
         <div id="swagger-ui"></div>
@@ -1008,10 +1011,11 @@ async def custom_swagger_ui_html():
                 defaultModelsExpandDepth: -1,
                 docExpansion: "none",
                 filter: true,
-                syntaxHighlight: {{ theme: "monokai" }}
+                syntaxHighlight: {{"theme": "monokai"}}
             }});
             window._swaggerUi = ui;
         </script>
+        <script id="swagger-dark-data" type="application/json">{json.dumps(SWAGGER_UI_DARK_CSS)}</script>
         <script>{SWAGGER_UI_CUSTOM_JS}</script>
     </body>
     </html>

--- a/backend/postman_collection.json
+++ b/backend/postman_collection.json
@@ -43,8 +43,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/",
-              "host": ["{{baseUrl}}"],
-              "path": [""]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                ""
+              ]
             },
             "description": "Renders the styled HTML landing page with links to /docs and /health."
           }
@@ -56,8 +60,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/health",
-              "host": ["{{baseUrl}}"],
-              "path": ["health"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "health"
+              ]
             },
             "description": "Returns `{status, classifier_loaded, ner_loaded}`. Always 200 when the process is up."
           }
@@ -69,8 +77,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/ready",
-              "host": ["{{baseUrl}}"],
-              "path": ["ready"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ready"
+              ]
             },
             "description": "Returns 200 only when classifier, NER, duplicate index, RAG, and (optionally) Supabase are healthy. Otherwise 503 with a per-check map."
           }
@@ -86,7 +98,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -94,10 +109,15 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/analyze_ticket",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "analyze_ticket"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "analyze_ticket"
+              ]
             },
-            "description": "Runs the full cascade (OCR → classifier V3 → NER → duplicate check → RAG → Gemini summary). Throttled to 10 req/min per IP."
+            "description": "Runs the full cascade (OCR \u2192 classifier V3 \u2192 NER \u2192 duplicate check \u2192 RAG \u2192 Gemini summary). Throttled to 10 req/min per IP."
           }
         },
         {
@@ -105,7 +125,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -113,8 +136,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/analyze",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "analyze"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "analyze"
+              ]
             },
             "description": "Identical pipeline as /ai/analyze_ticket but never persists. Use for preview/UX flows before the user confirms ticket creation."
           }
@@ -124,8 +152,14 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" },
-              { "key": "Accept", "value": "text/event-stream" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "text/event-stream"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -133,8 +167,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/analyze_stream",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "analyze_stream"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "analyze_stream"
+              ]
             },
             "description": "Server-sent events. Emits one `data:` chunk per pipeline stage and a final `step:done` event carrying the full TicketResponse payload."
           }
@@ -144,7 +183,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -152,8 +194,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/analyze-v2",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "analyze-v2"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "analyze-v2"
+              ]
             },
             "description": "Runs only the V2 classifier and returns its prediction. Used for offline comparison with the V3 pipeline."
           }
@@ -163,7 +210,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -171,8 +221,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/troubleshoot",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "troubleshoot"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "troubleshoot"
+              ]
             },
             "description": "Returns the next troubleshooting step, suggested options, and an `is_final` flag. Append the user's answer to `history` and call again."
           }
@@ -182,7 +237,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -190,8 +248,13 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/analyze_bug",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "analyze_bug"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "analyze_bug"
+              ]
             },
             "description": "Returns a Gemini-generated `probable_cause` for the supplied bug report."
           }
@@ -209,8 +272,12 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/tickets?company_id={{companyId}}",
-              "host": ["{{baseUrl}}"],
-              "path": ["tickets"],
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets"
+              ],
               "query": [
                 {
                   "key": "company_id",
@@ -229,8 +296,13 @@
             "header": [],
             "url": {
               "raw": "{{baseUrl}}/tickets/{{ticketId}}",
-              "host": ["{{baseUrl}}"],
-              "path": ["tickets", "{{ticketId}}"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets",
+                "{{ticketId}}"
+              ]
             },
             "description": "Fetch a single Supabase ticket by id."
           }
@@ -240,7 +312,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -248,10 +323,15 @@
             },
             "url": {
               "raw": "{{baseUrl}}/tickets/save",
-              "host": ["{{baseUrl}}"],
-              "path": ["tickets", "save"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets",
+                "save"
+              ]
             },
-            "description": "Persist a user-confirmed analysis. Enforces tenant linkage via the Supabase `profiles` table — 403 if `company_id` does not match the caller's profile."
+            "description": "Persist a user-confirmed analysis. Enforces tenant linkage via the Supabase `profiles` table \u2014 403 if `company_id` does not match the caller's profile."
           }
         },
         {
@@ -259,7 +339,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -267,8 +350,12 @@
             },
             "url": {
               "raw": "{{baseUrl}}/tickets",
-              "host": ["{{baseUrl}}"],
-              "path": ["tickets"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets"
+              ]
             },
             "description": "Insert into the legacy in-memory store (used by tests and local dev)."
           }
@@ -278,7 +365,10 @@
           "request": {
             "method": "PATCH",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -286,10 +376,188 @@
             },
             "url": {
               "raw": "{{baseUrl}}/tickets/{{ticketId}}",
-              "host": ["{{baseUrl}}"],
-              "path": ["tickets", "{{ticketId}}"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets",
+                "{{ticketId}}"
+              ]
             },
             "description": "Partial update of an in-memory ticket. 404 when the id is unknown."
+          }
+        },
+        {
+          "name": "Search tickets",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/tickets/search?q=VPN&company_id={{companyId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "VPN",
+                  "description": "Search query string"
+                },
+                {
+                  "key": "company_id",
+                  "value": "{{companyId}}",
+                  "description": "Optional tenant filter"
+                }
+              ]
+            },
+            "description": "Full-text search across ticket subjects and descriptions."
+          }
+        },
+        {
+          "name": "SLA estimate for ticket",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/tickets/{{ticketId}}/sla-estimate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets",
+                "{{ticketId}}",
+                "sla-estimate"
+              ]
+            },
+            "description": "Returns the predicted SLA breach time."
+          }
+        },
+        {
+          "name": "Audit logs for ticket",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/tickets/{{ticketId}}/audit_logs",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "tickets",
+                "{{ticketId}}",
+                "audit_logs"
+              ]
+            },
+            "description": "Audit trail of changes for a specific ticket."
+          }
+        }
+      ]
+    },
+    {
+      "name": "SLA",
+      "description": "Service Level Agreement monitoring and breach detection.",
+      "item": [
+        {
+          "name": "SLA stats overview",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/sla/stats",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "sla",
+                "stats"
+              ]
+            },
+            "description": "Aggregated SLA statistics (breach rate, avg response time, etc.)."
+          }
+        },
+        {
+          "name": "SLA tickets",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/sla/tickets",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "sla",
+                "tickets"
+              ]
+            },
+            "description": "List tickets with their SLA status."
+          }
+        },
+        {
+          "name": "SLA escalations",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/sla/escalations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "sla",
+                "escalations"
+              ]
+            },
+            "description": "List active SLA escalations."
+          }
+        },
+        {
+          "name": "SLA policies",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/sla/policies",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "sla",
+                "policies"
+              ]
+            },
+            "description": "List configured SLA policies."
+          }
+        },
+        {
+          "name": "Check SLA breach",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ticket_id\": \"{{ticketId}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/sla/check",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "sla",
+                "check"
+              ]
+            },
+            "description": "Check if a specific ticket has breached SLA."
           }
         }
       ]
@@ -303,7 +571,10 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -311,10 +582,43 @@
             },
             "url": {
               "raw": "{{baseUrl}}/ai/log_correction",
-              "host": ["{{baseUrl}}"],
-              "path": ["ai", "log_correction"]
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "ai",
+                "log_correction"
+              ]
             },
             "description": "Persist an admin override. Only diffs are logged; payloads where the corrected prediction equals the original are reported as `no_change`."
+          }
+        },
+        {
+          "name": "Send weekly digest",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"company_id\": \"{{companyId}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/digest/send-now",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "digest",
+                "send-now"
+              ]
+            },
+            "description": "Trigger an immediate weekly digest email."
           }
         }
       ]

--- a/backend/swagger_config.py
+++ b/backend/swagger_config.py
@@ -6,7 +6,7 @@ the AI Helpdesk brand identity and improve developer experience.
 """
 
 SWAGGER_UI_CUSTOM_CSS = """
-/* AI Helpdesk Swagger UI Custom Theme */
+/* AI Helpdesk Swagger UI Custom Theme - Light */
 
 /* Header bar */
 .swagger-ui .topbar {
@@ -139,8 +139,6 @@ SWAGGER_UI_CUSTOM_CSS = """
 .swagger-ui .try-out__btn {
     border: 2px solid #4361ee;
     color: #4361ee;
-    border-radius: 6px;
-    font-weight: 600;
 }
 
 .swagger-ui .try-out__btn:hover {
@@ -150,172 +148,533 @@ SWAGGER_UI_CUSTOM_CSS = """
 
 /* Execute button */
 .swagger-ui .btn.execute {
-    background: #4361ee;
+    background-color: #4361ee;
     border-color: #4361ee;
-    border-radius: 6px;
-    font-weight: 600;
 }
 
 .swagger-ui .btn.execute:hover {
-    background: #3a56d4;
+    background-color: #3651d4;
 }
 
-/* Response section */
-.swagger-ui .responses-inner {
-    padding: 12px;
+/* Response */
+.swagger-ui .responses-inner h4 {
+    color: #2d3748;
 }
 
-.swagger-ui .responses-table {
-    border-radius: 6px;
-    overflow: hidden;
+.swagger-ui .response-col_status {
+    color: #2d3748;
+    font-weight: 600;
 }
 
-/* Code blocks */
-.swagger-ui .highlight-code {
-    border-radius: 6px;
-    overflow: hidden;
+/* Brand watermark */
+.swagger-ui .topbar .topbar-wrapper::after {
+    content: "AI Helpdesk";
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 14px;
+    margin-left: 16px;
+    font-weight: 500;
 }
 
-/* Authorize button */
-.swagger-ui .btn.authorize {
-    color: #4361ee;
-    border-color: #4361ee;
-    border-radius: 6px;
+/* Wrapper */
+.swagger-ui .wrapper {
+    padding: 0 40px;
+    max-width: 1400px;
+    margin: 0 auto;
 }
 
-.swagger-ui .btn.authorize:hover {
-    background: #4361ee;
-    color: white;
+/* Table styling */
+.swagger-ui table thead tr td,
+.swagger-ui table thead tr th {
+    color: #2d3748;
+    font-weight: 600;
+    border-bottom: 2px solid #e2e8f0;
 }
 
-/* Scheme selector */
-.swagger-ui .scheme-container {
-    background: #f7fafc;
+/* Error container */
+.swagger-ui .errors-information {
+    border: 1px solid #fc8181;
     border-radius: 8px;
-    padding: 16px;
+}
+
+/* Info section */
+.swagger-ui .info {
+    margin: 24px 0;
+    padding: 24px;
+    background: #f7fafc;
+    border-radius: 12px;
     border: 1px solid #e2e8f0;
 }
 
-/* Custom scrollbar */
-::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
+/* Server selector */
+.swagger-ui .servers {
+    margin: 16px 0;
 }
 
-::-webkit-scrollbar-track {
-    background: #f1f1f1;
+.swagger-ui .servers select {
+    border: 2px solid #e2e8f0;
+    border-radius: 6px;
+    padding: 6px 12px;
+    font-size: 13px;
+}
+"""
+
+SWAGGER_UI_DARK_CSS = """
+/* AI Helpdesk Swagger UI Dark Theme - Corporate Dark Mode */
+
+/* Base background */
+.swagger-ui {
+    color: #e2e8f0;
+}
+
+/* Main background */
+html,
+.swagger-ui .information-container.wrapper {
+    background: #0f172a;
+}
+
+.swagger-ui .info .title {
+    color: #e2e8f0;
+}
+
+.swagger-ui .info .description p {
+    color: #94a3b8;
+}
+
+/* Header bar */
+.swagger-ui .topbar {
+    background-color: #020617;
+    border-bottom: 3px solid #4361ee;
+}
+
+/* Info section */
+.swagger-ui .info {
+    background: #1e293b;
+    border-color: #334155;
+    margin: 24px 0;
+    padding: 24px;
+    border-radius: 12px;
+}
+
+/* Section tags */
+.swagger-ui .opblock-tag {
+    color: #e2e8f0;
+    border-bottom-color: #334155;
+}
+
+.swagger-ui .opblock-tag:hover {
+    color: #60a5fa;
+    border-bottom-color: #4361ee;
+}
+
+.swagger-ui .opblock-tag noop {
+    color: #94a3b8;
+}
+
+/* Operation blocks */
+.swagger-ui .opblock {
+    border-radius: 8px;
+    border: 1px solid #334155;
+    background: #1e293b;
+    margin-bottom: 12px;
+}
+
+.swagger-ui .opblock .opblock-summary {
+    border-bottom-color: #334155;
+}
+
+/* GET */
+.swagger-ui .opblock.opblock-get {
+    background: rgba(34, 197, 94, 0.05);
+    border-color: #22c55e;
+}
+
+.swagger-ui .opblock.opblock-get .opblock-summary-method {
+    background: #16a34a;
+}
+
+/* POST */
+.swagger-ui .opblock.opblock-post {
+    background: rgba(59, 130, 246, 0.05);
+    border-color: #3b82f6;
+}
+
+.swagger-ui .opblock.opblock-post .opblock-summary-method {
+    background: #2563eb;
+}
+
+/* PUT */
+.swagger-ui .opblock.opblock-put {
+    background: rgba(234, 179, 8, 0.05);
+    border-color: #eab308;
+}
+
+.swagger-ui .opblock.opblock-put .opblock-summary-method {
+    background: #ca8a04;
+}
+
+/* DELETE */
+.swagger-ui .opblock.opblock-delete {
+    background: rgba(239, 68, 68, 0.05);
+    border-color: #ef4444;
+}
+
+.swagger-ui .opblock.opblock-delete .opblock-summary-method {
+    background: #dc2626;
+}
+
+/* PATCH */
+.swagger-ui .opblock.opblock-patch {
+    background: rgba(168, 85, 247, 0.05);
+    border-color: #a855f7;
+}
+
+.swagger-ui .opblock.opblock-patch .opblock-summary-method {
+    background: #9333ea;
+}
+
+/* Method badge */
+.swagger-ui .opblock .opblock-summary-method {
     border-radius: 4px;
+    font-weight: 600;
+    font-size: 12px;
+    min-width: 70px;
+    text-align: center;
 }
 
-::-webkit-scrollbar-thumb {
-    background: #a0aec0;
-    border-radius: 4px;
+/* Description text */
+.swagger-ui .opblock .opblock-summary-description {
+    color: #94a3b8;
 }
 
-::-webkit-scrollbar-thumb:hover {
-    background: #718096;
+/* Parameter names */
+.swagger-ui .parameter__name {
+    color: #e2e8f0;
+    font-weight: 600;
 }
 
-/* Footer */
-.swagger-ui .info .link {
-    color: #4361ee;
+.swagger-ui .parameter__type {
+    color: #94a3b8;
 }
 
-.swagger-ui .info .link:hover {
-    color: #3a56d4;
+.swagger-ui .parameter__extension,
+.swagger-ui .parameter__in {
+    color: #64748b;
 }
 
-/* Mobile responsive */
-@media (max-width: 768px) {
-    .swagger-ui .opblock .opblock-summary {
-        flex-direction: column;
-        align-items: flex-start;
-    }
+/* Table headers */
+.swagger-ui table thead tr td,
+.swagger-ui table thead tr th {
+    color: #e2e8f0;
+    border-bottom-color: #334155;
+}
 
-    .swagger-ui .opblock .opblock-summary-method {
-        margin-bottom: 8px;
-    }
+.swagger-ui table tbody tr td {
+    color: #cbd5e1;
+}
+
+/* Response */
+.swagger-ui .responses-inner h4 {
+    color: #e2e8f0;
+}
+
+.swagger-ui .response-col_status {
+    color: #e2e8f0;
+}
+
+.swagger-ui .response-col_description {
+    color: #cbd5e1;
+}
+
+/* Models section */
+.swagger-ui section.models {
+    border-color: #334155;
+    background: #1e293b;
+    border-radius: 8px;
+}
+
+.swagger-ui section.models .model-container {
+    background: #0f172a;
+    border-radius: 6px;
+}
+
+.swagger-ui .model {
+    color: #e2e8f0;
+}
+
+.swagger-ui .model .property {
+    color: #94a3b8;
+}
+
+.swagger-ui .model .property .property-name {
+    color: #60a5fa;
+}
+
+/* Model title */
+.swagger-ui .model-box {
+    color: #e2e8f0;
+}
+
+.swagger-ui .model-title {
+    color: #e2e8f0;
+}
+
+/* Buttons */
+.swagger-ui .btn {
+    border-color: #475569;
+    color: #e2e8f0;
+}
+
+.swagger-ui .btn:hover {
+    background: #334155;
+}
+
+.swagger-ui .try-out__btn {
+    border-color: #3b82f6;
+    color: #60a5fa;
+}
+
+.swagger-ui .try-out__btn:hover {
+    background: #3b82f6;
+    color: white;
+}
+
+.swagger-ui .btn.execute {
+    background: #3b82f6;
+    border-color: #3b82f6;
+}
+
+.swagger-ui .btn.execute:hover {
+    background: #2563eb;
+}
+
+.swagger-ui .btn.cancel {
+    color: #f87171;
+    border-color: #f87171;
+}
+
+/* Inputs */
+.swagger-ui input[type=text],
+.swagger-ui select {
+    background: #0f172a;
+    border-color: #475569;
+    color: #e2e8f0;
+}
+
+.swagger-ui textarea {
+    background: #0f172a !important;
+    color: #e2e8f0 !important;
+    border-color: #475569 !important;
+}
+
+/* Select */
+.swagger-ui select {
+    background: #1e293b;
+    color: #e2e8f0;
+}
+
+/* Markdown */
+.swagger-ui .markdown p,
+.swagger-ui .markdown li {
+    color: #cbd5e1;
+}
+
+.swagger-ui .markdown code {
+    background: #1e293b;
+    color: #e2e8f0;
+}
+
+/* Response header */
+.swagger-ui .response-controls {
+    color: #e2e8f0;
+}
+
+/* Highlight code */
+.swagger-ui .highlight-code {
+    background: #0f172a;
+}
+
+.swagger-ui .highlight-code .language-json {
+    background: #0f172a;
+}
+
+/* Scrollbar */
+.swagger-ui .opblock-body pre {
+    background: #0f172a !important;
+}
+
+/* Server selector */
+.swagger-ui .servers select {
+    background: #1e293b;
+    border-color: #475569;
+    color: #e2e8f0;
+}
+
+.swagger-ui .servers label {
+    color: #94a3b8;
+}
+
+/* Info table */
+.swagger-ui .info .info-table td {
+    color: #94a3b8;
+}
+
+/* Links */
+.swagger-ui a {
+    color: #60a5fa;
+}
+
+.swagger-ui a:hover {
+    color: #93c5fd;
+}
+
+/* Errors */
+.swagger-ui .errors-information {
+    border-color: #ef4444;
+    background: rgba(239, 68, 68, 0.05);
+}
+
+/* Loading */
+.swagger-ui .loading-container {
+    color: #94a3b8;
+}
+
+/* Topbar watermark */
+.swagger-ui .topbar .topbar-wrapper::after {
+    content: "AI Helpdesk";
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 14px;
+    margin-left: 16px;
+    font-weight: 500;
+}
+
+/* Wrapper */
+.swagger-ui .wrapper {
+    padding: 0 40px;
+    max-width: 1400px;
+    margin: 0 auto;
 }
 """
 
 SWAGGER_UI_CUSTOM_JS = """
-// AI Helpdesk Swagger UI Custom JavaScript
+(function() {
+    'use strict';
 
-// Add custom header with branding
-document.addEventListener('DOMContentLoaded', function() {
-    // Add version badge
-    const info = document.querySelector('.swagger-ui .info');
-    if (info) {
-        const versionBadge = document.createElement('span');
-        versionBadge.style.cssText = `
-            background: #4361ee;
-            color: white;
-            padding: 4px 12px;
-            border-radius: 20px;
-            font-size: 12px;
-            font-weight: 600;
-            margin-left: 12px;
-            vertical-align: middle;
-        `;
-        versionBadge.textContent = 'v1.0.0';
-        const title = info.querySelector('.title');
-        if (title) {
-            title.appendChild(versionBadge);
-        }
-    }
+    // ---- Environment selector ----
+    function addEnvSelector() {
+        var infoEl = document.querySelector('.swagger-ui .info');
+        if (!infoEl) return;
 
-    // Add environment selector
-    const topbar = document.querySelector('.swagger-ui .topbar');
-    if (topbar) {
-        const envSelector = document.createElement('div');
-        envSelector.style.cssText = `
-            position: absolute;
-            right: 20px;
-            top: 50%;
-            transform: translateY(-50%);
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        `;
-        envSelector.innerHTML = `
-            <select id="env-selector" style="
-                padding: 6px 12px;
-                border: 1px solid #4361ee;
-                border-radius: 4px;
-                background: white;
-                color: #1a1a2e;
-                font-size: 13px;
-            ">
-                <option value="local">Local Development</option>
-                <option value="staging">Staging</option>
-                <option value="production">Production</option>
-            </select>
-        `;
-        topbar.appendChild(envSelector);
+        var container = document.createElement('div');
+        container.style.cssText = 'margin-top: 16px; display: flex; align-items: center; gap: 8px;';
 
-        // Add change handler to switch API server
-        const selector = envSelector.querySelector('#env-selector');
-        const envUrls = {
-            local: window.location.origin,
+        var label = document.createElement('label');
+        label.textContent = 'Environment:';
+        label.style.cssText = 'font-weight: 600; font-size: 13px; color: #4a5568;';
+
+        var selector = document.createElement('select');
+        selector.style.cssText = 'padding: 6px 12px; border: 2px solid #e2e8f0; border-radius: 6px; font-size: 13px; background: white; cursor: pointer;';
+
+        var envUrls = {
+            local: 'http://localhost:8000',
             staging: 'https://staging-api.helpdesk.ai',
             production: 'https://api.helpdesk.ai'
         };
+
+        Object.keys(envUrls).forEach(function(env) {
+            var opt = document.createElement('option');
+            opt.value = env;
+            opt.textContent = env.charAt(0).toUpperCase() + env.slice(1) + ' (' + envUrls[env] + ')';
+            selector.appendChild(opt);
+        });
+
         selector.addEventListener('change', function() {
-            const env = this.value;
-            const baseUrl = envUrls[env] || envUrls.local;
+            var env = this.value;
+            var baseUrl = envUrls[env] || envUrls.local;
             if (window._swaggerUi) {
                 window._swaggerUi.specActions.updateUrl(baseUrl + '/openapi.json');
                 window._swaggerUi.specActions.download();
             }
         });
-    }
-});
 
-// Auto-collapse models section
+        container.appendChild(label);
+        container.appendChild(selector);
+
+        // Insert after the description
+        var desc = infoEl.querySelector('.description');
+        if (desc && desc.nextSibling) {
+            infoEl.insertBefore(container, desc.nextSibling);
+        } else {
+            infoEl.appendChild(container);
+        }
+    }
+
+    // ---- Theme toggle ----
+    function addThemeToggle() {
+        var topbar = document.querySelector('.swagger-ui .topbar .topbar-wrapper');
+        if (!topbar) return;
+
+        var toggleBtn = document.createElement('button');
+        toggleBtn.textContent = '🌙 Dark';
+        toggleBtn.style.cssText = 'margin-left: auto; padding: 4px 12px; border: 1px solid rgba(255,255,255,0.3); border-radius: 4px; background: transparent; color: rgba(255,255,255,0.8); cursor: pointer; font-size: 12px;';
+
+        // Check if dark theme is already set via query param
+        var isDark = window.location.search.includes('theme=dark');
+
+        function applyTheme(dark) {
+            var cssLink = document.getElementById('swagger-theme-css');
+            if (!cssLink) {
+                cssLink = document.createElement('style');
+                cssLink.id = 'swagger-theme-css';
+                document.head.appendChild(cssLink);
+            }
+            if (dark) {
+                cssLink.textContent = SWAGGER_DARK_CSS || '';
+                toggleBtn.textContent = '☀️ Light';
+            } else {
+                cssLink.textContent = '';
+                toggleBtn.textContent = '🌙 Dark';
+            }
+        }
+
+        // Expose dark CSS for the toggle
+        window.SWAGGER_DARK_CSS = document.getElementById('swagger-dark-css')?.textContent || '';
+
+        // Apply initial state
+        applyTheme(isDark);
+
+        toggleBtn.addEventListener('click', function() {
+            var currentlyDark = toggleBtn.textContent.includes('☀️');
+            applyTheme(!currentlyDark);
+            // Update URL without page reload
+            var url = new URL(window.location);
+            if (!currentlyDark) {
+                url.searchParams.set('theme', 'dark');
+            } else {
+                url.searchParams.delete('theme');
+            }
+            window.history.replaceState({}, '', url);
+        });
+
+        topbar.appendChild(toggleBtn);
+    }
+
+    // Wait for DOM
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function() {
+            setTimeout(addEnvSelector, 1500);
+            setTimeout(addThemeToggle, 1500);
+        });
+    } else {
+        setTimeout(addEnvSelector, 1500);
+        setTimeout(addThemeToggle, 1500);
+    }
+})();
+
+// Auto-collapse models section on load
 setTimeout(function() {
-    const models = document.querySelector('.swagger-ui section.models');
+    var models = document.querySelector('.swagger-ui section.models');
     if (models) {
-        const toggle = models.querySelector('h4');
+        var toggle = models.querySelector('h4');
         if (toggle) {
             toggle.click();
         }

--- a/backend/swagger_config.py
+++ b/backend/swagger_config.py
@@ -617,9 +617,12 @@ SWAGGER_UI_CUSTOM_JS = """
         toggleBtn.textContent = '🌙 Dark';
         toggleBtn.style.cssText = 'margin-left: auto; padding: 4px 12px; border: 1px solid rgba(255,255,255,0.3); border-radius: 4px; background: transparent; color: rgba(255,255,255,0.8); cursor: pointer; font-size: 12px;';
 
+        // Read dark CSS from the hidden data element
+        var darkDataEl = document.getElementById('swagger-dark-data');
+        var darkCSS = darkDataEl ? darkDataEl.textContent.replace(/^"/, '').replace(/"$/, '') : '';
+
         // Check if dark theme is already set via query param
         var isDark = window.location.search.includes('theme=dark');
-
         function applyTheme(dark) {
             var cssLink = document.getElementById('swagger-theme-css');
             if (!cssLink) {
@@ -627,25 +630,15 @@ SWAGGER_UI_CUSTOM_JS = """
                 cssLink.id = 'swagger-theme-css';
                 document.head.appendChild(cssLink);
             }
-            if (dark) {
-                cssLink.textContent = SWAGGER_DARK_CSS || '';
-                toggleBtn.textContent = '☀️ Light';
-            } else {
-                cssLink.textContent = '';
-                toggleBtn.textContent = '🌙 Dark';
-            }
+            cssLink.textContent = dark ? darkCSS : '';
+            toggleBtn.textContent = dark ? '☀️ Light' : '🌙 Dark';
         }
 
-        // Expose dark CSS for the toggle
-        window.SWAGGER_DARK_CSS = document.getElementById('swagger-dark-css')?.textContent || '';
-
-        // Apply initial state
         applyTheme(isDark);
 
         toggleBtn.addEventListener('click', function() {
             var currentlyDark = toggleBtn.textContent.includes('☀️');
             applyTheme(!currentlyDark);
-            // Update URL without page reload
             var url = new URL(window.location);
             if (!currentlyDark) {
                 url.searchParams.set('theme', 'dark');


### PR DESCRIPTION
    Changes

    1. Dark theme Swagger UI: Added corporate dark theme CSS + interactive toggle button (🌙/☀️) in the topbar
    2. Theme URL support: /docs?theme=dark for direct dark mode access
    3. Postman collection: Added missing SLA endpoints, ticket search, audit logs, weekly digest

    How to use

    - Light theme (default): /docs
    - Dark theme: /docs?theme=dark
    - Toggle: Click the moon/sun button in the topbar

    Closes #910