### PR TITLE
Add dark/light mode toggle across frontend

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -12,6 +12,7 @@ import useTicketStore from "./store/ticketStore";
 import Toaster from "./components/shared/Toaster";
 import BugReportWidget from "./components/shared/BugReportWidget";
 import useRealtimeNotifications from "./hooks/useRealtimeNotifications";
+import { ThemeProvider } from "./components/shared/ThemeProvider";
 
 // Auth Components
 import Login from "./pages/Login";
@@ -227,30 +228,33 @@ function App() {
 
   if (isDocsSubdomain) {
     return (
+      <ThemeProvider>
+        <BrowserRouter>
+          <TitleUpdater />
+          <ScrollToTop />
+          <Toaster />
+          <BugReportWidget />
+          <Routes>
+            <Route path="/" element={<DocsPortal />} />
+            <Route path="/docs" element={<Navigate to="/" replace />} />
+            <Route path="/api-reference" element={<ApiReference />} />
+            <Route path="/changelog" element={<Changelog />} />
+            <Route path="/status" element={<StatusPage />} />
+            <Route path="*" element={<DocsPortal />} />
+          </Routes>
+        </BrowserRouter>
+      </ThemeProvider>
+    );
+  }
+
+  return (
+    <ThemeProvider>
       <BrowserRouter>
         <TitleUpdater />
         <ScrollToTop />
         <Toaster />
         <BugReportWidget />
         <Routes>
-          <Route path="/" element={<DocsPortal />} />
-          <Route path="/docs" element={<Navigate to="/" replace />} />
-          <Route path="/api-reference" element={<ApiReference />} />
-          <Route path="/changelog" element={<Changelog />} />
-          <Route path="/status" element={<StatusPage />} />
-          <Route path="*" element={<DocsPortal />} />
-        </Routes>
-      </BrowserRouter>
-    );
-  }
-
-  return (
-    <BrowserRouter>
-      <TitleUpdater />
-      <ScrollToTop />
-      <Toaster />
-      <BugReportWidget />
-      <Routes>
         {/* Public */}
         <Route path="/" element={<LandingPage />} />
         <Route path="/login" element={<Login />} />
@@ -297,8 +301,9 @@ function App() {
         <Route element={<ProtectedRoute />}>
           <Route path="/*" element={<AppLayout />} />
         </Route>
-      </Routes>
-    </BrowserRouter>
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }
 

--- a/Frontend/src/admin/components/AdminHeader.jsx
+++ b/Frontend/src/admin/components/AdminHeader.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import NotificationPopover from '../../user/components/NotificationPopover';
 import useAuthStore from '../../store/authStore';
 import { Avatar, AvatarFallback, AvatarImage } from "../../components/ui/avatar";
+import ThemeToggle from '../../components/shared/ThemeToggle';
 
 /**
  * AdminHeader Component
@@ -52,12 +53,12 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
     };
 
     return (
-        <header className="h-16 bg-white border-b border-slate-200 sticky top-0 z-30 px-6 md:px-10 flex items-center justify-between">
+        <header className="h-16 bg-white border-b border-slate-200 sticky top-0 z-30 px-6 md:px-10 flex items-center justify-between transition-colors duration-200 dark:bg-[#061a13] dark:border-emerald-900/40">
             <div className="flex items-center gap-4 flex-1">
                 {/* Mobile Menu Toggle */}
                 <button
                     onClick={onMobileNavToggle}
-                    className="lg:hidden p-2 hover:bg-slate-50 rounded-xl text-slate-500 transition-colors"
+                    className="lg:hidden p-2 hover:bg-slate-50 rounded-xl text-slate-500 transition-colors dark:text-slate-300 dark:hover:bg-white/10"
                 >
                     <Menu size={20} />
                 </button>
@@ -66,7 +67,7 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                 {onToggleSidebar && (
                     <button
                         onClick={onToggleSidebar}
-                        className="hidden md:flex p-2 hover:bg-emerald-50 rounded-xl text-slate-400 hover:text-emerald-600 transition-all"
+                        className="hidden md:flex p-2 hover:bg-emerald-50 rounded-xl text-slate-400 hover:text-emerald-600 transition-all dark:hover:bg-emerald-500/10 dark:hover:text-emerald-300"
                         title={isSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
                     >
                         {isSidebarCollapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
@@ -83,7 +84,7 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                         onChange={(e) => setSearchQuery(e.target.value)}
                         onKeyDown={handleSearchKeyDown}
                         placeholder="Search tickets, users… (press Enter)"
-                        className="w-full bg-slate-50/50 border border-slate-200 rounded-xl pl-11 pr-9 py-2 text-sm font-medium tracking-tight focus:outline-none focus:ring-4 focus:ring-emerald-600/5 focus:border-emerald-600 focus:bg-white transition-all text-slate-600 placeholder:text-slate-400"
+                        className="w-full bg-slate-50/50 border border-slate-200 rounded-xl pl-11 pr-9 py-2 text-sm font-medium tracking-tight focus:outline-none focus:ring-4 focus:ring-emerald-600/5 focus:border-emerald-600 focus:bg-white transition-all text-slate-600 placeholder:text-slate-400 dark:bg-[#0f1f18] dark:border-emerald-900/40 dark:text-slate-100 dark:focus:bg-[#102219]"
                     />
                     {searchQuery && (
                         <button
@@ -99,8 +100,9 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
 
             {/* Header Operations */}
             <div className="flex items-center gap-4 lg:gap-6">
+                <ThemeToggle />
                 {/* Communications Hub */}
-                <div className="relative border-r border-slate-200 pr-4 lg:pr-6 hidden sm:block">
+                <div className="relative border-r border-slate-200 pr-4 lg:pr-6 hidden sm:block dark:border-emerald-900/40">
                     <NotificationPopover isAdmin={true} />
                 </div>
 
@@ -108,7 +110,7 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                 <div className="relative" ref={dropdownRef}>
                     <button
                         onClick={() => setIsProfileOpen(!isProfileOpen)}
-                        className="flex items-center gap-3 hover:bg-slate-50 p-1 rounded-2xl border border-transparent hover:border-slate-100 transition-all group"
+                        className="flex items-center gap-3 hover:bg-slate-50 p-1 rounded-2xl border border-transparent hover:border-slate-100 transition-all group dark:hover:bg-white/10 dark:hover:border-emerald-900/40"
                     >
                         <Avatar className="w-8 h-8 rounded-lg shadow-md group-hover:scale-105 transition-transform">
                             <AvatarImage src={adminProfile?.profile_picture} className="object-cover" />
@@ -118,7 +120,7 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                         </Avatar>
                         <div className="hidden lg:block text-left">
                             <div className="flex items-center gap-1">
-                                <p className="text-xs font-black text-slate-900 tracking-tight leading-none italic uppercase">Admin</p>
+                                <p className="text-xs font-black text-slate-900 tracking-tight leading-none italic uppercase dark:text-white">Admin</p>
                                 <ChevronDown size={12} className={`text-slate-400 transition-transform duration-300 ${isProfileOpen ? 'rotate-180' : ''}`} />
                             </div>
                         </div>
@@ -126,20 +128,20 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
 
                     {/* Dropdown Menu */}
                     {isProfileOpen && (
-                        <div className="absolute right-0 mt-2 w-48 bg-white border border-slate-200 rounded-2xl shadow-xl shadow-slate-200/50 py-2 animate-in fade-in zoom-in-95 duration-200">
+                        <div className="absolute right-0 mt-2 w-48 bg-white border border-slate-200 rounded-2xl shadow-xl shadow-slate-200/50 py-2 animate-in fade-in zoom-in-95 duration-200 dark:bg-[#0f1f18] dark:border-emerald-900/40 dark:shadow-black/30">
                             <button
                                 onClick={() => { navigate('/admin/profile'); setIsProfileOpen(false); }}
-                                className="w-full flex items-center gap-3 px-4 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 hover:text-emerald-600 transition-colors"
+                                className="w-full flex items-center gap-3 px-4 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 hover:text-emerald-600 transition-colors dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-emerald-300"
                             >
                                 <UserCircle size={16} /> Profile
                             </button>
                             <button
                                 onClick={() => { navigate('/admin/settings'); setIsProfileOpen(false); }}
-                                className="w-full flex items-center gap-3 px-4 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 hover:text-emerald-600 transition-colors"
+                                className="w-full flex items-center gap-3 px-4 py-2 text-xs font-bold text-slate-600 hover:bg-slate-50 hover:text-emerald-600 transition-colors dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-emerald-300"
                             >
                                 <Settings size={16} /> Settings
                             </button>
-                            <div className="my-1 border-t border-slate-100"></div>
+                            <div className="my-1 border-t border-slate-100 dark:border-emerald-900/40"></div>
                             <button
                                 onClick={handleLogout}
                                 className="w-full flex items-center gap-3 px-4 py-2 text-xs font-bold text-red-500 hover:bg-red-50 transition-colors"

--- a/Frontend/src/admin/components/AdminSidebar.jsx
+++ b/Frontend/src/admin/components/AdminSidebar.jsx
@@ -13,6 +13,7 @@ import {
     ChevronRight
 } from 'lucide-react';
 import useAuthStore from '../../store/authStore';
+import { useTheme } from '../../components/shared/ThemeProvider';
 
 const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
     const navItems = [
@@ -24,6 +25,7 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
     ];
 
     const { logout } = useAuthStore();
+    const { isDark } = useTheme();
     const navigate = useNavigate();
 
     const handleLogout = async () => {
@@ -38,9 +40,9 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
             className={`${isMobile ? 'w-full h-full' : 'fixed left-0 top-0 h-full'} z-40 transition-all duration-300 overflow-hidden flex flex-col`}
             style={{
                 width: isMobile ? '100%' : (isCollapsed ? '80px' : '260px'),
-                background: '#ffffff',
-                borderRight: '1px solid #f0fdf4',
-                boxShadow: '2px 0 12px rgba(0,0,0,0.04)'
+                background: isDark ? '#0f1f18' : '#ffffff',
+                borderRight: isDark ? '1px solid rgba(148, 163, 184, 0.16)' : '1px solid #f0fdf4',
+                boxShadow: isDark ? '2px 0 18px rgba(0,0,0,0.28)' : '2px 0 12px rgba(0,0,0,0.04)'
             }}
         >
             {/* Logo Section */}
@@ -66,9 +68,10 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
                     <button
                         onClick={onToggleCollapse}
                         style={{
-                            background: '#f0fdf4', border: '1px solid #d1fae5',
+                            background: isDark ? 'rgba(16, 185, 129, 0.12)' : '#f0fdf4',
+                            border: isDark ? '1px solid rgba(52, 211, 153, 0.28)' : '1px solid #d1fae5',
                             borderRadius: '8px', padding: '4px', cursor: 'pointer',
-                            color: '#15803d', display: 'flex', alignItems: 'center',
+                            color: isDark ? '#86efac' : '#15803d', display: 'flex', alignItems: 'center',
                             justifyContent: 'center', transition: 'all 0.2s ease',
                             position: isCollapsed ? 'absolute' : 'relative',
                             right: isCollapsed ? '-12px' : 'auto',
@@ -85,7 +88,7 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
             {/* Navigation Links */}
             <nav className="flex-1 px-3 py-8 space-y-1.5 overflow-y-auto custom-scrollbar">
                 {showLabels && (
-                    <p style={{ fontSize: '10px', letterSpacing: '0.14em', color: '#9ca3af', fontWeight: 600, paddingLeft: '14px', marginBottom: '16px' }} className="uppercase">
+                    <p style={{ fontSize: '10px', letterSpacing: '0.14em', color: isDark ? '#789286' : '#9ca3af', fontWeight: 600, paddingLeft: '14px', marginBottom: '16px' }} className="uppercase">
                         CORE MODULES
                     </p>
                 )}
@@ -97,8 +100,8 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
                         style={({ isActive }) => ({
                             display: 'flex', alignItems: 'center', gap: '12px',
                             borderRadius: '10px', padding: isCollapsed && !isMobile ? '10px' : '9px 14px',
-                            color: isActive ? '#15803d' : '#6b7280',
-                            background: isActive ? '#f0fdf4' : 'transparent',
+                            color: isActive ? (isDark ? '#86efac' : '#15803d') : (isDark ? '#a7b7c2' : '#6b7280'),
+                            background: isActive ? (isDark ? 'rgba(16, 185, 129, 0.12)' : '#f0fdf4') : 'transparent',
                             fontWeight: isActive ? 600 : 500,
                             textDecoration: 'none', transition: 'all 0.2s ease',
                             justifyContent: isCollapsed && !isMobile ? 'center' : 'flex-start'
@@ -129,8 +132,8 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
                     style={({ isActive }) => ({
                         display: 'flex', alignItems: 'center', gap: '12px',
                         borderRadius: '10px', padding: isCollapsed && !isMobile ? '10px' : '9px 14px',
-                        color: isActive ? '#15803d' : '#6b7280',
-                        background: isActive ? '#f0fdf4' : 'transparent',
+                        color: isActive ? (isDark ? '#86efac' : '#15803d') : (isDark ? '#a7b7c2' : '#6b7280'),
+                        background: isActive ? (isDark ? 'rgba(16, 185, 129, 0.12)' : '#f0fdf4') : 'transparent',
                         fontWeight: isActive ? 600 : 500,
                         textDecoration: 'none', transition: 'all 0.2s ease',
                         justifyContent: isCollapsed && !isMobile ? 'center' : 'flex-start'
@@ -146,7 +149,7 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
                     style={{
                         display: 'flex', alignItems: 'center', gap: '12px',
                         borderRadius: '10px', padding: isCollapsed && !isMobile ? '10px' : '9px 14px',
-                        color: '#6b7280', background: 'transparent',
+                        color: isDark ? '#a7b7c2' : '#6b7280', background: 'transparent',
                         fontWeight: 500, border: 'none', cursor: 'pointer',
                         transition: 'all 0.2s ease', width: '100%',
                         justifyContent: isCollapsed && !isMobile ? 'center' : 'flex-start'

--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -14,7 +14,7 @@ const AdminLayout = () => {
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
     return (
-        <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
+        <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans transition-colors duration-200 dark:bg-[#07140f] dark:text-slate-100">
             {/* Master Navigation Column (Responsive) */}
             <div 
                 className={`hidden md:block flex-shrink-0 relative z-40 transition-all duration-300`}

--- a/Frontend/src/components/landing/TeamSection.jsx
+++ b/Frontend/src/components/landing/TeamSection.jsx
@@ -193,14 +193,14 @@ const TEAM_GROUPS = [
 
 export default function TeamSection() {
     return (
-        <section className="py-24 bg-gray-50/50 border-t border-gray-100">
+        <section className="py-24 bg-gray-50/50 border-t border-gray-100 dark:bg-[#081510] dark:border-emerald-900/30">
             <div className="max-w-[1100px] mx-auto px-6">
                 {/* Section Header */}
                 <div className="text-center mb-16">
-                    <h2 className="text-3xl md:text-4xl font-black text-slate-900 tracking-tight mb-4">
+                    <h2 className="text-3xl md:text-4xl font-black text-slate-900 tracking-tight mb-4 dark:text-white">
                         Meet the Team Behind helpdesk.ai
                     </h2>
-                    <p className="text-slate-500 font-medium text-lg max-w-2xl mx-auto">
+                    <p className="text-slate-500 font-medium text-lg max-w-2xl mx-auto dark:text-slate-300">
                         Built by engineers focused on intelligent support automation.
                     </p>
                 </div>
@@ -213,7 +213,7 @@ export default function TeamSection() {
 
                         return (
                             <div key={group.id}>
-                                <h3 className="text-xl font-black text-slate-800 uppercase tracking-widest border-b border-gray-200 pb-2 mb-8 inline-block">
+                                <h3 className="text-xl font-black text-slate-800 uppercase tracking-widest border-b border-gray-200 pb-2 mb-8 inline-block dark:text-slate-100 dark:border-emerald-900/40">
                                     {group.label}
                                 </h3>
 
@@ -222,10 +222,10 @@ export default function TeamSection() {
                                     {groupMembers.map((member, index) => (
                                         <div
                                             key={index}
-                                            className="group relative bg-white border border-slate-100 rounded-2xl p-6 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 ease-out flex flex-col items-center text-center"
+                                            className="group relative bg-white border border-slate-100 rounded-2xl p-6 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 ease-out flex flex-col items-center text-center dark:bg-[#0f1f18] dark:border-emerald-900/35 dark:hover:shadow-black/30"
                                         >
                                             {/* Image Container with Hover Overlay */}
-                                            <div className="relative w-32 h-32 mb-5 rounded-full overflow-hidden border-4 border-white shadow-md bg-gray-100/50">
+                                            <div className="relative w-32 h-32 mb-5 rounded-full overflow-hidden border-4 border-white shadow-md bg-gray-100/50 dark:border-emerald-100 dark:bg-emerald-950/40">
                                                 {member.image ? (
                                                     <img
                                                         src={member.image}
@@ -273,7 +273,7 @@ export default function TeamSection() {
 
                                             {/* Text Content */}
                                             <div>
-                                                <h3 className="text-lg font-bold text-slate-900 mb-1 leading-tight">{member.name}</h3>
+                                                <h3 className="text-lg font-bold text-slate-900 mb-1 leading-tight dark:text-white">{member.name}</h3>
                                                 <p className={`text-[11px] font-black uppercase tracking-widest ${member.role.includes('Lead') ? 'text-indigo-600' : 'text-emerald-600'}`}>
                                                     {member.role}
                                                 </p>

--- a/Frontend/src/components/shared/ThemeProvider.jsx
+++ b/Frontend/src/components/shared/ThemeProvider.jsx
@@ -5,8 +5,13 @@ const ThemeContext = createContext(null);
 
 function getSavedTheme() {
     if (typeof window === 'undefined') return 'light';
-    const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
-    return savedTheme === 'dark' ? 'dark' : 'light';
+
+    try {
+        const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+        return savedTheme === 'dark' ? 'dark' : 'light';
+    } catch {
+        return 'light';
+    }
 }
 
 export function ThemeProvider({ children }) {
@@ -16,7 +21,12 @@ export function ThemeProvider({ children }) {
         const root = document.documentElement;
         root.classList.toggle('dark', theme === 'dark');
         root.style.colorScheme = theme;
-        window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+
+        try {
+            window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+        } catch {
+            // Ignore storage failures in restricted browsing contexts.
+        }
     }, [theme]);
 
     const value = useMemo(() => ({

--- a/Frontend/src/components/shared/ThemeProvider.jsx
+++ b/Frontend/src/components/shared/ThemeProvider.jsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const THEME_STORAGE_KEY = 'helpdesk-ai-theme';
+const ThemeContext = createContext(null);
+
+function getSavedTheme() {
+    if (typeof window === 'undefined') return 'light';
+    const savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return savedTheme === 'dark' ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }) {
+    const [theme, setTheme] = useState(getSavedTheme);
+
+    useEffect(() => {
+        const root = document.documentElement;
+        root.classList.toggle('dark', theme === 'dark');
+        root.style.colorScheme = theme;
+        window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    }, [theme]);
+
+    const value = useMemo(() => ({
+        theme,
+        isDark: theme === 'dark',
+        toggleTheme: () => setTheme((currentTheme) => currentTheme === 'dark' ? 'light' : 'dark'),
+    }), [theme]);
+
+    return (
+        <ThemeContext.Provider value={value}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme() {
+    const context = useContext(ThemeContext);
+    if (!context) {
+        throw new Error('useTheme must be used inside ThemeProvider');
+    }
+    return context;
+}

--- a/Frontend/src/components/shared/ThemeToggle.jsx
+++ b/Frontend/src/components/shared/ThemeToggle.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from './ThemeProvider';
+
+const ThemeToggle = ({ className = '' }) => {
+    const { isDark, toggleTheme } = useTheme();
+    const Icon = isDark ? Sun : Moon;
+
+    return (
+        <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            className={`theme-toggle inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border transition-all duration-200 ${className}`}
+        >
+            <Icon className="h-4 w-4" />
+        </button>
+    );
+};
+
+export default ThemeToggle;

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -154,8 +154,7 @@ body{
 .dark .bg-gray-100,
 .dark .bg-slate-100,
 .dark .bg-white\/50,
-.dark .bg-white\/80,
-.dark .bg-white\/90 {
+.dark .bg-white\/80 {
   background-color: #14261e !important;
 }
 

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -43,7 +43,7 @@
   }
 
   body {
-    @apply bg-[#f6f8f7] text-slate-900;
+    @apply bg-[#f6f8f7] text-slate-900 transition-colors duration-200;
   }
 
   .dark {
@@ -103,4 +103,319 @@ html::-webkit-scrollbar{
 
 body{
   overflow-x: hidden;
+}
+
+.theme-toggle {
+  background: #ffffff;
+  border-color: #dbe5df;
+  color: #334155;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.theme-toggle:hover {
+  border-color: #86efac;
+  color: #047857;
+  background: #f0fdf4;
+}
+
+.dark .theme-toggle {
+  background: rgba(15, 23, 42, 0.92);
+  border-color: rgba(148, 163, 184, 0.26);
+  color: #f8fafc;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.28);
+}
+
+.dark .theme-toggle:hover {
+  background: rgba(6, 78, 59, 0.9);
+  border-color: rgba(52, 211, 153, 0.65);
+  color: #bbf7d0;
+}
+
+.dark body {
+  background: #07140f;
+  color: #e5edf0;
+}
+
+.dark .bg-white,
+.dark .bg-white\/90,
+.dark .bg-white\/95 {
+  background-color: #0f1f18 !important;
+}
+
+.dark .bg-gray-50,
+.dark .bg-gray-50\/50,
+.dark .bg-slate-50,
+.dark .bg-slate-50\/50,
+.dark .bg-\[\#f6f8f7\],
+.dark .bg-\[\#f8faf9\] {
+  background-color: #07140f !important;
+}
+
+.dark .bg-gray-100,
+.dark .bg-slate-100,
+.dark .bg-white\/50,
+.dark .bg-white\/80,
+.dark .bg-white\/90 {
+  background-color: #14261e !important;
+}
+
+.dark .bg-emerald-50,
+.dark .bg-green-50,
+.dark .bg-emerald-100,
+.dark .bg-green-100,
+.dark .bg-indigo-50,
+.dark .bg-indigo-50\/30,
+.dark .bg-blue-50,
+.dark .bg-red-50,
+.dark .bg-orange-50,
+.dark .bg-amber-50,
+.dark .bg-yellow-50,
+.dark .bg-\[\#f0fdf4\] {
+  background-color: rgba(16, 185, 129, 0.12) !important;
+}
+
+.dark .from-green-50,
+.dark .from-emerald-50,
+.dark .from-blue-50,
+.dark .from-red-50,
+.dark .from-orange-50,
+.dark .from-teal-50,
+.dark .to-gray-50,
+.dark .to-green-50,
+.dark .to-teal-50,
+.dark .to-orange-50 {
+  --tw-gradient-from: rgba(16, 185, 129, 0.12) var(--tw-gradient-from-position) !important;
+  --tw-gradient-to: rgba(7, 20, 15, 0) var(--tw-gradient-to-position) !important;
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to) !important;
+}
+
+.dark .border-gray-50,
+.dark .border-gray-100,
+.dark .border-gray-200,
+.dark .border-gray-300,
+.dark .border-slate-100,
+.dark .border-slate-200,
+.dark .border-slate-300,
+.dark .border-emerald-100,
+.dark .border-emerald-200,
+.dark .border-green-200,
+.dark .border-indigo-100,
+.dark .border-blue-100,
+.dark .border-red-100,
+.dark .border-amber-100,
+.dark .border-amber-200,
+.dark .border-yellow-100 {
+  border-color: rgba(52, 211, 153, 0.18) !important;
+}
+
+.dark .text-gray-950,
+.dark .text-gray-900,
+.dark .text-slate-950,
+.dark .text-slate-900,
+.dark .text-gray-800,
+.dark .text-slate-800,
+.dark .text-gray-700,
+.dark .text-slate-700 {
+  color: #f8fafc !important;
+}
+
+.dark .text-gray-600,
+.dark .text-slate-600,
+.dark .text-gray-500,
+.dark .text-slate-500,
+.dark .text-gray-400,
+.dark .text-slate-400 {
+  color: #b6c6cf !important;
+}
+
+.dark .text-emerald-900,
+.dark .text-emerald-800,
+.dark .text-emerald-700,
+.dark .text-green-700 {
+  color: #6ee7b7 !important;
+}
+
+.dark .hover\:bg-gray-50:hover,
+.dark .hover\:bg-slate-50:hover,
+.dark .hover\:bg-emerald-50:hover,
+.dark .hover\:bg-green-50:hover {
+  background-color: rgba(16, 185, 129, 0.1) !important;
+}
+
+.dark .hover\:text-gray-900:hover,
+.dark .hover\:text-slate-900:hover,
+.dark .hover\:text-emerald-800:hover,
+.dark .hover\:text-emerald-700:hover,
+.dark .hover\:text-emerald-600:hover {
+  color: #86efac !important;
+}
+
+.dark .focus\:bg-white:focus {
+  background-color: #102219 !important;
+}
+
+.dark .ring-red-50,
+.dark .ring-orange-50,
+.dark .ring-emerald-50,
+.dark .ring-blue-50,
+.dark .ring-indigo-50 {
+  --tw-ring-color: rgba(52, 211, 153, 0.16) !important;
+}
+
+.dark .shadow-slate-200\/40,
+.dark .shadow-slate-200\/50,
+.dark .shadow-gray-200\/50,
+.dark .shadow-emerald-900\/10,
+.dark .shadow-emerald-900\/20,
+.dark .shadow-emerald-900\/25 {
+  --tw-shadow-color: rgba(0, 0, 0, 0.32) !important;
+}
+
+.dark [style*="background: #ffffff"],
+.dark [style*="background:#ffffff"],
+.dark [style*="background: #fff"],
+.dark [style*="background:#fff"],
+.dark [style*="background: '#ffffff'"],
+.dark [style*="background: '#fff'"],
+.dark [style*="background-color: #ffffff"],
+.dark [style*="background-color:#ffffff"],
+.dark [style*="background-color: #fff"],
+.dark [style*="background-color:#fff"],
+.dark [style*="background: rgb(255, 255, 255)"],
+.dark [style*="background-color: rgb(255, 255, 255)"] {
+  background: #0f1f18 !important;
+  background-color: #0f1f18 !important;
+}
+
+.dark [style*="background: #f8faf9"],
+.dark [style*="background:#f8faf9"],
+.dark [style*="background: #f9fafb"],
+.dark [style*="background:#f9fafb"],
+.dark [style*="background: #f3f4f6"],
+.dark [style*="background:#f3f4f6"],
+.dark [style*="background: '#f8faf9'"],
+.dark [style*="background: '#f9fafb'"],
+.dark [style*="background: '#f3f4f6'"],
+.dark [style*="background-color: #f8faf9"],
+.dark [style*="background-color:#f8faf9"],
+.dark [style*="background-color: #f9fafb"],
+.dark [style*="background-color:#f9fafb"],
+.dark [style*="background-color: #f3f4f6"],
+.dark [style*="background-color:#f3f4f6"],
+.dark [style*="background: rgb(248, 250, 249)"],
+.dark [style*="background: rgb(249, 250, 251)"],
+.dark [style*="background: rgb(243, 244, 246)"] {
+  background: #07140f !important;
+  background-color: #07140f !important;
+}
+
+.dark [style*="background: #f0fdf4"],
+.dark [style*="background:#f0fdf4"],
+.dark [style*="background: #dcfce7"],
+.dark [style*="background:#dcfce7"],
+.dark [style*="background: #edfaf3"],
+.dark [style*="background:#edfaf3"],
+.dark [style*="background: '#f0fdf4'"],
+.dark [style*="background: '#dcfce7'"],
+.dark [style*="background: '#edfaf3'"],
+.dark [style*="background-color: #f0fdf4"],
+.dark [style*="background-color:#f0fdf4"],
+.dark [style*="background-color: #dcfce7"],
+.dark [style*="background-color:#dcfce7"],
+.dark [style*="background-color: #edfaf3"],
+.dark [style*="background-color:#edfaf3"],
+.dark [style*="background: rgb(240, 253, 244)"],
+.dark [style*="background: rgb(220, 252, 231)"] {
+  background: rgba(16, 185, 129, 0.12) !important;
+  background-color: rgba(16, 185, 129, 0.12) !important;
+}
+
+.dark [style*="border: 1px solid #f0fdf4"],
+.dark [style*="border:1px solid #f0fdf4"],
+.dark [style*="border: 1px solid #e5e7eb"],
+.dark [style*="border:1px solid #e5e7eb"],
+.dark [style*="border: 1.5px solid #e5e7eb"],
+.dark [style*="border:1.5px solid #e5e7eb"],
+.dark [style*="border: 1px solid #d1fae5"],
+.dark [style*="border:1px solid #d1fae5"],
+.dark [style*="border: 1.5px solid #d1fae5"],
+.dark [style*="border:1.5px solid #d1fae5"],
+.dark [style*="border: '1px solid #f0fdf4'"],
+.dark [style*="border: '1px solid #e5e7eb'"],
+.dark [style*="border: '1.5px solid #e5e7eb'"],
+.dark [style*="border: '1px solid #d1fae5'"],
+.dark [style*="border: '1.5px solid #d1fae5'"] {
+  border-color: rgba(52, 211, 153, 0.22) !important;
+}
+
+.dark [style*="border-bottom: 1px solid #f0fdf4"],
+.dark [style*="border-bottom:1px solid #f0fdf4"],
+.dark [style*="border-bottom: 1px solid #e5e7eb"],
+.dark [style*="border-bottom:1px solid #e5e7eb"],
+.dark [style*="border-top: 1px solid #f0fdf4"],
+.dark [style*="border-top:1px solid #f0fdf4"],
+.dark [style*="border-top: 1px solid #e5e7eb"],
+.dark [style*="border-top:1px solid #e5e7eb"] {
+  border-color: rgba(52, 211, 153, 0.18) !important;
+}
+
+.dark [style*="color: #0f1f12"],
+.dark [style*="color:#0f1f12"],
+.dark [style*="color: #111827"],
+.dark [style*="color:#111827"],
+.dark [style*="color: #1f2937"],
+.dark [style*="color:#1f2937"],
+.dark [style*="color: '#0f1f12'"],
+.dark [style*="color: '#111827'"],
+.dark [style*="color: '#1f2937'"],
+.dark [style*="color: rgb(15, 31, 18)"],
+.dark [style*="color: rgb(17, 24, 39)"] {
+  color: #f8fafc !important;
+}
+
+.dark [style*="color: #374151"],
+.dark [style*="color:#374151"],
+.dark [style*="color: #475569"],
+.dark [style*="color:#475569"],
+.dark [style*="color: #6b7280"],
+.dark [style*="color:#6b7280"],
+.dark [style*="color: #9ca3af"],
+.dark [style*="color:#9ca3af"],
+.dark [style*="color: '#374151'"],
+.dark [style*="color: '#475569'"],
+.dark [style*="color: '#6b7280'"],
+.dark [style*="color: '#9ca3af'"],
+.dark [style*="color: rgb(55, 65, 81)"],
+.dark [style*="color: rgb(71, 85, 105)"],
+.dark [style*="color: rgb(107, 114, 128)"],
+.dark [style*="color: rgb(156, 163, 175)"] {
+  color: #b6c6cf !important;
+}
+
+.dark [style*="linear-gradient(160deg, #f0fdf4"],
+.dark [style*="linear-gradient(160deg,#f0fdf4"],
+.dark [style*="linear-gradient(160deg, rgb(240, 253, 244)"] {
+  background: linear-gradient(160deg, #061a13 0%, #0f2a1d 58%, #123d28 100%) !important;
+}
+
+.dark .placeholder\:text-slate-400::placeholder,
+.dark input::placeholder,
+.dark textarea::placeholder {
+  color: #718096 !important;
+}
+
+.dark input,
+.dark textarea,
+.dark select {
+  background-color: rgba(15, 31, 24, 0.96);
+  border-color: rgba(148, 163, 184, 0.18);
+  color: #f8fafc;
+}
+
+.dark .shadow-sm,
+.dark .shadow,
+.dark .shadow-lg,
+.dark .shadow-xl,
+.dark .shadow-2xl {
+  --tw-shadow-color: rgba(0, 0, 0, 0.38);
 }

--- a/Frontend/src/master-admin/layout/MasterAdminLayout.jsx
+++ b/Frontend/src/master-admin/layout/MasterAdminLayout.jsx
@@ -59,24 +59,24 @@ function MasterAdminLayout() {
     ];
 
     return (
-        <div className="min-h-screen bg-[#050508] flex font-sans overflow-hidden text-slate-300">
+        <div className="min-h-screen bg-[#f8faf9] flex font-sans overflow-hidden text-slate-700 transition-colors duration-200 dark:bg-[#050508] dark:text-slate-300">
             {/* Ambient Background Glows */}
             <div className="fixed inset-0 pointer-events-none z-0">
-                <div className="absolute top-0 right-0 w-[800px] h-[800px] bg-indigo-600/5 rounded-full blur-[150px] mix-blend-screen" />
-                <div className="absolute bottom-0 left-0 w-[600px] h-[600px] bg-emerald-600/5 rounded-full blur-[120px] mix-blend-screen" />
-                <div className="absolute top-0 left-0 w-full h-full bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-[0.03]"></div>
+                <div className="absolute top-0 right-0 w-[800px] h-[800px] bg-indigo-200/30 rounded-full blur-[150px] mix-blend-multiply dark:bg-indigo-600/5 dark:mix-blend-screen" />
+                <div className="absolute bottom-0 left-0 w-[600px] h-[600px] bg-emerald-200/30 rounded-full blur-[120px] mix-blend-multiply dark:bg-emerald-600/5 dark:mix-blend-screen" />
+                <div className="absolute top-0 left-0 w-full h-full bg-[url('https://grainy-gradients.vercel.app/noise.svg')] opacity-[0.02] dark:opacity-[0.03]"></div>
             </div>
 
             {/* Sidebar */}
-            <aside className="w-64 border-r border-white/5 bg-white/[0.02] backdrop-blur-xl z-20 flex flex-col shrink-0">
-                <div className="p-6 border-b border-white/5">
+            <aside className="w-64 border-r border-slate-200 bg-white/90 backdrop-blur-xl z-20 flex flex-col shrink-0 shadow-sm dark:border-white/5 dark:bg-white/[0.02] dark:shadow-none">
+                <div className="p-6 border-b border-slate-100 dark:border-white/5">
                     <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 rounded-xl bg-indigo-500/20 border border-indigo-500/30 flex items-center justify-center shadow-[0_0_15px_rgba(99,102,241,0.2)]">
-                            <ShieldCheck className="w-5 h-5 text-indigo-400" />
+                        <div className="w-10 h-10 rounded-xl bg-indigo-50 border border-indigo-100 flex items-center justify-center shadow-sm dark:bg-indigo-500/20 dark:border-indigo-500/30 dark:shadow-[0_0_15px_rgba(99,102,241,0.2)]">
+                            <ShieldCheck className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
                         </div>
                         <div>
-                            <h1 className="text-white font-bold tracking-tight">HelpDesk.ai</h1>
-                            <p className="text-[10px] text-indigo-400 uppercase tracking-widest font-semibold">Master Admin</p>
+                            <h1 className="text-slate-950 font-bold tracking-tight dark:text-white">HelpDesk.ai</h1>
+                            <p className="text-[10px] text-indigo-600 uppercase tracking-widest font-semibold dark:text-indigo-400">Master Admin</p>
                         </div>
                     </div>
                 </div>
@@ -89,12 +89,12 @@ function MasterAdminLayout() {
                                 key={item.path}
                                 to={item.path}
                                 className={`flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium transition-all group ${isActive
-                                    ? "bg-indigo-500/10 text-indigo-300 border border-indigo-500/20"
-                                    : "text-slate-400 hover:text-white hover:bg-white/5 border border-transparent"
+                                    ? "bg-indigo-50 text-indigo-700 border border-indigo-100 dark:bg-indigo-500/10 dark:text-indigo-300 dark:border-indigo-500/20"
+                                    : "text-slate-500 hover:text-slate-950 hover:bg-slate-50 border border-transparent dark:text-slate-400 dark:hover:text-white dark:hover:bg-white/5"
                                     }`}
                             >
                                 {React.cloneElement(item.icon, {
-                                    className: `w-5 h-5 transition-colors ${isActive ? "text-indigo-400" : "text-slate-500 group-hover:text-slate-300"}`
+                                    className: `w-5 h-5 transition-colors ${isActive ? "text-indigo-600 dark:text-indigo-400" : "text-slate-400 group-hover:text-slate-700 dark:text-slate-500 dark:group-hover:text-slate-300"}`
                                 })}
                                 {item.label}
                                 {item.count > 0 && (
@@ -103,19 +103,19 @@ function MasterAdminLayout() {
                                     </span>
                                 )}
                                 {item.label === "Pending Requests" && item.count === 0 && (
-                                    <span className="ml-auto w-1.5 h-1.5 rounded-full bg-slate-700"></span>
+                                    <span className="ml-auto w-1.5 h-1.5 rounded-full bg-slate-300 dark:bg-slate-700"></span>
                                 )}
                             </Link>
                         );
                     })}
                 </nav>
 
-                <div className="p-4 border-t border-white/5">
+                <div className="p-4 border-t border-slate-100 dark:border-white/5">
                     <button
                         onClick={handleLogout}
-                        className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium text-slate-400 hover:text-red-400 hover:bg-red-500/5 transition-all group"
+                        className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm font-medium text-slate-500 hover:text-red-600 hover:bg-red-50 transition-all group dark:text-slate-400 dark:hover:text-red-400 dark:hover:bg-red-500/5"
                     >
-                        <LogOut className="w-5 h-5 text-slate-500 group-hover:text-red-400 transition-colors" />
+                        <LogOut className="w-5 h-5 text-slate-400 group-hover:text-red-600 transition-colors dark:text-slate-500 dark:group-hover:text-red-400" />
                         Sign Out
                     </button>
                 </div>
@@ -124,28 +124,28 @@ function MasterAdminLayout() {
             {/* Main Content Area */}
             <main className="flex-1 flex flex-col min-w-0 relative z-10 h-screen overflow-hidden">
                 {/* Top Bar */}
-                <header className="h-16 border-b border-white/5 bg-white/[0.01] backdrop-blur-md flex items-center justify-between px-8 shrink-0">
+                <header className="h-16 border-b border-slate-200 bg-white/80 backdrop-blur-md flex items-center justify-between px-8 shrink-0 dark:border-white/5 dark:bg-white/[0.01]">
                     <div className="flex items-center gap-4 flex-1 max-w-xl">
                         <div className="relative w-full group">
-                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 group-focus-within:text-indigo-400 transition-colors" />
+                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 group-focus-within:text-indigo-500 transition-colors dark:text-slate-500 dark:group-focus-within:text-indigo-400" />
                             <input
                                 type="text"
                                 placeholder="Global search admins, companies, or IDs..."
-                                className="w-full bg-white/5 border border-white/10 rounded-lg py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500/50 transition-all"
+                                className="w-full bg-white border border-slate-200 rounded-lg py-2 pl-10 pr-4 text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500/50 transition-all dark:bg-white/5 dark:border-white/10 dark:text-slate-100"
                                 onChange={(e) => console.log("Global search:", e.target.value)}
                             />
                         </div>
                     </div>
 
                     <div className="flex items-center gap-6">
-                        <ThemeToggle className="border-white/10 bg-white/5 text-slate-100 hover:bg-indigo-500/10 hover:text-indigo-200" />
-                        <div className="flex items-center gap-3 pl-6 border-l border-white/10">
+                        <ThemeToggle />
+                        <div className="flex items-center gap-3 pl-6 border-l border-slate-200 dark:border-white/10">
                             <div className="text-right hidden sm:block">
-                                <p className="text-sm font-semibold text-white truncate max-w-[150px]">{profile?.full_name}</p>
+                                <p className="text-sm font-semibold text-slate-950 truncate max-w-[150px] dark:text-white">{profile?.full_name}</p>
                                 <p className="text-[10px] text-emerald-400 font-medium uppercase tracking-wider">Superuser Access</p>
                             </div>
-                            <div className="w-10 h-10 rounded-full bg-indigo-500/20 border border-indigo-500/30 flex items-center justify-center overflow-hidden">
-                                <UserCircle className="w-6 h-6 text-indigo-400" />
+                            <div className="w-10 h-10 rounded-full bg-indigo-50 border border-indigo-100 flex items-center justify-center overflow-hidden dark:bg-indigo-500/20 dark:border-indigo-500/30">
+                                <UserCircle className="w-6 h-6 text-indigo-600 dark:text-indigo-400" />
                             </div>
                         </div>
                     </div>

--- a/Frontend/src/master-admin/layout/MasterAdminLayout.jsx
+++ b/Frontend/src/master-admin/layout/MasterAdminLayout.jsx
@@ -16,6 +16,7 @@ import {
     Settings,
     Activity
 } from "lucide-react";
+import ThemeToggle from "../../components/shared/ThemeToggle";
 
 /**
  * MasterAdminLayout — Professional sidebar-based layout for platform oversight.
@@ -137,6 +138,7 @@ function MasterAdminLayout() {
                     </div>
 
                     <div className="flex items-center gap-6">
+                        <ThemeToggle className="border-white/10 bg-white/5 text-slate-100 hover:bg-indigo-500/10 hover:text-indigo-200" />
                         <div className="flex items-center gap-3 pl-6 border-l border-white/10">
                             <div className="text-right hidden sm:block">
                                 <p className="text-sm font-semibold text-white truncate max-w-[150px]">{profile?.full_name}</p>

--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -67,6 +67,22 @@ function AdminSignup() {
         inputBorder: isDark ? 'rgba(52, 211, 153, 0.24)' : '#e5e7eb',
     };
 
+    const headingClass = "text-2xl font-bold text-gray-900 dark:text-white";
+    const descriptionClass = "text-gray-500 text-sm dark:text-slate-300";
+    const labelClass = "text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2 dark:text-slate-300";
+    const inputClass = "w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:border-emerald-600 focus:bg-white outline-none transition-all dark:bg-[#081c14] dark:border-emerald-500/20 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:bg-[#102219] dark:focus:border-emerald-400";
+    const passwordInputClass = `${inputClass} pr-11`;
+    const iconButtonClass = "absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:text-slate-400 dark:hover:text-emerald-300";
+    const dividerClass = "grid grid-cols-1 md:grid-cols-2 gap-6 pt-4 border-t border-gray-100 dark:border-emerald-500/20";
+    const agreementPanelClass = "bg-gray-50 border border-gray-100 rounded-2xl p-6 space-y-4 dark:bg-[#081c14] dark:border-emerald-500/20";
+    const agreementTextClass = "text-sm text-gray-600 leading-relaxed group-hover:text-gray-900 transition-colors dark:text-slate-300 dark:group-hover:text-white";
+    const secondaryButtonStyle = {
+        background: theme.inputBg,
+        color: theme.body,
+        border: `1.5px solid ${theme.inputBorder}`,
+        cursor: 'pointer'
+    };
+
     // Redirect if already logged in and verified
     useEffect(() => {
         if (user && profile && profile.status === 'active') {
@@ -370,13 +386,13 @@ function AdminSignup() {
                                     className="space-y-6"
                                 >
                                     <div className="mb-8">
-                                        <h2 className="text-2xl font-bold text-gray-900">Personal Information</h2>
-                                        <p className="text-gray-500 text-sm">Tell us who you are and create your admin account.</p>
+                                        <h2 className={headingClass}>Personal Information</h2>
+                                        <p className={descriptionClass}>Tell us who you are and create your admin account.</p>
                                     </div>
 
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <User className="w-3 h-3" /> Full Name
                                             </label>
                                             <input
@@ -386,11 +402,11 @@ function AdminSignup() {
                                                 placeholder="Alex Mercer"
                                                 value={formData.fullName}
                                                 onChange={handleChange}
-                                                className="w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:bg-white outline-none transition-all"
+                                                className={inputClass}
                                             />
                                         </div>
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Mail className="w-3 h-3" /> Work Email
                                             </label>
                                             <input
@@ -400,11 +416,11 @@ function AdminSignup() {
                                                 placeholder="alex.mercer@acmecorp.com"
                                                 value={formData.email}
                                                 onChange={handleChange}
-                                                className="w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:bg-white outline-none transition-all"
+                                                className={inputClass}
                                             />
                                         </div>
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Phone className="w-3 h-3" /> Phone Number
                                             </label>
                                             <input
@@ -413,11 +429,11 @@ function AdminSignup() {
                                                 placeholder="+1 (415) 555-0198"
                                                 value={formData.phone}
                                                 onChange={handleChange}
-                                                className="w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:bg-white outline-none transition-all"
+                                                className={inputClass}
                                             />
                                         </div>
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Briefcase className="w-3 h-3" /> Job Title
                                             </label>
                                             <input
@@ -426,14 +442,14 @@ function AdminSignup() {
                                                 placeholder="Director of Operations"
                                                 value={formData.jobTitle}
                                                 onChange={handleChange}
-                                                className="w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:bg-white outline-none transition-all"
+                                                className={inputClass}
                                             />
                                         </div>
                                     </div>
 
-                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 pt-4 border-t border-gray-100">
+                                    <div className={dividerClass}>
                                         <div className="space-y-2 text-left">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Lock className="w-3 h-3" /> Create Password
                                             </label>
                                             <div className="relative">
@@ -444,12 +460,12 @@ function AdminSignup() {
                                                     placeholder="••••••••••"
                                                     value={formData.password}
                                                     onChange={handleChange}
-                                                    className="w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:bg-white outline-none transition-all pr-11"
+                                                    className={passwordInputClass}
                                                 />
                                                 <button
                                                     type="button"
                                                     onClick={() => setShowPassword(!showPassword)}
-                                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                                                    className={iconButtonClass}
                                                 >
                                                     {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                                                 </button>
@@ -457,13 +473,13 @@ function AdminSignup() {
                                             {/* Password Requirements */}
                                             <div className="mt-2 space-y-1">
                                                 {formData.password && (
-                                                    <div className="flex justify-between items-center text-[10px] font-bold uppercase tracking-widest text-gray-400">
+                                                    <div className="flex justify-between items-center text-[10px] font-bold uppercase tracking-widest text-gray-400 dark:text-slate-400">
                                                         <span>Strength: {getStrengthText()}</span>
                                                         <span>{passwordStrength}%</span>
                                                     </div>
                                                 )}
                                                 {formData.password && (
-                                                    <div className="h-1 w-full bg-gray-100 rounded-full overflow-hidden">
+                                                    <div className="h-1 w-full bg-gray-100 rounded-full overflow-hidden dark:bg-emerald-950/60">
                                                         <motion.div
                                                             className={`h-full ${getStrengthColor()}`}
                                                             initial={{ width: 0 }}
@@ -479,7 +495,7 @@ function AdminSignup() {
                                                         { label: 'Number (0-9)', ok: /[0-9]/.test(formData.password) },
                                                     ].map(({ label, ok }) => (
                                                         <span key={label} className={`text-[10px] font-semibold flex items-center gap-1 transition-colors ${
-                                                            formData.password ? (ok ? 'text-emerald-600' : 'text-red-400') : 'text-gray-300'
+                                                            formData.password ? (ok ? 'text-emerald-600 dark:text-emerald-300' : 'text-red-400') : 'text-gray-300 dark:text-slate-600'
                                                         }`}>
                                                             <span>{ok ? '✓' : '○'}</span> {label}
                                                         </span>
@@ -488,7 +504,7 @@ function AdminSignup() {
                                             </div>
                                         </div>
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Lock className="w-3 h-3" /> Confirm Password
                                             </label>
                                             <div className="relative">
@@ -499,12 +515,12 @@ function AdminSignup() {
                                                     placeholder="••••••••••"
                                                     value={formData.confirmPassword}
                                                     onChange={handleChange}
-                                                    className="w-full bg-gray-50 border border-gray-100 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:bg-white outline-none transition-all pr-11"
+                                                    className={passwordInputClass}
                                                 />
                                                 <button
                                                     type="button"
                                                     onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                                                    className={iconButtonClass}
                                                 >
                                                     {showConfirmPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
                                                 </button>
@@ -535,12 +551,12 @@ function AdminSignup() {
                                     className="space-y-6"
                                 >
                                     <div className="mb-8">
-                                        <h2 className="text-2xl font-bold text-gray-900">Company Details</h2>
-                                        <p className="text-gray-500 text-sm">Tell us about the organization you're registering.</p>
+                                        <h2 className={headingClass}>Company Details</h2>
+                                        <p className={descriptionClass}>Tell us about the organization you're registering.</p>
                                     </div>
 
                                     <div className="space-y-2">
-                                        <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                        <label className={labelClass}>
                                             <Building2 className="w-3 h-3" /> Company Name
                                         </label>
                                         <input
@@ -550,13 +566,13 @@ function AdminSignup() {
                                             placeholder="Acme Global Inc."
                                             value={formData.companyName}
                                             onChange={handleChange}
-                                            className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:ring-2 focus:ring-emerald-50 outline-none transition-all"
+                                            className={`${inputClass} focus:ring-2 focus:ring-emerald-50 dark:focus:ring-emerald-500/10`}
                                         />
                                     </div>
 
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <User className="w-3 h-3" /> Company Size
                                             </label>
                                             <Select
@@ -574,7 +590,7 @@ function AdminSignup() {
                                             />
                                         </div>
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Briefcase className="w-3 h-3" /> Industry
                                             </label>
                                             <Select
@@ -597,7 +613,7 @@ function AdminSignup() {
 
                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Globe className="w-3 h-3" /> Company Website
                                             </label>
                                             <input
@@ -606,11 +622,11 @@ function AdminSignup() {
                                                 placeholder="https://acme.com"
                                                 value={formData.website}
                                                 onChange={handleChange}
-                                                className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:ring-2 focus:ring-emerald-50 outline-none transition-all"
+                                                className={`${inputClass} focus:ring-2 focus:ring-emerald-50 dark:focus:ring-emerald-500/10`}
                                             />
                                         </div>
                                         <div className="space-y-2">
-                                            <label className="text-xs font-bold text-gray-400 uppercase tracking-wider flex items-center gap-2">
+                                            <label className={labelClass}>
                                                 <Globe className="w-3 h-3" /> Country
                                             </label>
                                             <input
@@ -620,7 +636,7 @@ function AdminSignup() {
                                                 placeholder="United States"
                                                 value={formData.country}
                                                 onChange={handleChange}
-                                                className="w-full bg-white border border-gray-200 rounded-xl px-4 py-3 text-sm focus:border-emerald-600 focus:ring-2 focus:ring-emerald-50 outline-none transition-all"
+                                                className={`${inputClass} focus:ring-2 focus:ring-emerald-50 dark:focus:ring-emerald-500/10`}
                                             />
                                         </div>
                                     </div>
@@ -628,9 +644,9 @@ function AdminSignup() {
                                          <div className="flex gap-4 pt-8">
                                          <button type="button" onClick={prevStep}
                                              className="flex-1 rounded-xl py-4 font-bold transition-all flex items-center justify-center gap-2"
-                                             style={{ background: '#f9fafb', color: '#374151', border: '1.5px solid #e5e7eb', cursor: 'pointer' }}
-                                             onMouseEnter={(e) => e.currentTarget.style.background='#f3f4f6'}
-                                             onMouseLeave={(e) => e.currentTarget.style.background='#f9fafb'}
+                                             style={secondaryButtonStyle}
+                                             onMouseEnter={(e) => e.currentTarget.style.background = isDark ? 'rgba(16, 185, 129, 0.12)' : '#f3f4f6'}
+                                             onMouseLeave={(e) => e.currentTarget.style.background = theme.inputBg}
                                          >
                                              <ChevronLeft className="w-5 h-5" /> Back
                                          </button>
@@ -656,11 +672,11 @@ function AdminSignup() {
                                     className="space-y-6"
                                 >
                                     <div className="mb-8">
-                                        <h2 className="text-2xl font-bold text-gray-900">Final Confirmation</h2>
-                                        <p className="text-gray-500 text-sm">Review our policies and submit your application.</p>
+                                        <h2 className={headingClass}>Final Confirmation</h2>
+                                        <p className={descriptionClass}>Review our policies and submit your application.</p>
                                     </div>
 
-                                    <div className="bg-gray-50 border border-gray-100 rounded-2xl p-6 space-y-4">
+                                    <div className={agreementPanelClass}>
                                         <label className="flex items-start gap-4 cursor-pointer group">
                                             <input
                                                 type="checkbox"
@@ -669,11 +685,11 @@ function AdminSignup() {
                                                 onChange={handleChange}
                                                 className="mt-1 w-5 h-5 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500 transition-all"
                                             />
-                                            <span className="text-sm text-gray-600 leading-relaxed group-hover:text-gray-900 transition-colors">
+                                            <span className={agreementTextClass}>
                                                 I agree to the <Link to="/terms" className="text-emerald-700 font-bold hover:underline">Terms of Service</Link> and <Link to="/privacy" className="text-emerald-700 font-bold hover:underline">Privacy Policy</Link>. I understand that my data will be stored securely.
                                             </span>
                                         </label>
-                                        <label className="flex items-start gap-4 cursor-pointer group pt-4 border-t border-gray-200/50">
+                                        <label className="flex items-start gap-4 cursor-pointer group pt-4 border-t border-gray-200/50 dark:border-emerald-500/20">
                                             <input
                                                 type="checkbox"
                                                 name="isAuthorized"
@@ -681,8 +697,8 @@ function AdminSignup() {
                                                 onChange={handleChange}
                                                 className="mt-1 w-5 h-5 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500 transition-all"
                                             />
-                                            <span className="text-sm text-gray-600 leading-relaxed group-hover:text-gray-900 transition-colors">
-                                                I confirm that I am authorized to register <span className="font-bold text-gray-900 underline">{formData.companyName || "my company"}</span> on the HelpDesk.ai platform as a primary administrator.
+                                            <span className={agreementTextClass}>
+                                                I confirm that I am authorized to register <span className="font-bold text-gray-900 underline dark:text-white">{formData.companyName || "my company"}</span> on the HelpDesk.ai platform as a primary administrator.
                                             </span>
                                         </label>
                                     </div>
@@ -692,7 +708,8 @@ function AdminSignup() {
                                             type="button"
                                             onClick={prevStep}
                                             disabled={loading}
-                                            className="flex-1 bg-gray-100 text-gray-700 rounded-xl py-4 font-bold hover:bg-gray-200 transition-all flex items-center justify-center gap-2"
+                                            className="flex-1 rounded-xl py-4 font-bold transition-all flex items-center justify-center gap-2"
+                                            style={secondaryButtonStyle}
                                         >
                                             <ChevronLeft className="w-5 h-5" /> Back
                                         </button>

--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import useAuthStore from "../store/authStore";
 import { Select } from "../components/ui/select";
+import ThemeToggle from "../components/shared/ThemeToggle";
+import { useTheme } from "../components/shared/ThemeProvider";
 
 /**
  * AdminSignup — Premium Multi-step Company Registration
@@ -44,6 +46,26 @@ function AdminSignup() {
 
     const navigate = useNavigate();
     const { signup, loading, user, profile } = useAuthStore();
+    const { isDark } = useTheme();
+
+    const theme = {
+        page: isDark ? '#07140f' : '#ffffff',
+        leftBg: isDark
+            ? 'linear-gradient(160deg, #061a13 0%, #0f2a1d 58%, #123d28 100%)'
+            : 'linear-gradient(160deg, #f0fdf4 0%, #dcfce7 60%, #bbf7d0 100%)',
+        rightBg: isDark ? '#07140f' : '#ffffff',
+        cardBg: isDark ? '#0f1f18' : '#ffffff',
+        subtleBg: isDark ? 'rgba(16, 185, 129, 0.12)' : 'rgba(34,160,69,0.08)',
+        title: isDark ? '#f8fafc' : '#0f1f12',
+        body: isDark ? '#cbd5e1' : '#374151',
+        muted: isDark ? '#9fb0ba' : '#6b7280',
+        accent: isDark ? '#34d399' : '#16a34a',
+        accentStrong: isDark ? '#86efac' : '#15803d',
+        border: isDark ? 'rgba(52, 211, 153, 0.22)' : '#f0fdf4',
+        strongBorder: isDark ? 'rgba(52, 211, 153, 0.32)' : '#d1fae5',
+        inputBg: isDark ? '#081c14' : '#f9fafb',
+        inputBorder: isDark ? 'rgba(52, 211, 153, 0.24)' : '#e5e7eb',
+    };
 
     // Redirect if already logged in and verified
     useEffect(() => {
@@ -177,27 +199,28 @@ function AdminSignup() {
 
     if (isSubmitted) {
         return (
-            <div className="min-h-screen flex items-center justify-center p-6 relative overflow-hidden" style={{ fontFamily: "'Inter', sans-serif", background: 'linear-gradient(160deg, #f0fdf4 0%, #dcfce7 60%, #bbf7d0 100%)' }}>
-                <div className="absolute top-0 left-0 w-[600px] h-[600px] rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(34,160,69,0.12) 0%, transparent 70%)' }} />
+            <div className="min-h-screen flex items-center justify-center p-6 relative overflow-hidden" style={{ fontFamily: "'Inter', sans-serif", background: theme.leftBg }}>
+                <div className="absolute top-6 right-6 z-20"><ThemeToggle /></div>
+                <div className="absolute top-0 left-0 w-[600px] h-[600px] rounded-full pointer-events-none" style={{ background: isDark ? 'radial-gradient(circle, rgba(52,211,153,0.16) 0%, transparent 70%)' : 'radial-gradient(circle, rgba(34,160,69,0.12) 0%, transparent 70%)' }} />
 
                 <motion.div
                     initial={{ opacity: 0, scale: 0.95 }}
                     animate={{ opacity: 1, scale: 1 }}
-                    className="bg-white rounded-3xl p-10 max-w-lg w-full text-center relative z-10"
-                    style={{ boxShadow: '0 8px 40px rgba(0,0,0,0.08)', border: '1px solid #f0fdf4' }}
+                    className="rounded-3xl p-10 max-w-lg w-full text-center relative z-10"
+                    style={{ background: theme.cardBg, boxShadow: isDark ? '0 8px 40px rgba(0,0,0,0.28)' : '0 8px 40px rgba(0,0,0,0.08)', border: `1px solid ${theme.border}` }}
                 >
-                    <div className="w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-6" style={{ background: '#f0fdf4', border: '1px solid #d1fae5' }}>
-                        <Mail className="w-10 h-10" style={{ color: '#16a34a' }} />
+                    <div className="w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-6" style={{ background: theme.subtleBg, border: `1px solid ${theme.strongBorder}` }}>
+                        <Mail className="w-10 h-10" style={{ color: theme.accent }} />
                     </div>
-                    <h2 style={{ fontFamily: "'Syne', sans-serif", fontSize: '28px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.02em', marginBottom: '16px' }}>Check Your Email</h2>
-                    <p style={{ color: '#374151', fontSize: '15px', lineHeight: 1.7, marginBottom: '32px' }}>
-                        Registration request received! We've sent a verification link to <span style={{ fontWeight: 700, color: '#16a34a' }}>{formData.email}</span>.
+                    <h2 style={{ fontFamily: "'Syne', sans-serif", fontSize: '28px', fontWeight: 800, color: theme.title, letterSpacing: '-0.02em', marginBottom: '16px' }}>Check Your Email</h2>
+                    <p style={{ color: theme.body, fontSize: '15px', lineHeight: 1.7, marginBottom: '32px' }}>
+                        Registration request received! We've sent a verification link to <span style={{ fontWeight: 700, color: theme.accent }}>{formData.email}</span>.
                     </p>
-                    <div className="rounded-2xl p-6 text-left mb-8" style={{ background: '#f0fdf4', border: '1px solid #d1fae5' }}>
-                        <h4 className="font-bold mb-2 flex items-center gap-2" style={{ color: '#0f1f12' }}>
-                            <Info className="w-4 h-4" style={{ color: '#16a34a' }} /> Next Steps:
+                    <div className="rounded-2xl p-6 text-left mb-8" style={{ background: theme.subtleBg, border: `1px solid ${theme.strongBorder}` }}>
+                        <h4 className="font-bold mb-2 flex items-center gap-2" style={{ color: theme.title }}>
+                            <Info className="w-4 h-4" style={{ color: theme.accent }} /> Next Steps:
                         </h4>
-                        <ul className="space-y-3" style={{ fontSize: '14px', color: '#374151' }}>
+                        <ul className="space-y-3" style={{ fontSize: '14px', color: theme.body }}>
                             <li className="flex gap-2"><span className="font-bold">1.</span> Verify your email by clicking the link in our message.</li>
                             <li className="flex gap-2"><span className="font-bold">2.</span> Your request will be reviewed by our Master Admin.</li>
                             <li className="flex gap-2"><span className="font-bold">3.</span> You'll receive a final confirmation once approved.</li>
@@ -218,67 +241,67 @@ function AdminSignup() {
     }
 
     return (
-        <div className="min-h-screen flex overflow-hidden" style={{ fontFamily: "'Inter', sans-serif" }}>
+        <div className="min-h-screen flex overflow-hidden" style={{ fontFamily: "'Inter', sans-serif", background: theme.page }}>
 
             {/* Left Side: Branding/Hero */}
-            <div className="hidden lg:flex w-5/12 items-center justify-center p-16 relative overflow-hidden" style={{ background: 'linear-gradient(160deg, #f0fdf4 0%, #dcfce7 60%, #bbf7d0 100%)' }}>
-                <div className="absolute top-0 left-0 w-[600px] h-[600px] rounded-full pointer-events-none" style={{ background: 'radial-gradient(circle, rgba(34,160,69,0.12) 0%, transparent 70%)' }} />
+            <div className="hidden lg:flex w-5/12 items-center justify-center p-16 relative overflow-hidden" style={{ background: theme.leftBg }}>
+                <div className="absolute top-0 left-0 w-[600px] h-[600px] rounded-full pointer-events-none" style={{ background: isDark ? 'radial-gradient(circle, rgba(52,211,153,0.16) 0%, transparent 70%)' : 'radial-gradient(circle, rgba(34,160,69,0.12) 0%, transparent 70%)' }} />
 
                 {/* Back to Home */}
                 <Link to="/"
                     className="absolute top-8 left-8 flex items-center gap-2 z-10 transition-all"
-                    style={{ color: '#374151', fontWeight: 500, fontSize: '14px' }}
-                    onMouseEnter={(e) => e.currentTarget.style.color = '#16a34a'}
-                    onMouseLeave={(e) => e.currentTarget.style.color = '#374151'}
+                    style={{ color: theme.body, fontWeight: 500, fontSize: '14px' }}
+                    onMouseEnter={(e) => e.currentTarget.style.color = theme.accent}
+                    onMouseLeave={(e) => e.currentTarget.style.color = theme.body}
                 >
-                    <div className="p-2 rounded-full" style={{ background: '#ffffff', border: '1px solid #e5e7eb' }}>
+                    <div className="p-2 rounded-full" style={{ background: theme.cardBg, border: `1px solid ${theme.inputBorder}` }}>
                         <ChevronLeft className="w-4 h-4" />
                     </div>
                     <span>Back to Home</span>
                 </Link>
 
                 <div className="relative z-10 max-w-md">
-                    <div className="p-3 rounded-2xl w-fit mb-8 cursor-pointer" style={{ background: 'rgba(34,160,69,0.08)', border: '1px solid #d1fae5' }} onClick={() => navigate('/')}>
-                        <BrainCircuit className="w-10 h-10" style={{ color: '#16a34a' }} />
+                    <div className="p-3 rounded-2xl w-fit mb-8 cursor-pointer" style={{ background: theme.subtleBg, border: `1px solid ${theme.strongBorder}` }} onClick={() => navigate('/')}>
+                        <BrainCircuit className="w-10 h-10" style={{ color: theme.accent }} />
                     </div>
-                    <p style={{ color: '#16a34a', fontWeight: 700, fontSize: '11px', letterSpacing: '0.1em', textTransform: 'uppercase', marginBottom: '16px' }}>Enterprise Edition</p>
-                    <h1 style={{ fontFamily: "'Syne', sans-serif", fontSize: '42px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.03em', lineHeight: 1.1, marginBottom: '32px' }}>
-                        Scale your <span style={{ color: '#16a34a' }}>IT Support</span> globally.
+                    <p style={{ color: theme.accent, fontWeight: 700, fontSize: '11px', letterSpacing: '0.1em', textTransform: 'uppercase', marginBottom: '16px' }}>Enterprise Edition</p>
+                    <h1 style={{ fontFamily: "'Syne', sans-serif", fontSize: '42px', fontWeight: 800, color: theme.title, letterSpacing: '-0.03em', lineHeight: 1.1, marginBottom: '32px' }}>
+                        Scale your <span style={{ color: theme.accent }}>IT Support</span> globally.
                     </h1>
 
                     <div className="space-y-8">
                         {[{
-                            icon: <ShieldCheck className="w-6 h-6" style={{ color: '#16a34a' }} />,
+                            icon: <ShieldCheck className="w-6 h-6" style={{ color: theme.accent }} />,
                             title: 'Company-wide Isolation',
                             desc: 'Secure data siloing for departments and multiple office locations.'
                         }, {
-                            icon: <Building2 className="w-6 h-6" style={{ color: '#16a34a' }} />,
+                            icon: <Building2 className="w-6 h-6" style={{ color: theme.accent }} />,
                             title: 'Custom Dashboards',
                             desc: 'Tailored analytics and ticket routing for your industry specific needs.'
                         }, {
-                            icon: <User className="w-6 h-6" style={{ color: '#16a34a' }} />,
+                            icon: <User className="w-6 h-6" style={{ color: theme.accent }} />,
                             title: 'Admin Approval System',
                             desc: 'Multi-tenant architecture with human-verified vetting process.'
                         }].map((item, i) => (
                             <div key={i} className="flex gap-4 items-start">
-                                <div className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0" style={{ background: 'rgba(34,160,69,0.08)', border: '1px solid #d1fae5' }}>
+                                <div className="w-12 h-12 rounded-xl flex items-center justify-center shrink-0" style={{ background: theme.subtleBg, border: `1px solid ${theme.strongBorder}` }}>
                                     {item.icon}
                                 </div>
                                 <div>
-                                    <h4 style={{ fontWeight: 700, fontSize: '16px', color: '#0f1f12', marginBottom: '4px' }}>{item.title}</h4>
-                                    <p style={{ color: '#6b7280', fontSize: '14px', lineHeight: 1.6 }}>{item.desc}</p>
+                                    <h4 style={{ fontWeight: 700, fontSize: '16px', color: theme.title, marginBottom: '4px' }}>{item.title}</h4>
+                                    <p style={{ color: theme.muted, fontSize: '14px', lineHeight: 1.6 }}>{item.desc}</p>
                                 </div>
                             </div>
                         ))}
                     </div>
 
                     {/* System Status Badge */}
-                    <div className="mt-10" style={{ background: '#ffffff', border: '1px solid #d1fae5', borderRadius: '14px', padding: '14px 18px', boxShadow: '0 2px 12px rgba(0,0,0,0.06)' }}>
+                    <div className="mt-10" style={{ background: theme.cardBg, border: `1px solid ${theme.strongBorder}`, borderRadius: '14px', padding: '14px 18px', boxShadow: isDark ? '0 2px 12px rgba(0,0,0,0.24)' : '0 2px 12px rgba(0,0,0,0.06)' }}>
                         <div className="flex items-center gap-3">
                             <span className="inline-block w-2.5 h-2.5 rounded-full animate-pulse" style={{ background: '#22c55e' }} />
                             <div>
-                                <p style={{ fontSize: '11px', fontWeight: 600, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em' }}>System Status</p>
-                                <p style={{ fontSize: '13px', color: '#111827', fontWeight: 500 }}>All systems operational. 99.9% uptime.</p>
+                                <p style={{ fontSize: '11px', fontWeight: 600, color: theme.body, textTransform: 'uppercase', letterSpacing: '0.05em' }}>System Status</p>
+                                <p style={{ fontSize: '13px', color: theme.title, fontWeight: 500 }}>All systems operational. 99.9% uptime.</p>
                             </div>
                         </div>
                     </div>
@@ -286,14 +309,17 @@ function AdminSignup() {
             </div>
 
             {/* Right Side: Step Form */}
-            <div className="flex-1 overflow-y-auto px-4 py-8 lg:p-12 relative flex justify-center items-start lg:items-center" style={{ background: '#ffffff', borderLeft: '1px solid #f0fdf4' }}>
+            <div className="flex-1 overflow-y-auto px-4 py-8 lg:p-12 relative flex justify-center items-start lg:items-center" style={{ background: theme.rightBg, borderLeft: `1px solid ${theme.border}` }}>
+                <div className="absolute top-6 right-6 z-20">
+                    <ThemeToggle />
+                </div>
 
-                <div className="w-full max-w-2xl bg-white rounded-[2rem] p-6 md:p-12 my-auto relative z-10" style={{ boxShadow: '0 4px 40px rgba(0,0,0,0.06)', border: '1px solid #f0fdf4' }}>
+                <div className="w-full max-w-2xl rounded-[2rem] p-6 md:p-12 my-auto relative z-10" style={{ background: theme.cardBg, boxShadow: isDark ? '0 4px 40px rgba(0,0,0,0.26)' : '0 4px 40px rgba(0,0,0,0.06)', border: `1px solid ${theme.border}` }}>
 
                     {/* Progress Indicator */}
                     <div className="flex items-center justify-between mb-12 max-w-md mx-auto relative">
                         {/* Connector Line */}
-                        <div className="absolute top-1/2 left-0 w-full h-0.5 bg-gray-100 -translate-y-1/2 z-0"></div>
+                        <div className="absolute top-1/2 left-0 w-full h-0.5 bg-gray-100 -translate-y-1/2 z-0" style={{ background: isDark ? 'rgba(148, 163, 184, 0.18)' : undefined }}></div>
                         <div
                             className="absolute top-1/2 left-0 h-0.5 bg-emerald-600 -translate-y-1/2 z-0 transition-all duration-500"
                             style={{ width: `${(step - 1) * 50}%` }}
@@ -304,14 +330,14 @@ function AdminSignup() {
                                 <div style={{
                                     width: '40px', height: '40px', borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center',
                                     fontWeight: 700, fontSize: '14px', transition: 'all 0.3s',
-                                    background: step >= s ? 'linear-gradient(135deg,#16a34a,#22c55e)' : '#f9fafb',
-                                    color: step >= s ? '#fff' : '#9ca3af',
-                                    border: step >= s ? 'none' : '2px solid #e5e7eb',
+                                    background: step >= s ? 'linear-gradient(135deg,#16a34a,#22c55e)' : theme.inputBg,
+                                    color: step >= s ? '#fff' : theme.muted,
+                                    border: step >= s ? 'none' : `2px solid ${theme.inputBorder}`,
                                     boxShadow: step >= s ? '0 4px 12px rgba(34,160,69,0.25)' : 'none'
                                 }}>
                                     {step > s ? <CheckCircle2 className="w-5 h-5" /> : s}
                                 </div>
-                                <span style={{ fontSize: '10px', textTransform: 'uppercase', fontWeight: 700, letterSpacing: '0.08em', color: step >= s ? '#16a34a' : '#9ca3af' }}>
+                                <span style={{ fontSize: '10px', textTransform: 'uppercase', fontWeight: 700, letterSpacing: '0.08em', color: step >= s ? theme.accent : theme.muted }}>
                                     {s === 1 ? "Personal" : s === 2 ? "Company" : "Agreement"}
                                 </span>
                             </div>

--- a/Frontend/src/pages/LandingPage.jsx
+++ b/Frontend/src/pages/LandingPage.jsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import useAuthStore from '../store/authStore';
 import TeamSection from '../components/landing/TeamSection';
+import ThemeToggle from '../components/shared/ThemeToggle';
 
 // ---- Count-up animation component ----
 function AnimatedStat({ target, suffix = '', prefix = '', label, isWord = false }) {
@@ -273,37 +274,38 @@ export default function LandingPage() {
     };
 
     return (
-        <div className="min-h-screen bg-white font-sans text-slate-800">
+        <div className="min-h-screen bg-white font-sans text-slate-800 transition-colors duration-200 dark:bg-[#07140f] dark:text-slate-100">
             {showDemo && <DemoModal onClose={() => setShowDemo(false)} />}
 
             {/* ==================== NAV ==================== */}
-            <nav className="sticky top-0 z-50 bg-white/90 backdrop-blur-md border-b border-gray-100 shadow-sm">
+            <nav className="sticky top-0 z-50 bg-white/90 backdrop-blur-md border-b border-gray-100 shadow-sm transition-colors duration-200 dark:bg-[#061a13]/95 dark:border-emerald-900/40 dark:shadow-black/30">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div className="flex justify-between items-center h-16">
                         {/* Logo */}
                         <div className="flex items-center gap-2 cursor-pointer" onClick={() => navigate('/')}>
                             <img src="/favicon.png" alt="H" className="w-8 h-8 object-contain" />
-                            <span className="font-black text-2xl tracking-tighter text-emerald-900 italic uppercase">HelpDesk.ai</span>
+                            <span className="font-black text-2xl tracking-tighter text-emerald-900 italic uppercase dark:text-emerald-300">HelpDesk.ai</span>
                         </div>
 
                         {/* Desktop Links */}
                         <div className="hidden md:flex items-center gap-8">
-                            <a href="#features" className="text-sm font-semibold text-gray-600 hover:text-emerald-800 transition-colors">Features</a>
-                            <a href="#how-it-works" className="text-sm font-semibold text-gray-600 hover:text-emerald-800 transition-colors">How It Works</a>
-                            <a href="#pricing" className="text-sm font-semibold text-gray-600 hover:text-emerald-800 transition-colors">Pricing</a>
+                            <a href="#features" className="text-sm font-semibold text-gray-600 hover:text-emerald-800 transition-colors dark:text-slate-300 dark:hover:text-emerald-300">Features</a>
+                            <a href="#how-it-works" className="text-sm font-semibold text-gray-600 hover:text-emerald-800 transition-colors dark:text-slate-300 dark:hover:text-emerald-300">How It Works</a>
+                            <a href="#pricing" className="text-sm font-semibold text-gray-600 hover:text-emerald-800 transition-colors dark:text-slate-300 dark:hover:text-emerald-300">Pricing</a>
                         </div>
 
                         {/* CTA Buttons */}
                         <div className="hidden md:flex items-center gap-3">
+                            <ThemeToggle />
                             <button
                                 onClick={() => navigate('/login')}
-                                className="text-sm font-semibold text-gray-700 hover:text-emerald-800 transition-colors px-4 py-2 rounded-lg hover:bg-gray-50"
+                                className="text-sm font-semibold text-gray-700 hover:text-emerald-800 transition-colors px-4 py-2 rounded-lg hover:bg-gray-50 dark:text-slate-200 dark:hover:bg-white/10 dark:hover:text-emerald-300"
                             >
                                 Sign In
                             </button>
                             <button
                                 onClick={() => setShowDemo(true)}
-                                className="text-sm font-semibold text-emerald-800 border border-emerald-200 px-4 py-2 rounded-lg hover:bg-emerald-50 transition-all flex items-center gap-1.5"
+                                className="text-sm font-semibold text-emerald-800 border border-emerald-200 px-4 py-2 rounded-lg hover:bg-emerald-50 transition-all flex items-center gap-1.5 dark:border-emerald-500/30 dark:text-emerald-300 dark:hover:bg-emerald-500/10"
                             >
                                 <Play className="w-3.5 h-3.5 fill-emerald-700" /> Watch Demo
                             </button>
@@ -316,8 +318,9 @@ export default function LandingPage() {
                         </div>
 
                         {/* Mobile Menu Button */}
-                        <div className="md:hidden">
-                            <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="text-gray-600 hover:text-emerald-800 p-2">
+                        <div className="md:hidden flex items-center gap-2">
+                            <ThemeToggle />
+                            <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="text-gray-600 hover:text-emerald-800 p-2 dark:text-slate-200 dark:hover:text-emerald-300">
                                 {isMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
                             </button>
                         </div>
@@ -326,16 +329,16 @@ export default function LandingPage() {
 
                 {/* Mobile Menu */}
                 {isMenuOpen && (
-                    <div className="md:hidden bg-white border-t border-gray-100 absolute w-full shadow-xl z-50">
+                    <div className="md:hidden bg-white border-t border-gray-100 absolute w-full shadow-xl z-50 dark:bg-[#061a13] dark:border-emerald-900/40">
                         <div className="px-5 pt-3 pb-6 space-y-4">
-                            <a href="#features" onClick={() => setIsMenuOpen(false)} className="block text-base font-semibold text-gray-700 hover:text-emerald-800 py-2">Features</a>
-                            <a href="#how-it-works" onClick={() => setIsMenuOpen(false)} className="block text-base font-semibold text-gray-700 hover:text-emerald-800 py-2">How It Works</a>
-                            <a href="#pricing" onClick={() => setIsMenuOpen(false)} className="block text-base font-semibold text-gray-700 hover:text-emerald-800 py-2">Pricing</a>
-                            <div className="pt-4 flex flex-col gap-3 border-t border-gray-100">
+                            <a href="#features" onClick={() => setIsMenuOpen(false)} className="block text-base font-semibold text-gray-700 hover:text-emerald-800 py-2 dark:text-slate-200 dark:hover:text-emerald-300">Features</a>
+                            <a href="#how-it-works" onClick={() => setIsMenuOpen(false)} className="block text-base font-semibold text-gray-700 hover:text-emerald-800 py-2 dark:text-slate-200 dark:hover:text-emerald-300">How It Works</a>
+                            <a href="#pricing" onClick={() => setIsMenuOpen(false)} className="block text-base font-semibold text-gray-700 hover:text-emerald-800 py-2 dark:text-slate-200 dark:hover:text-emerald-300">Pricing</a>
+                            <div className="pt-4 flex flex-col gap-3 border-t border-gray-100 dark:border-emerald-900/40">
                                 <button onClick={() => { setIsMenuOpen(false); setShowDemo(true); }} className="w-full text-center py-2.5 text-emerald-800 font-semibold border border-emerald-200 rounded-lg flex items-center justify-center gap-2">
                                     <Play className="w-4 h-4 fill-emerald-700" /> Watch Demo
                                 </button>
-                                <button onClick={() => navigate('/login')} className="w-full text-center py-2.5 text-gray-700 font-semibold border border-gray-100 rounded-lg">
+                                <button onClick={() => navigate('/login')} className="w-full text-center py-2.5 text-gray-700 font-semibold border border-gray-100 rounded-lg dark:border-emerald-900/40 dark:text-slate-200">
                                     Sign In
                                 </button>
                                 <button onClick={() => navigate('/admin-signup')} className="w-full bg-emerald-900 text-white py-3 rounded-lg font-semibold shadow">
@@ -349,20 +352,20 @@ export default function LandingPage() {
 
             {/* ==================== HERO ==================== */}
             <section className="relative pt-12 md:pt-20 pb-20 md:pb-32 overflow-hidden">
-                <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full h-[300px] md:h-[600px] bg-gradient-to-b from-green-50/80 to-transparent pointer-events-none -z-10" />
+                <div className="absolute top-0 left-1/2 -translate-x-1/2 w-full h-[300px] md:h-[600px] bg-gradient-to-b from-green-50/80 to-transparent pointer-events-none -z-10 dark:from-emerald-950/70" />
 
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
-                    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-50 border border-emerald-100 text-emerald-700 text-xs font-bold uppercase tracking-wider mb-8">
+                    <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-50 border border-emerald-100 text-emerald-700 text-xs font-bold uppercase tracking-wider mb-8 dark:bg-emerald-400/10 dark:border-emerald-400/20 dark:text-emerald-300">
                         <Activity className="w-3 h-3" />
                         <span>AI-Powered Helpdesk Automation · Made in India 🇮🇳</span>
                     </div>
 
-                    <h1 className="text-4xl sm:text-5xl md:text-7xl font-extrabold text-gray-900 tracking-tight mb-6 leading-[1.1]">
+                    <h1 className="text-4xl sm:text-5xl md:text-7xl font-extrabold text-gray-900 tracking-tight mb-6 leading-[1.1] dark:text-white">
                         Your IT Helpdesk,<br />
                         <span className="text-emerald-700">Fully Automated.</span>
                     </h1>
 
-                    <p className="max-w-2xl mx-auto text-lg md:text-xl text-gray-500 mb-10 leading-relaxed">
+                    <p className="max-w-2xl mx-auto text-lg md:text-xl text-gray-500 mb-10 leading-relaxed dark:text-slate-300">
                         Turn messy user complaints into structured, categorized, and prioritized support tickets — instantly. No manual triage. No missed urgencies.
                     </p>
 
@@ -375,7 +378,7 @@ export default function LandingPage() {
                         </button>
                         <button
                             onClick={() => setShowDemo(true)}
-                            className="w-full sm:w-auto px-8 py-4 bg-white text-gray-700 border border-gray-200 rounded-xl font-semibold hover:border-emerald-500 hover:text-emerald-700 transition-all flex items-center justify-center gap-2 text-base"
+                            className="w-full sm:w-auto px-8 py-4 bg-white text-gray-700 border border-gray-200 rounded-xl font-semibold hover:border-emerald-500 hover:text-emerald-700 transition-all flex items-center justify-center gap-2 text-base dark:bg-white/10 dark:text-slate-100 dark:border-white/15 dark:hover:border-emerald-400 dark:hover:text-emerald-300"
                         >
                             <Play className="w-4 h-4 fill-gray-500" /> Watch a Demo
                         </button>
@@ -509,17 +512,17 @@ export default function LandingPage() {
             </section>
 
             {/* ==================== FEATURES GRID ==================== */}
-            <section className="py-24 bg-white" id="features">
+            <section className="py-24 bg-white dark:bg-[#07140f]" id="features">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div className="text-center mb-16">
                         <span className="text-xs font-bold tracking-widest text-emerald-700 uppercase mb-3 block">Core Intelligence</span>
-                        <h2 className="text-3xl md:text-5xl font-extrabold text-gray-900 tracking-tight">Work Smarter, Not Harder</h2>
-                        <p className="text-gray-500 mt-4 text-lg max-w-xl mx-auto">Three AI capabilities that eliminate manual helpdesk work.</p>
+                        <h2 className="text-3xl md:text-5xl font-extrabold text-gray-900 tracking-tight dark:text-white">Work Smarter, Not Harder</h2>
+                        <p className="text-gray-500 mt-4 text-lg max-w-xl mx-auto dark:text-slate-300">Three AI capabilities that eliminate manual helpdesk work.</p>
                     </div>
 
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                         {/* Card 1: Auto-Categorization */}
-                        <div className="group rounded-3xl bg-gray-50 border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-gray-200/50 transition-all duration-300 hover:-translate-y-1">
+                        <div className="group rounded-3xl bg-gray-50 border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-gray-200/50 transition-all duration-300 hover:-translate-y-1 dark:bg-[#0f1f18] dark:border-emerald-900/30 dark:hover:shadow-black/30">
                             <div className="h-52 bg-gradient-to-br from-blue-50 to-gray-50 p-6 flex items-center justify-center relative overflow-hidden">
                                 <div className="relative z-10 flex flex-col gap-3 items-center">
                                     <div className="bg-white px-4 py-2 rounded-lg shadow-sm border border-gray-200 text-xs font-bold text-gray-400 flex items-center gap-2 transform -translate-x-4 opacity-60">
@@ -540,8 +543,8 @@ export default function LandingPage() {
                                 </div>
                             </div>
                             <div className="p-8">
-                                <h3 className="text-xl font-bold text-gray-900 mb-3">Auto-Categorization</h3>
-                                <p className="text-gray-500 leading-relaxed mb-6">
+                                <h3 className="text-xl font-bold text-gray-900 mb-3 dark:text-white">Auto-Categorization</h3>
+                                <p className="text-gray-500 leading-relaxed mb-6 dark:text-slate-300">
                                     Instantly detects if an issue is Network, Hardware, Software, or Access-related — no manual tagging.
                                 </p>
                                 <button
@@ -554,7 +557,7 @@ export default function LandingPage() {
                         </div>
 
                         {/* Card 2: Priority Detection */}
-                        <div className="group rounded-3xl bg-gray-50 border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-gray-200/50 transition-all duration-300 hover:-translate-y-1">
+                        <div className="group rounded-3xl bg-gray-50 border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-gray-200/50 transition-all duration-300 hover:-translate-y-1 dark:bg-[#0f1f18] dark:border-emerald-900/30 dark:hover:shadow-black/30">
                             <div className="h-52 bg-gradient-to-br from-red-50 to-orange-50 p-6 flex items-center justify-center relative overflow-hidden">
                                 <div className="relative z-10 w-full max-w-[200px] space-y-2.5">
                                     <div className="bg-white p-2.5 rounded-lg border border-gray-200 shadow-sm flex items-center justify-between opacity-50 scale-95">
@@ -581,8 +584,8 @@ export default function LandingPage() {
                                 </div>
                             </div>
                             <div className="p-8">
-                                <h3 className="text-xl font-bold text-gray-900 mb-3">Priority Detection</h3>
-                                <p className="text-gray-500 leading-relaxed mb-6">
+                                <h3 className="text-xl font-bold text-gray-900 mb-3 dark:text-white">Priority Detection</h3>
+                                <p className="text-gray-500 leading-relaxed mb-6 dark:text-slate-300">
                                     Understands urgency signals in text and automatically flags issues from Low to Critical.
                                 </p>
                                 <button
@@ -595,7 +598,7 @@ export default function LandingPage() {
                         </div>
 
                         {/* Card 3: Smart Resolution */}
-                        <div className="group rounded-3xl bg-gray-50 border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-gray-200/50 transition-all duration-300 hover:-translate-y-1">
+                        <div className="group rounded-3xl bg-gray-50 border border-gray-100 overflow-hidden hover:shadow-xl hover:shadow-gray-200/50 transition-all duration-300 hover:-translate-y-1 dark:bg-[#0f1f18] dark:border-emerald-900/30 dark:hover:shadow-black/30">
                             <div className="h-52 bg-gradient-to-br from-emerald-50 to-teal-50 p-6 flex items-center justify-center relative overflow-hidden">
                                 <div className="relative z-10 w-full max-w-[200px] flex flex-col gap-3">
                                     <div className="self-end bg-emerald-600 text-white p-2.5 rounded-2xl rounded-tr-none shadow-sm text-[10px] max-w-[80%]">
@@ -616,8 +619,8 @@ export default function LandingPage() {
                                 </div>
                             </div>
                             <div className="p-8">
-                                <h3 className="text-xl font-bold text-gray-900 mb-3">Smart Resolution</h3>
-                                <p className="text-gray-500 leading-relaxed mb-6">
+                                <h3 className="text-xl font-bold text-gray-900 mb-3 dark:text-white">Smart Resolution</h3>
+                                <p className="text-gray-500 leading-relaxed mb-6 dark:text-slate-300">
                                     Checks historical data to auto-fix simple issues, or routes complex ones to the right human team.
                                 </p>
                                 <button
@@ -717,14 +720,14 @@ export default function LandingPage() {
             </section>
 
             {/* ==================== PRICING ==================== */}
-            <section className="py-24 bg-gray-50" id="pricing">
+            <section className="py-24 bg-gray-50 dark:bg-[#0b1712]" id="pricing">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div className="text-center mb-12">
-                        <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 mb-4">Simple, Transparent Pricing</h2>
-                        <p className="text-gray-500 mb-8">All plans in Indian Rupees (₹) · GST applicable</p>
+                        <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 mb-4 dark:text-white">Simple, Transparent Pricing</h2>
+                        <p className="text-gray-500 mb-8 dark:text-slate-400">All plans in Indian Rupees (₹) · GST applicable</p>
 
                         {/* Billing Toggle */}
-                        <div className="inline-flex items-center gap-3 bg-white border border-gray-200 rounded-full px-2 py-2 shadow-sm">
+                        <div className="inline-flex items-center gap-3 bg-white border border-gray-200 rounded-full px-2 py-2 shadow-sm dark:bg-[#0f1f18] dark:border-emerald-900/30">
                             <button
                                 onClick={() => setBillingAnnual(false)}
                                 className={`px-5 py-2 rounded-full text-sm font-semibold transition-all ${!billingAnnual ? 'bg-emerald-900 text-white shadow' : 'text-gray-500 hover:text-gray-700'}`}
@@ -744,18 +747,18 @@ export default function LandingPage() {
                         {pricingPlans.map(({ name, price, priceLabel, period, desc, cta, ctaStyle, features, popular }) => (
                             <div
                                 key={name}
-                                className={`p-8 rounded-2xl bg-white transition-all relative ${popular ? 'border-2 border-emerald-900 shadow-2xl shadow-emerald-900/10 scale-[1.02]' : 'border border-gray-200 hover:border-gray-300'}`}
+                                className={`p-8 rounded-2xl bg-white transition-all relative dark:bg-[#0f1f18] ${popular ? 'border-2 border-emerald-900 shadow-2xl shadow-emerald-900/10 scale-[1.02] dark:border-emerald-400/70' : 'border border-gray-200 hover:border-gray-300 dark:border-emerald-900/30 dark:hover:border-emerald-500/40'}`}
                             >
                                 {popular && (
                                     <div className="absolute -top-4 left-1/2 -translate-x-1/2 bg-emerald-900 text-white px-4 py-1.5 rounded-full text-xs font-bold tracking-wide whitespace-nowrap shadow-lg">
                                         ⭐ MOST POPULAR
                                     </div>
                                 )}
-                                <h3 className="text-lg font-bold text-gray-900 mb-2">{name}</h3>
-                                <div className="text-4xl font-extrabold text-gray-900 mb-2">
-                                    {priceLabel ? priceLabel : <>₹{price.toLocaleString('en-IN')}<span className="text-base font-normal text-gray-500">{period}</span></>}
+                                <h3 className="text-lg font-bold text-gray-900 mb-2 dark:text-white">{name}</h3>
+                                <div className="text-4xl font-extrabold text-gray-900 mb-2 dark:text-white">
+                                    {priceLabel ? priceLabel : <>₹{price.toLocaleString('en-IN')}<span className="text-base font-normal text-gray-500 dark:text-slate-400">{period}</span></>}
                                 </div>
-                                <p className="text-sm text-gray-500 mb-6">{desc}</p>
+                                <p className="text-sm text-gray-500 mb-6 dark:text-slate-400">{desc}</p>
                                 <button
                                     onClick={() => handlePricingClick(name)}
                                     disabled={isRedirecting && name === 'Growth'}
@@ -772,7 +775,7 @@ export default function LandingPage() {
                                 </button>
                                 <ul className="space-y-3">
                                     {features.map(feat => (
-                                        <li key={feat} className="flex items-start gap-3 text-sm text-gray-600">
+                                        <li key={feat} className="flex items-start gap-3 text-sm text-gray-600 dark:text-slate-300">
                                             <CheckCircle className="w-5 h-5 text-emerald-700 shrink-0 mt-px" />
                                             {feat}
                                         </li>

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -4,6 +4,8 @@ import { useNavigate, Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import useAuthStore from "../store/authStore";
 import { Eye, EyeOff, BrainCircuit, ArrowRight, Loader2, ArrowLeft } from "lucide-react";
+import ThemeToggle from "../components/shared/ThemeToggle";
+import { useTheme } from "../components/shared/ThemeProvider";
 
 function Login() {
   const [email, setEmail] = useState("");
@@ -16,6 +18,26 @@ function Login() {
 
   const navigate = useNavigate();
   const { login, signInWithMagicLink, loading, user, profile } = useAuthStore();
+  const { isDark } = useTheme();
+
+  const theme = {
+    page: isDark ? '#07140f' : '#ffffff',
+    leftBg: isDark
+      ? 'linear-gradient(160deg, #061a13 0%, #0f2a1d 58%, #123d28 100%)'
+      : 'linear-gradient(160deg, #f0fdf4 0%, #dcfce7 60%, #bbf7d0 100%)',
+    rightBg: isDark ? '#0b1712' : '#ffffff',
+    panelBorder: isDark ? '1px solid rgba(52, 211, 153, 0.16)' : '1px solid #f0fdf4',
+    title: isDark ? '#f8fafc' : '#0f1f12',
+    body: isDark ? '#cbd5e1' : '#374151',
+    muted: isDark ? '#94a3b8' : '#6b7280',
+    inputBg: isDark ? '#102219' : '#f9fafb',
+    inputBorder: isDark ? 'rgba(148, 163, 184, 0.24)' : '#e5e7eb',
+    cardBg: isDark ? 'rgba(15, 31, 24, 0.94)' : '#ffffff',
+    cardBorder: isDark ? 'rgba(52, 211, 153, 0.24)' : '#d1fae5',
+    softGreen: isDark ? 'rgba(16, 185, 129, 0.12)' : '#f0fdf4',
+    accent: isDark ? '#34d399' : '#16a34a',
+    accentStrong: isDark ? '#86efac' : '#15803d',
+  };
 
   // Auto-redirect if already logged in
   useEffect(() => {
@@ -101,20 +123,20 @@ function Login() {
   const currentSubmitHandler = isMagicLink ? handleMagicLink : handleLogin;
 
   return (
-    <div className="min-h-screen flex" style={{ fontFamily: "'Inter', sans-serif" }}>
+    <div className="min-h-screen flex" style={{ fontFamily: "'Inter', sans-serif", background: theme.page }}>
 
       {/* ── Left Panel ── */}
       <div
         className="hidden lg:flex w-1/2 items-center justify-center p-12 relative overflow-hidden"
         style={{
-          background: 'linear-gradient(160deg, #f0fdf4 0%, #dcfce7 60%, #bbf7d0 100%)',
+          background: theme.leftBg,
         }}
       >
         {/* Radial glow */}
         <div
           className="absolute top-0 left-0 w-[600px] h-[600px] rounded-full pointer-events-none"
           style={{
-            background: 'radial-gradient(circle, rgba(34,160,69,0.12) 0%, transparent 70%)',
+            background: isDark ? 'radial-gradient(circle, rgba(52,211,153,0.16) 0%, transparent 70%)' : 'radial-gradient(circle, rgba(34,160,69,0.12) 0%, transparent 70%)',
           }}
         />
 
@@ -122,9 +144,9 @@ function Login() {
           {/* Logo / Icon */}
           <div
             className="p-3 rounded-2xl w-fit mb-8"
-            style={{ background: 'rgba(34,160,69,0.08)', border: '1px solid #d1fae5' }}
+            style={{ background: theme.softGreen, border: theme.cardBorder }}
           >
-            <BrainCircuit className="w-10 h-10" style={{ color: '#16a34a' }} />
+            <BrainCircuit className="w-10 h-10" style={{ color: theme.accent }} />
           </div>
 
           {/* Headline */}
@@ -133,44 +155,44 @@ function Login() {
               fontFamily: "'Syne', sans-serif",
               fontSize: '48px',
               fontWeight: 800,
-              color: '#0f1f12',
+              color: theme.title,
               letterSpacing: '-0.03em',
               lineHeight: 1.1,
               marginBottom: '24px',
             }}
           >
             Automate your{' '}
-            <span style={{ color: '#16a34a' }}>IT Support</span>
+            <span style={{ color: theme.accent }}>IT Support</span>
           </h1>
 
           {/* Subtext */}
-          <p style={{ color: '#374151', fontSize: '16px', lineHeight: 1.7, marginBottom: '32px' }}>
+          <p style={{ color: theme.body, fontSize: '16px', lineHeight: 1.7, marginBottom: '32px' }}>
             Join thousands of IT teams using HelpDesk.ai to categorize, route, and resolve tickets instantly.
           </p>
 
           {/* System Status Badge */}
           <div
             style={{
-              background: '#ffffff',
-              border: '1px solid #d1fae5',
+              background: theme.cardBg,
+              border: theme.cardBorder,
               borderRadius: '14px',
               padding: '14px 18px',
               boxShadow: '0 2px 12px rgba(0,0,0,0.06)',
             }}
           >
             <div className="flex gap-4 items-start">
-              <div className="w-10 h-10 rounded-full flex items-center justify-center shrink-0" style={{ background: '#f0fdf4' }}>
-                <div style={{ color: '#0f1f12', fontWeight: 800, fontSize: '14px' }}>AI</div>
+              <div className="w-10 h-10 rounded-full flex items-center justify-center shrink-0" style={{ background: theme.softGreen }}>
+                <div style={{ color: theme.title, fontWeight: 800, fontSize: '14px' }}>AI</div>
               </div>
               <div>
-                <p className="flex items-center gap-2" style={{ fontSize: '12px', fontWeight: 600, color: '#374151', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '4px' }}>
+                <p className="flex items-center gap-2" style={{ fontSize: '12px', fontWeight: 600, color: theme.body, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '4px' }}>
                   <span
                     className="inline-block w-2 h-2 rounded-full animate-pulse"
                     style={{ background: '#22c55e' }}
                   />
                   System Status
                 </p>
-                <p style={{ color: '#111827', fontWeight: 500, fontSize: '14px' }}>All systems operational. 99.9% uptime this month.</p>
+                <p style={{ color: theme.title, fontWeight: 500, fontSize: '14px' }}>All systems operational. 99.9% uptime this month.</p>
               </div>
             </div>
           </div>
@@ -180,17 +202,21 @@ function Login() {
       {/* ── Right Panel ── */}
       <div
         className="flex w-full lg:w-1/2 items-center justify-center p-6 relative"
-        style={{ background: '#ffffff', borderLeft: '1px solid #f0fdf4' }}
+        style={{ background: theme.rightBg, borderLeft: theme.panelBorder }}
       >
+        <div className="absolute top-8 right-8">
+          <ThemeToggle />
+        </div>
+
         {/* Back Button */}
         <Link
           to="/"
           className="absolute top-8 left-8 flex items-center gap-2 transition-all group"
-          style={{ color: '#374151', fontWeight: 500, fontSize: '14px' }}
-          onMouseEnter={(e) => e.currentTarget.style.color = '#16a34a'}
-          onMouseLeave={(e) => e.currentTarget.style.color = '#374151'}
+          style={{ color: theme.body, fontWeight: 500, fontSize: '14px' }}
+          onMouseEnter={(e) => e.currentTarget.style.color = theme.accent}
+          onMouseLeave={(e) => e.currentTarget.style.color = theme.body}
         >
-          <div className="p-2 rounded-full transition-all" style={{ background: '#f9fafb', border: '1px solid #e5e7eb' }}>
+          <div className="p-2 rounded-full transition-all" style={{ background: theme.inputBg, border: `1px solid ${theme.inputBorder}` }}>
             <ArrowLeft className="w-4 h-4" />
           </div>
           <span>Back to Home</span>
@@ -204,14 +230,14 @@ function Login() {
                 fontFamily: "'Syne', sans-serif",
                 fontSize: '28px',
                 fontWeight: 800,
-                color: '#0f1f12',
+                color: theme.title,
                 letterSpacing: '-0.02em',
                 marginBottom: '8px',
               }}
             >
               Welcome Back
             </h2>
-            <p style={{ color: '#6b7280', fontSize: '14px' }}>Please sign in to continue</p>
+            <p style={{ color: theme.muted, fontSize: '14px' }}>Please sign in to continue</p>
           </div>
 
           {/* Role Toggle Removed */}
@@ -230,12 +256,12 @@ function Login() {
               <div className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6" style={{ background: '#f0fdf4', border: '1px solid #d1fae5' }}>
                 <BrainCircuit className="w-8 h-8" style={{ color: '#16a34a' }} />
               </div>
-              <h3 style={{ fontSize: '20px', fontWeight: 700, color: '#0f1f12', marginBottom: '8px' }}>Check your email</h3>
-              <p style={{ color: '#6b7280', fontSize: '14px', marginBottom: '24px' }}>We've sent a magic link to <span style={{ fontWeight: 600, color: '#111827' }}>{email}</span></p>
+              <h3 style={{ fontSize: '20px', fontWeight: 700, color: theme.title, marginBottom: '8px' }}>Check your email</h3>
+              <p style={{ color: theme.muted, fontSize: '14px', marginBottom: '24px' }}>We've sent a magic link to <span style={{ fontWeight: 600, color: theme.title }}>{email}</span></p>
               <button
                 onClick={() => setMagicLinkSent(false)}
                 className="hover:underline transition-all"
-                style={{ color: '#16a34a', fontWeight: 700, fontSize: '14px', background: 'none', border: 'none', cursor: 'pointer' }}
+                style={{ color: theme.accent, fontWeight: 700, fontSize: '14px', background: 'none', border: 'none', cursor: 'pointer' }}
               >
                 Try another email
               </button>
@@ -246,7 +272,7 @@ function Login() {
               <div>
                 <label
                   className="block mb-2"
-                  style={{ fontSize: '12px', fontWeight: 600, color: '#374151', letterSpacing: '0.05em', textTransform: 'uppercase' }}
+                  style={{ fontSize: '12px', fontWeight: 600, color: theme.body, letterSpacing: '0.05em', textTransform: 'uppercase' }}
                 >
                   Email Address
                 </label>
@@ -255,17 +281,17 @@ function Login() {
                   placeholder="Enter your system email"
                   style={{
                     width: '100%',
-                    background: '#f9fafb',
-                    border: '1.5px solid #e5e7eb',
+                    background: theme.inputBg,
+                    border: `1.5px solid ${theme.inputBorder}`,
                     borderRadius: '12px',
                     padding: '13px 16px',
                     fontSize: '15px',
-                    color: '#111827',
+                    color: theme.title,
                     outline: 'none',
                     transition: 'border-color 0.2s, box-shadow 0.2s',
                   }}
                   onFocus={(e) => { e.target.style.borderColor = '#22c55e'; e.target.style.boxShadow = '0 0 0 3px rgba(34,160,69,0.1)'; }}
-                  onBlur={(e) => { e.target.style.borderColor = '#e5e7eb'; e.target.style.boxShadow = 'none'; }}
+                  onBlur={(e) => { e.target.style.borderColor = theme.inputBorder; e.target.style.boxShadow = 'none'; }}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                 />
@@ -277,7 +303,7 @@ function Login() {
                   <div className="flex justify-between items-center mb-2">
                     <label
                       className="block"
-                      style={{ fontSize: '12px', fontWeight: 600, color: '#374151', letterSpacing: '0.05em', textTransform: 'uppercase' }}
+                      style={{ fontSize: '12px', fontWeight: 600, color: theme.body, letterSpacing: '0.05em', textTransform: 'uppercase' }}
                     >
                       Password
                     </label>
@@ -285,7 +311,7 @@ function Login() {
                       to="/forgot-password"
                       title="Reset your password"
                       className="transition-all"
-                      style={{ fontSize: '12px', fontWeight: 600, color: '#16a34a' }}
+                      style={{ fontSize: '12px', fontWeight: 600, color: theme.accent }}
                     >
                       Forgot password?
                     </Link>
@@ -296,18 +322,18 @@ function Login() {
                       placeholder="Enter your password"
                       style={{
                         width: '100%',
-                        background: '#f9fafb',
-                        border: '1.5px solid #e5e7eb',
+                        background: theme.inputBg,
+                        border: `1.5px solid ${theme.inputBorder}`,
                         borderRadius: '12px',
                         padding: '13px 16px',
                         paddingRight: '44px',
                         fontSize: '15px',
-                        color: '#111827',
+                        color: theme.title,
                         outline: 'none',
                         transition: 'border-color 0.2s, box-shadow 0.2s',
                       }}
                       onFocus={(e) => { e.target.style.borderColor = '#22c55e'; e.target.style.boxShadow = '0 0 0 3px rgba(34,160,69,0.1)'; }}
-                      onBlur={(e) => { e.target.style.borderColor = '#e5e7eb'; e.target.style.boxShadow = 'none'; }}
+                      onBlur={(e) => { e.target.style.borderColor = theme.inputBorder; e.target.style.boxShadow = 'none'; }}
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
                     />
@@ -349,9 +375,9 @@ function Login() {
 
               {/* Divider */}
               <div className="relative flex items-center py-2">
-                <div className="flex-grow" style={{ borderTop: '1px solid #e5e7eb' }}></div>
-                <span className="flex-shrink-0 mx-4" style={{ color: '#9ca3af', fontSize: '13px', fontWeight: 500 }}>Or</span>
-                <div className="flex-grow" style={{ borderTop: '1px solid #e5e7eb' }}></div>
+                <div className="flex-grow" style={{ borderTop: `1px solid ${theme.inputBorder}` }}></div>
+                <span className="flex-shrink-0 mx-4" style={{ color: theme.muted, fontSize: '13px', fontWeight: 500 }}>Or</span>
+                <div className="flex-grow" style={{ borderTop: `1px solid ${theme.inputBorder}` }}></div>
               </div>
 
               {/* Magic Link Toggle */}
@@ -360,9 +386,9 @@ function Login() {
                 onClick={() => { setIsMagicLink(!isMagicLink); setError(""); }}
                 className="w-full flex items-center justify-center gap-2 transition-all"
                 style={{
-                  background: '#ffffff',
-                  border: '1.5px solid #d1fae5',
-                  color: '#15803d',
+                  background: theme.cardBg,
+                  border: `1.5px solid ${isDark ? 'rgba(52, 211, 153, 0.3)' : '#d1fae5'}`,
+                  color: theme.accentStrong,
                   borderRadius: '12px',
                   padding: '13px',
                   fontWeight: 500,
@@ -370,16 +396,16 @@ function Login() {
                   cursor: 'pointer',
                   transition: 'background 0.2s',
                 }}
-                onMouseEnter={(e) => e.currentTarget.style.background = '#f0fdf4'}
-                onMouseLeave={(e) => e.currentTarget.style.background = '#ffffff'}
+                onMouseEnter={(e) => e.currentTarget.style.background = theme.softGreen}
+                onMouseLeave={(e) => e.currentTarget.style.background = theme.cardBg}
               >
                 {isMagicLink ? "Sign in with Password" : "Sign in with Magic Link"}
               </button>
 
               {/* Create Account */}
-              <p className="text-center" style={{ fontSize: '14px', color: '#6b7280', marginTop: '32px' }}>
+              <p className="text-center" style={{ fontSize: '14px', color: theme.muted, marginTop: '32px' }}>
                 Don't have an account?{" "}
-                <Link to="/signup" className="hover:underline transition-all" style={{ color: '#16a34a', fontWeight: 600 }}>
+                <Link to="/signup" className="hover:underline transition-all" style={{ color: theme.accent, fontWeight: 600 }}>
                   Create Account
                 </Link>
               </p>

--- a/Frontend/src/user/UserLayout.jsx
+++ b/Frontend/src/user/UserLayout.jsx
@@ -5,7 +5,7 @@ import NotificationToast from './components/NotificationToast';
 
 const UserLayout = () => {
     return (
-        <div className="bg-[#f6f8f7] min-h-screen flex flex-col text-slate-900 transition-colors duration-200 antialiased font-sans">
+        <div className="bg-[#f6f8f7] min-h-screen flex flex-col text-slate-900 transition-colors duration-200 antialiased font-sans dark:bg-[#07140f] dark:text-slate-100">
             <TopNav />
             {/* The routed content like Dashboard or CreateTicket will render here */}
             <Outlet />

--- a/Frontend/src/user/components/TopNav.jsx
+++ b/Frontend/src/user/components/TopNav.jsx
@@ -10,6 +10,7 @@ import useTicketStore from "../../store/ticketStore";
 import NotificationPopover from "./NotificationPopover";
 
 import useAuthStore from "../../store/authStore";
+import ThemeToggle from "../../components/shared/ThemeToggle";
 
 const TopNav = () => {
     const navigate = useNavigate();
@@ -28,26 +29,27 @@ const TopNav = () => {
 
 
     return (
-        <header className="w-full bg-white border-b border-gray-200 sticky top-0 z-50">
+        <header className="w-full bg-white border-b border-gray-200 sticky top-0 z-50 transition-colors duration-200 dark:bg-[#061a13] dark:border-emerald-900/40">
             <div className="max-w-[1100px] mx-auto px-4 md:px-6 h-16 flex items-center justify-between">
                 {/* Left: Logo */}
                 <div className="flex items-center gap-3 cursor-pointer" onClick={() => navigate('/dashboard')}>
                     <div className="flex items-center justify-center overflow-hidden">
                         <img src="/favicon.png" alt="HELPDESK.AI Logo" className="w-7 h-7 object-contain" />
                     </div>
-                    <h1 className="text-xl font-black tracking-tighter text-gray-900 italic">HELPDESK.AI</h1>
+                    <h1 className="text-xl font-black tracking-tighter text-gray-900 italic dark:text-emerald-300">HELPDESK.AI</h1>
                 </div>
 
                 {/* Center: Navigation Links */}
                 <nav className="hidden md:flex items-center gap-8">
-                    <Link className="text-sm font-semibold text-gray-900 hover:text-emerald-600 transition-colors" to="/dashboard">Dashboard</Link>
-                    <Link className="text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors" to="/my-tickets">My Tickets</Link>
-                    <Link className="text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors" to="/help">Help</Link>
-                    <Link className="text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors" to="/docs">Documentation</Link>
+                    <Link className="text-sm font-semibold text-gray-900 hover:text-emerald-600 transition-colors dark:text-white dark:hover:text-emerald-300" to="/dashboard">Dashboard</Link>
+                    <Link className="text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors dark:text-slate-300 dark:hover:text-white" to="/my-tickets">My Tickets</Link>
+                    <Link className="text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors dark:text-slate-300 dark:hover:text-white" to="/help">Help</Link>
+                    <Link className="text-sm font-semibold text-gray-500 hover:text-gray-900 transition-colors dark:text-slate-300 dark:hover:text-white" to="/docs">Documentation</Link>
                 </nav>
 
                 {/* Right: Profile */}
                 <div className="flex items-center gap-3">
+                    <ThemeToggle />
                     <NotificationPopover />
                     <div className="hidden md:block">
                         <Avatar
@@ -60,7 +62,7 @@ const TopNav = () => {
                     </div>
                     <button
                         onClick={() => setIsMenuOpen(!isMenuOpen)}
-                        className="md:hidden p-2 text-gray-600 focus:outline-none"
+                        className="md:hidden p-2 text-gray-600 focus:outline-none dark:text-slate-200"
                     >
                         {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
                     </button>
@@ -69,16 +71,16 @@ const TopNav = () => {
 
             {/* Mobile Menu Overlay */}
             {isMenuOpen && (
-                <div className="md:hidden bg-white border-t border-gray-100 absolute w-full shadow-2xl z-50 animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="md:hidden bg-white border-t border-gray-100 absolute w-full shadow-2xl z-50 animate-in fade-in slide-in-from-top-2 duration-200 dark:bg-[#061a13] dark:border-emerald-900/40">
                     <div className="px-6 py-8 space-y-6">
-                        <div className="flex items-center gap-4 border-b border-gray-50 pb-6">
+                        <div className="flex items-center gap-4 border-b border-gray-50 pb-6 dark:border-emerald-900/40">
                             <Avatar className="size-12 border border-gray-100">
                                 <AvatarImage src={profile?.profile_picture} />
                                 <AvatarFallback className="bg-emerald-50 text-emerald-700 font-black">{initials}</AvatarFallback>
                             </Avatar>
                             <div>
-                                <p className="font-bold text-gray-900">{profile?.full_name}</p>
-                                <p className="text-xs text-gray-400 font-medium">{profile?.email}</p>
+                                <p className="font-bold text-gray-900 dark:text-white">{profile?.full_name}</p>
+                                <p className="text-xs text-gray-400 font-medium dark:text-slate-400">{profile?.email}</p>
                             </div>
                         </div>
 
@@ -86,37 +88,37 @@ const TopNav = () => {
                             <Link
                                 to="/dashboard"
                                 onClick={() => setIsMenuOpen(false)}
-                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors"
+                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors dark:text-slate-200 dark:hover:text-emerald-300"
                             >
                                 <Box size={20} className="text-gray-400" /> Dashboard
                             </Link>
                             <Link
                                 to="/my-tickets"
                                 onClick={() => setIsMenuOpen(false)}
-                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors"
+                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors dark:text-slate-200 dark:hover:text-emerald-300"
                             >
                                 <MessageSquare size={20} className="text-gray-400" /> My Tickets
                             </Link>
                             <Link
                                 to="/profile"
                                 onClick={() => setIsMenuOpen(false)}
-                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors"
+                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors dark:text-slate-200 dark:hover:text-emerald-300"
                             >
                                 <UserIcon size={20} className="text-gray-400" /> My Profile
                             </Link>
                             <Link
                                 to="/docs"
                                 onClick={() => setIsMenuOpen(false)}
-                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors"
+                                className="flex items-center gap-3 text-lg font-bold text-gray-700 hover:text-emerald-700 transition-colors dark:text-slate-200 dark:hover:text-emerald-300"
                             >
                                 <BookOpen size={20} className="text-gray-400" /> Documentation
                             </Link>
                         </div>
 
-                        <div className="pt-6 border-t border-gray-50">
+                        <div className="pt-6 border-t border-gray-50 dark:border-emerald-900/40">
                             <button
                                 onClick={handleLogout}
-                                className="w-full py-4 bg-gray-50 rounded-2xl flex items-center justify-center gap-2 text-red-600 font-bold active:scale-95 transition-all"
+                                className="w-full py-4 bg-gray-50 rounded-2xl flex items-center justify-center gap-2 text-red-600 font-bold active:scale-95 transition-all dark:bg-red-500/10 dark:text-red-300"
                             >
                                 <LogOut size={18} /> Sign Out
                             </button>


### PR DESCRIPTION
Closes #343 
## Summary

This PR adds a polished dark/light mode experience across the HelpDesk.AI frontend.

Users can now switch themes from the main public pages and logged-in layouts, and their preference is saved so the selected theme stays active while navigating through the app.

## What Changed

- Added a reusable `ThemeProvider` for global theme state.
- Added a reusable `ThemeToggle` component.
- Saved the selected theme in `localStorage`.
- Applied theme support across public and authenticated routes.
- Added theme toggles to:
  - Landing page
  - Login page
  - Admin signup page
  - User navbar
  - Admin header
  - Master admin header
- Improved dark mode styling for:
  - Landing page
  - Team section
  - Login page
  - Admin signup page
  - User dashboard layout
  - Admin dashboard layout
  - Master admin layout
- Added broader dark-mode compatibility for existing hardcoded light UI styles.

## Why

The website previously did not have a dark/light mode toggle. This update gives users a consistent theme-switching experience across the app, including after login.

## Testing

Run locally:

```bash
cd Frontend
npm run dev