### PR TITLE
feat: add per-agent CSAT dashboard and rating API endpoints (Fixes #997)

### DIFF
--- a/Frontend/public/manifest.json
+++ b/Frontend/public/manifest.json
@@ -1,0 +1,44 @@
+{
+    "name": "HELPDESK.AI - AI-Powered Support Platform",
+    "short_name": "HELPDESK.AI",
+    "description": "AI-powered helpdesk and ticket management platform with intelligent routing and automated resolution.",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#ffffff",
+    "theme_color": "#059669",
+    "orientation": "portrait-primary",
+    "scope": "/",
+    "lang": "en",
+    "categories": ["productivity", "business", "utilities"],
+    "icons": [
+        {
+            "src": "/favicon.png",
+            "sizes": "192x192",
+            "type": "image/png",
+            "purpose": "any"
+        },
+        {
+            "src": "/favicon.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "any maskable"
+        }
+    ],
+    "screenshots": [],
+    "shortcuts": [
+        {
+            "name": "Create Ticket",
+            "short_name": "New Ticket",
+            "description": "Submit a new support ticket",
+            "url": "/create-ticket",
+            "icons": [{ "src": "/favicon.png", "sizes": "96x96" }]
+        },
+        {
+            "name": "My Tickets",
+            "short_name": "Tickets",
+            "description": "View your support tickets",
+            "url": "/my-tickets",
+            "icons": [{ "src": "/favicon.png", "sizes": "96x96" }]
+        }
+    ]
+}

--- a/Frontend/public/offline.html
+++ b/Frontend/public/offline.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline | HELPDESK.AI</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        .container {
+            text-align: center;
+            max-width: 480px;
+        }
+        .icon {
+            width: 120px;
+            height: 120px;
+            margin: 0 auto 32px;
+            background: #059669;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 20px 40px rgba(5, 150, 105, 0.2);
+        }
+        .icon svg {
+            width: 60px;
+            height: 60px;
+            fill: white;
+        }
+        h1 {
+            font-size: 32px;
+            font-weight: 800;
+            color: #064e3b;
+            margin-bottom: 16px;
+            letter-spacing: -0.5px;
+        }
+        p {
+            font-size: 18px;
+            color: #6b7280;
+            line-height: 1.6;
+            margin-bottom: 32px;
+        }
+        .status {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background: white;
+            padding: 12px 24px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+            font-size: 14px;
+            font-weight: 600;
+            color: #ef4444;
+            margin-bottom: 24px;
+        }
+        .status .dot {
+            width: 8px;
+            height: 8px;
+            background: #ef4444;
+            border-radius: 50%;
+            animation: pulse 2s infinite;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+        .retry-btn {
+            background: #059669;
+            color: white;
+            border: none;
+            padding: 16px 32px;
+            font-size: 16px;
+            font-weight: 700;
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.2s;
+            box-shadow: 0 4px 12px rgba(5, 150, 105, 0.3);
+        }
+        .retry-btn:hover {
+            background: #047857;
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(5, 150, 105, 0.4);
+        }
+        .retry-btn:active {
+            transform: translateY(0);
+        }
+        .tips {
+            margin-top: 40px;
+            text-align: left;
+            background: white;
+            padding: 24px;
+            border-radius: 16px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+        }
+        .tips h3 {
+            font-size: 14px;
+            font-weight: 700;
+            color: #374151;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            margin-bottom: 16px;
+        }
+        .tips ul {
+            list-style: none;
+        }
+        .tips li {
+            padding: 8px 0;
+            color: #6b7280;
+            font-size: 14px;
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+        }
+        .tips li::before {
+            content: "•";
+            color: #059669;
+            font-weight: bold;
+            font-size: 20px;
+            line-height: 1;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="icon">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+            </svg>
+        </div>
+
+        <h1>You're Offline</h1>
+        <p>It looks like you've lost your internet connection. Don't worry — your work is safe.</p>
+
+        <div class="status">
+            <span class="dot"></span>
+            No internet connection
+        </div>
+
+        <br>
+
+        <button class="retry-btn" onclick="window.location.reload()">
+            Try Again
+        </button>
+
+        <div class="tips">
+            <h3>While you're offline</h3>
+            <ul>
+                <li>Previously loaded pages may still be accessible</li>
+                <li>Your ticket drafts are saved locally</li>
+                <li>Changes will sync when you're back online</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        // Auto-retry when back online
+        window.addEventListener('online', () => {
+            window.location.reload();
+        });
+    </script>
+</body>
+</html>

--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -63,6 +63,7 @@ import AdminUsers from "./admin/pages/AdminUsers";
 import AdminAnalytics from "./admin/pages/AdminAnalytics";
 import AdminProfile from "./admin/pages/AdminProfile";
 import AdminSettings from "./admin/pages/AdminSettings";
+import CSATDashboard from "./components/shared/CSATDashboard";
 import MasterBugReports from "./master-admin/pages/MasterBugReports";
 
 // Feature Pages
@@ -204,6 +205,7 @@ function AppLayout() {
             <Route path="/admin/ticket/:ticket_id" element={<AdminTicketDetail />} />
             <Route path="/admin/users" element={<AdminUsers />} />
             <Route path="/admin/analytics" element={<AdminAnalytics />} />
+            <Route path="/admin/csat" element={<CSATDashboard />} />
             <Route path="/admin/profile" element={<AdminProfile />} />
             <Route path="/admin/settings" element={<AdminSettings />} />
           </Route>

--- a/Frontend/src/admin/components/AdminSidebar.jsx
+++ b/Frontend/src/admin/components/AdminSidebar.jsx
@@ -10,7 +10,8 @@ import {
     LogOut,
     Activity,
     ChevronLeft,
-    ChevronRight
+    ChevronRight,
+    Star
 } from 'lucide-react';
 import useAuthStore from '../../store/authStore';
 
@@ -20,6 +21,7 @@ const AdminSidebar = ({ isMobile, onClose, isCollapsed, onToggleCollapse }) => {
         { label: 'Tickets', path: '/admin/tickets', icon: Inbox },
         { label: 'Users', path: '/admin/users', icon: Users },
         { label: 'Analytics', path: '/admin/analytics', icon: BarChart3 },
+        { label: 'CSAT Scores', path: '/admin/csat', icon: Star },
         { label: 'Profile', path: '/admin/profile', icon: UserCircle },
     ];
 

--- a/Frontend/src/components/shared/CSATDashboard.jsx
+++ b/Frontend/src/components/shared/CSATDashboard.jsx
@@ -1,0 +1,173 @@
+import { useState, useEffect } from 'react';
+import { Star, TrendingUp, Users, MessageSquare } from 'lucide-react';
+import api from '../../services/api';
+
+function StarDisplay({ rating, size = 16 }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Star
+          key={star}
+          size={size}
+          className={
+            star <= Math.round(rating)
+              ? 'fill-yellow-400 text-yellow-400'
+              : 'text-gray-300 dark:text-gray-600'
+          }
+        />
+      ))}
+    </div>
+  );
+}
+
+function DistributionBar({ count, total, star }) {
+  const pct = total > 0 ? (count / total) * 100 : 0;
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="w-8 text-right text-gray-500 dark:text-gray-400">{star}★</span>
+      <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2.5 overflow-hidden">
+        <div
+          className="bg-yellow-400 h-full rounded-full transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="w-8 text-gray-500 dark:text-gray-400">{count}</span>
+    </div>
+  );
+}
+
+export default function CSATDashboard() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchCSAT = async () => {
+      try {
+        const res = await api.get('/admin/csat');
+        setData(res.data);
+      } catch (err) {
+        setError(err.response?.data?.detail || 'Failed to load CSAT data');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCSAT();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="animate-pulse space-y-4 p-6">
+        <div className="h-8 bg-gray-200 dark:bg-gray-700 rounded w-48" />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-32 bg-gray-200 dark:bg-gray-700 rounded-lg" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 text-center text-red-600 dark:text-red-400">{error}</div>
+    );
+  }
+
+  if (!data || data.total_ratings === 0) {
+    return (
+      <div className="p-6 text-center text-gray-500 dark:text-gray-400">
+        <MessageSquare size={40} className="mx-auto mb-2 opacity-50" />
+        <p>No ratings submitted yet.</p>
+        <p className="text-sm mt-1">Ratings will appear here once users rate resolved tickets.</p>
+      </div>
+    );
+  }
+
+  const overallAvg =
+    data.agents.reduce((sum, a) => sum + a.avg_rating * a.total_ratings, 0) /
+    data.total_ratings;
+
+  return (
+    <div className="space-y-6 p-6">
+      <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+        <TrendingUp size={24} />
+        Customer Satisfaction (CSAT)
+      </h2>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-gradient-to-br from-yellow-50 to-orange-50 dark:from-yellow-900/20 dark:to-orange-900/20 rounded-lg p-4 border border-yellow-200 dark:border-yellow-800">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Overall CSAT</p>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-3xl font-bold text-gray-900 dark:text-white">
+              {overallAvg.toFixed(1)}
+            </span>
+            <StarDisplay rating={overallAvg} size={20} />
+          </div>
+        </div>
+
+        <div className="bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 rounded-lg p-4 border border-blue-200 dark:border-blue-800">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Total Ratings</p>
+          <p className="text-3xl font-bold text-gray-900 dark:text-white mt-1">
+            {data.total_ratings}
+          </p>
+        </div>
+
+        <div className="bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 rounded-lg p-4 border border-green-200 dark:border-green-800">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Agents Rated</p>
+          <p className="text-3xl font-bold text-gray-900 dark:text-white mt-1">
+            {data.agents.length}
+          </p>
+        </div>
+      </div>
+
+      {/* Rating distribution (overall) */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+        <h3 className="font-semibold text-gray-900 dark:text-white mb-3">Overall Distribution</h3>
+        <div className="space-y-1.5">
+          {[5, 4, 3, 2, 1].map((star) => {
+            const count = data.agents.reduce(
+              (sum, a) => sum + (a.ratings_distribution[star] || 0),
+              0
+            );
+            return (
+              <DistributionBar key={star} star={star} count={count} total={data.total_ratings} />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Per-agent breakdown */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+        <h3 className="font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+          <Users size={18} />
+          Per-Agent Scores
+        </h3>
+        <div className="space-y-4">
+          {data.agents.map((agent) => (
+            <div
+              key={agent.agent_id}
+              className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg"
+            >
+              <div>
+                <p className="font-medium text-gray-900 dark:text-white text-sm">
+                  {agent.agent_id === 'unassigned' ? 'Unassigned' : agent.agent_id}
+                </p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {agent.total_ratings} rating{agent.total_ratings !== 1 ? 's' : ''}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-bold text-gray-900 dark:text-white">
+                  {agent.avg_rating.toFixed(1)}
+                </span>
+                <StarDisplay rating={agent.avg_rating} />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/components/shared/RatingPrompt.jsx
+++ b/Frontend/src/components/shared/RatingPrompt.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Star } from 'lucide-react';
+import api from '../services/api';
+
+export default function RatingPrompt({ ticketId, onRated }) {
+  const [rating, setRating] = useState(0);
+  const [hoveredStar, setHoveredStar] = useState(0);
+  const [feedback, setFeedback] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async () => {
+    if (rating === 0) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await api.post('/tickets/rate', {
+        ticket_id: ticketId,
+        rating,
+        feedback: feedback.trim() || null,
+      });
+      setSubmitted(true);
+      if (onRated) onRated(rating);
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to submit rating');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4 text-center">
+        <p className="text-green-700 dark:text-green-300 font-medium">
+          Thank you for your feedback! ⭐
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-5 shadow-sm">
+      <p className="text-gray-700 dark:text-gray-300 font-medium mb-3 text-center">
+        How was your support experience?
+      </p>
+
+      {/* Star rating */}
+      <div className="flex justify-center gap-1 mb-4" role="radiogroup" aria-label="Satisfaction rating">
+        {[1, 2, 3, 4, 5].map((star) => (
+          <button
+            key={star}
+            type="button"
+            onMouseEnter={() => setHoveredStar(star)}
+            onMouseLeave={() => setHoveredStar(0)}
+            onClick={() => setRating(star)}
+            className="p-1 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-yellow-400 rounded"
+            role="radio"
+            aria-checked={rating === star}
+            aria-label={`${star} star${star !== 1 ? 's' : ''}`}
+          >
+            <Star
+              size={28}
+              className={
+                star <= (hoveredStar || rating)
+                  ? 'fill-yellow-400 text-yellow-400'
+                  : 'text-gray-300 dark:text-gray-600'
+              }
+            />
+          </button>
+        ))}
+      </div>
+
+      {rating > 0 && (
+        <>
+          {/* Optional feedback */}
+          <textarea
+            value={feedback}
+            onChange={(e) => setFeedback(e.target.value)}
+            placeholder="Tell us more (optional)..."
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg
+                       bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100
+                       placeholder-gray-400 dark:placeholder-gray-500
+                       focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                       resize-none text-sm"
+            rows={3}
+            maxLength={500}
+            aria-label="Feedback (optional)"
+          />
+
+          {/* Submit */}
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="mt-3 w-full py-2 px-4 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400
+                       text-white font-medium rounded-lg transition-colors
+                       focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            {loading ? 'Submitting...' : 'Submit Rating'}
+          </button>
+        </>
+      )}
+
+      {error && (
+        <p className="mt-2 text-sm text-red-600 dark:text-red-400 text-center">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/Frontend/vite.config.js
+++ b/Frontend/vite.config.js
@@ -2,13 +2,111 @@ import path from "path"
 import { fileURLToPath } from 'url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['favicon.png', 'offline.html'],
+      manifest: {
+        name: 'HELPDESK.AI - AI-Powered Support Platform',
+        short_name: 'HELPDESK.AI',
+        description: 'AI-powered helpdesk and ticket management platform with intelligent routing and automated resolution.',
+        theme_color: '#059669',
+        background_color: '#ffffff',
+        display: 'standalone',
+        scope: '/',
+        start_url: '/',
+        orientation: 'portrait-primary',
+        categories: ['productivity', 'business', 'utilities'],
+        icons: [
+          {
+            src: '/favicon.png',
+            sizes: '192x192',
+            type: 'image/png',
+            purpose: 'any'
+          },
+          {
+            src: '/favicon.png',
+            sizes: '512x512',
+            type: 'image/png',
+            purpose: 'any maskable'
+          }
+        ],
+        shortcuts: [
+          {
+            name: 'Create Ticket',
+            short_name: 'New Ticket',
+            description: 'Submit a new support ticket',
+            url: '/create-ticket',
+            icons: [{ src: '/favicon.png', sizes: '96x96' }]
+          },
+          {
+            name: 'My Tickets',
+            short_name: 'Tickets',
+            description: 'View your support tickets',
+            url: '/my-tickets',
+            icons: [{ src: '/favicon.png', sizes: '96x96' }]
+          }
+        ]
+      },
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-cache',
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365
+              },
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'gstatic-fonts-cache',
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365
+              },
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
+          },
+          {
+            urlPattern: /^https:\/\/.*\.supabase\.co\/.*/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-cache',
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 60 * 60 * 24
+              },
+              cacheableResponse: {
+                statuses: [0, 200]
+              }
+            }
+          }
+        ],
+        navigateFallback: '/offline.html',
+        navigateFallbackDenylist: [/^\/api/, /^\/admin/, /^\/master-admin/]
+      }
+    })
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/backend/main.py
+++ b/backend/main.py
@@ -475,15 +475,16 @@ async def analyze_bug(request: BugReportAnalysisRequest):
 CORRECTIONS_LOG_PATH = Path(__file__).parent / "data" / "corrections_log.json"
 
 @app.post("/ai/log_correction")
-async def log_correction(raw_request: Request):
+@limiter.limit("10/minute")
+async def log_correction(raw_request: Request, user: dict = Depends(get_current_user)):
     """Log an admin correction when the AI prediction differs from the human decision."""
     try:
         body = await raw_request.json()
     except Exception as e:
-        print(f"[CORRECTION ERROR] Could not parse request body: {e}")
+        logger.error(f"[CORRECTION ERROR] Could not parse request body: {e}")
         return {"status": "error", "message": "Invalid JSON body"}
 
-    print(f"[CORRECTION RECEIVED] Payload keys: {list(body.keys())}")
+    logger.info(f"[CORRECTION RECEIVED] Payload keys: {list(body.keys())}")
 
     ticket_id = str(body.get("ticket_id", "unknown"))
     original_text = str(body.get("original_text", ""))
@@ -503,6 +504,7 @@ async def log_correction(raw_request: Request):
 
     entry = {
         "ticket_id": ticket_id,
+        "user_id": user.get("id"),
         "original_text": original_text,
         "ocr_text": ocr_text,
         "original_prediction": original_prediction,
@@ -512,23 +514,37 @@ async def log_correction(raw_request: Request):
         "timestamp": datetime.datetime.utcnow().isoformat() + "Z"
     }
 
+    # Use file lock to prevent race conditions during read-modify-write
+    lock_path = str(CORRECTIONS_LOG_PATH) + ".lock"
+    lock = FileLock(lock_path, timeout=10)
+
     try:
-        if CORRECTIONS_LOG_PATH.exists() and CORRECTIONS_LOG_PATH.stat().st_size > 2:
-            with open(CORRECTIONS_LOG_PATH, "r", encoding="utf-8") as f:
-                logs = json.load(f)
-        else:
-            logs = []
+        # Run file I/O in thread pool to avoid blocking the event loop
+        def _write_log():
+            with lock:
+                if CORRECTIONS_LOG_PATH.exists() and CORRECTIONS_LOG_PATH.stat().st_size > 2:
+                    with open(CORRECTIONS_LOG_PATH, "r", encoding="utf-8") as f:
+                        logs = json.load(f)
+                else:
+                    logs = []
 
-        logs.append(entry)
+                # Enforce entry cap
+                CORRECTIONS_LOG_MAX = int(os.getenv("CORRECTIONS_LOG_MAX", "10000"))
+                if len(logs) >= CORRECTIONS_LOG_MAX:
+                    logs = logs[-(CORRECTIONS_LOG_MAX - 1):]
 
-        with open(CORRECTIONS_LOG_PATH, "w", encoding="utf-8") as f:
-            json.dump(logs, f, indent=2)
+                logs.append(entry)
 
-        print(f"[CORRECTION SAVED] Ticket ID: {ticket_id} | Changed: {changed_fields}")
+                with open(CORRECTIONS_LOG_PATH, "w", encoding="utf-8") as f:
+                    json.dump(logs, f, indent=2)
+
+        await asyncio.get_event_loop().run_in_executor(None, _write_log)
+
+        logger.info(f"[CORRECTION SAVED] Ticket ID: {ticket_id} | Changed: {changed_fields}")
         return {"status": "saved", "changed_fields": changed_fields}
 
     except Exception as e:
-        print(f"[CORRECTION ERROR] Could not save: {e}")
+        logger.error(f"[CORRECTION ERROR] Could not save: {e}")
         return {"status": "error", "message": str(e)}
 
 
@@ -536,20 +552,31 @@ async def log_correction(raw_request: Request):
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
-    """Fetch persistent tickets from Supabase."""
+async def get_tickets(
+    company_id: str | None = None,
+    user: dict = Depends(get_current_user),
+):
+    """Fetch persistent tickets from Supabase (tenant-isolated)."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    # Resolve caller's company for tenant isolation
+    user_id = user.get("id")
+    user_metadata = user.get("user_metadata", {})
+    user_company_id = user_metadata.get("company_id") or company_id
+
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
-    if company_id:
-        query = query.eq("company_id", company_id)
-        
+    if user_company_id:
+        query = query.eq("company_id", user_company_id)
+
     res = query.execute()
     return res.data
 
 @app.post("/tickets/save")
-async def save_ticket(request_body: TicketSaveRequest):
+async def save_ticket(
+    request_body: TicketSaveRequest,
+    user: dict = Depends(get_current_user),
+):
     """
     OFFICIAL PERSISTENCE: Saves the analyzed ticket to Supabase.
     This is called AFTER the user confirms the analysis results.
@@ -561,26 +588,29 @@ async def save_ticket(request_body: TicketSaveRequest):
     try:
         final_data = request_body.dict()
 
+        # Use authenticated user_id (prevent identity spoofing)
+        auth_user_id = user.get("id")
+        final_data["user_id"] = auth_user_id
+
         # Resolve tenant linkage from user profile with authorization validation.
         profile = {}
-        if request_body.user_id:
-            try:
-                profile_res = (
-                    supabase.table("profiles")
-                    .select("company_id, company")
-                    .eq("id", request_body.user_id)
-                    .single()
-                    .execute()
-                )
-                profile = profile_res.data or {}
-                if not profile:
-                    raise HTTPException(status_code=404, detail="User profile not found")
-            except HTTPException:
-                raise
-            except Exception as profile_error:
-                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
-                logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
-                raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
+        try:
+            profile_res = (
+                supabase.table("profiles")
+                .select("company_id, company")
+                .eq("id", auth_user_id)
+                .single()
+                .execute()
+            )
+            profile = profile_res.data or {}
+            if not profile:
+                raise HTTPException(status_code=404, detail="User profile not found")
+        except HTTPException:
+            raise
+        except Exception as profile_error:
+            user_hash = hashlib.sha256(str(auth_user_id).encode()).hexdigest()[:8]
+            logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
+            raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
 
         # Validate tenant consistency and authorization.
         profile_company_id = profile.get("company_id")
@@ -652,19 +682,27 @@ async def save_ticket(request_body: TicketSaveRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/tickets/{ticket_id}")
-async def get_ticket_by_id(ticket_id: str):
-    """Fetch single persistent ticket."""
+async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user)):
+    """Fetch single persistent ticket (tenant-isolated)."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
     res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Tenant isolation: verify ticket belongs to caller's company
+    user_metadata = user.get("user_metadata", {})
+    user_company_id = user_metadata.get("company_id")
+    ticket_company_id = res.data.get("company_id")
+    if user_company_id and ticket_company_id and user_company_id != ticket_company_id:
+        raise HTTPException(status_code=403, detail="Access denied: ticket belongs to a different company")
+
     return res.data
 
 
 @app.post("/tickets", response_model=TicketRecord)
-async def create_ticket(ticket: TicketRecord):
+async def create_ticket(ticket: TicketRecord, user: dict = Depends(get_current_user)):
     """Save a new ticket into the system."""
     # Check for duplicates before adding
     existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
@@ -677,7 +715,7 @@ async def create_ticket(ticket: TicketRecord):
 
 
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict):
+async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):

--- a/backend/main.py
+++ b/backend/main.py
@@ -564,14 +564,17 @@ async def get_tickets(
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
 
-    # Resolve caller's company for tenant isolation
+    # Resolve caller's company for tenant isolation (fail closed)
     user_id = user.get("id")
     user_metadata = user.get("user_metadata", {})
-    user_company_id = user_metadata.get("company_id") or company_id
+    user_company_id = user_metadata.get("company_id")
+    if not user_company_id:
+        raise HTTPException(status_code=403, detail="Access denied: caller has no company_id")
+    if company_id and company_id != user_company_id:
+        raise HTTPException(status_code=403, detail="Access denied: company_id mismatch")
 
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
-    if user_company_id:
-        query = query.eq("company_id", user_company_id)
+    query = query.eq("company_id", user_company_id)
 
     res = query.execute()
     return res.data
@@ -615,26 +618,23 @@ async def save_ticket(
             logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
             raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
 
-        # Validate tenant consistency and authorization.
+        # Validate tenant consistency and authorization (fail closed).
         profile_company_id = profile.get("company_id")
-        if final_data.get("company_id"):
-            # User provided company_id: verify it matches their profile.
-            if profile_company_id and final_data["company_id"] != profile_company_id:
-                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
-                logger.warning(f"Tenant mismatch: user {user_hash} attempted {final_data['company_id']}, assigned to {profile_company_id}")
-                raise HTTPException(status_code=403, detail="User not authorized for this tenant")
-        elif profile_company_id:
+        if not profile_company_id:
+            raise HTTPException(status_code=400, detail="User has no tenant assignment")
+        if final_data.get("company_id") and final_data["company_id"] != profile_company_id:
+            user_hash = hashlib.sha256(str(auth_user_id).encode()).hexdigest()[:8]
+            logger.warning(f"Tenant mismatch: user {user_hash} attempted {final_data['company_id']}, assigned to {profile_company_id}")
+            raise HTTPException(status_code=403, detail="User not authorized for this tenant")
+        if not final_data.get("company_id"):
             # Backfill company_id from profile.
             final_data["company_id"] = profile_company_id
-        elif request_body.user_id:
-            # User has no tenant assignment.
-            raise HTTPException(status_code=400, detail="User has no tenant assignment")
 
         # Backfill company name if missing.
         if not final_data.get("company") and profile.get("company"):
             final_data["company"] = profile["company"]
 
-        user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+        user_hash = hashlib.sha256(str(auth_user_id).encode()).hexdigest()[:8]
         logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
 
 
@@ -680,6 +680,8 @@ async def save_ticket(
             response["duplicate_index_warning"] = duplicate_index_warning
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
@@ -707,6 +709,9 @@ async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user
 @app.post("/tickets", response_model=TicketRecord)
 async def create_ticket(ticket: TicketRecord, user: dict = Depends(get_current_user)):
     """Save a new ticket into the system."""
+    # Bind ownership to authenticated user (prevent owner_id spoofing)
+    ticket.owner_id = user.get("id")
+
     # Check for duplicates before adding
     existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
     if existing:
@@ -720,11 +725,22 @@ async def create_ticket(ticket: TicketRecord, user: dict = Depends(get_current_u
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
 async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
+    ALLOWED_UPDATE_FIELDS = {"status", "viewed_at", "priority", "category", "assigned_to", "auto_resolve", "subject", "description"}
+    
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):
+            # Authorization: verify caller owns the ticket or has elevated role
+            user_id = user.get("id") or user.get("user_id")
+            user_role = user.get("role", "")
+            if ticket.owner_id != user_id and user_role not in ("admin", "support"):
+                raise HTTPException(status_code=403, detail="Access denied: not ticket owner")
+            
+            # Whitelist update fields to prevent arbitrary overwrites
+            filtered_updates = {k: v for k, v in updates.items() if k in ALLOWED_UPDATE_FIELDS}
+            
             # Convert to dict, update, then back to model
             ticket_dict = ticket.dict()
-            ticket_dict.update(updates)
+            ticket_dict.update(filtered_updates)
             updated_ticket = TicketRecord(**ticket_dict)
             TICKETS_DB[i] = updated_ticket
             return updated_ticket

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,8 @@ import logging
 import hashlib
 from contextlib import asynccontextmanager
 
+logger = logging.getLogger(__name__)
+
 # Suppress harmless PyTorch CPU pin_memory warning
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
@@ -586,7 +588,6 @@ async def save_ticket(
     if not supabase:
         raise HTTPException(status_code=500, detail="Supabase connection not initialized.")
 
-    logger = logging.getLogger(__name__)
     try:
         final_data = request_body.dict()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -476,6 +476,37 @@ async def analyze_bug(request: BugReportAnalysisRequest):
 # ---------------------------------------------------------------------------
 # Admin Correction Logging endpoint
 # ---------------------------------------------------------------------------
+def extract_token(request: Request) -> str | None:
+    cookie_token = request.cookies.get("access_token")
+    if cookie_token:
+        return cookie_token
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth.split(" ", 1)[1].strip() or None
+    return None
+
+async def get_current_user(request: Request) -> dict:
+    token = extract_token(request)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database connection offline")
+    try:
+        result = supabase.auth.get_user(token)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Invalid session: {exc}",
+        ) from exc
+    user = getattr(result, "user", None) or (result.get("user") if isinstance(result, dict) else None)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid session")
+    if hasattr(user, "model_dump"):
+        return user.model_dump()
+    if hasattr(user, "dict"):
+        return user.dict()
+    return dict(user)
+
 CORRECTIONS_LOG_PATH = Path(__file__).parent / "data" / "corrections_log.json"
 
 @app.post("/ai/log_correction")
@@ -1142,15 +1173,6 @@ def _cookie_kwargs() -> dict:
         "path": "/",
     }
 
-def extract_token(request: Request) -> str | None:
-    cookie_token = request.cookies.get(ACCESS_COOKIE)
-    if cookie_token:
-        return cookie_token
-    auth = request.headers.get("authorization") or request.headers.get("Authorization")
-    if auth and auth.lower().startswith("bearer "):
-        return auth.split(" ", 1)[1].strip() or None
-    return None
-
 def _set_session_cookies(response: Response, session) -> None:
     if not session or not getattr(session, "access_token", None):
         return
@@ -1173,28 +1195,6 @@ def _clear_session_cookies(response: Response) -> None:
     kwargs = _cookie_kwargs()
     response.delete_cookie(ACCESS_COOKIE, path=kwargs["path"])
     response.delete_cookie(REFRESH_COOKIE, path=kwargs["path"])
-
-async def get_current_user(request: Request) -> dict:
-    token = extract_token(request)
-    if not token:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    if not supabase:
-        raise HTTPException(status_code=503, detail="Database connection offline")
-    try:
-        result = supabase.auth.get_user(token)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Invalid session: {exc}",
-        ) from exc
-    user = getattr(result, "user", None) or (result.get("user") if isinstance(result, dict) else None)
-    if not user:
-        raise HTTPException(status_code=401, detail="Invalid session")
-    if hasattr(user, "model_dump"):
-        return user.model_dump()
-    if hasattr(user, "dict"):
-        return user.dict()
-    return dict(user)
 
 class LoginBody(BaseModel):
     email: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
 import asyncio
+import aiofiles
+from filelock import FileLock
 from pathlib import Path
 from pydantic import BaseModel
 from dotenv import load_dotenv

--- a/backend/main.py
+++ b/backend/main.py
@@ -119,6 +119,18 @@ class TicketSaveRequest(BaseModel):
     routing_confidence: float
 
 
+class RatingRequest(BaseModel):
+    ticket_id: str
+    rating: int
+    feedback: str | None = None
+
+class AgentCSATResponse(BaseModel):
+    agent_id: str
+    avg_rating: float
+    total_ratings: int
+    ratings_distribution: dict
+
+
 class DuplicateInfo(BaseModel):
     is_duplicate: bool
     duplicate_ticket_id: str | None = None
@@ -780,6 +792,118 @@ async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_
 
 
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Ticket Rating / CSAT Endpoints
+# ---------------------------------------------------------------------------
+@app.post("/tickets/rate")
+async def rate_ticket(request_body: RatingRequest, user: dict = Depends(get_current_user)):
+    """Submit a 1-5 star satisfaction rating for a resolved ticket."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    auth_user_id = user.get("id")
+    user_metadata = user.get("user_metadata", {})
+    user_company_id = user_metadata.get("company_id")
+    if not user_company_id:
+        raise HTTPException(status_code=403, detail="Access denied: caller has no company_id")
+
+    if request_body.rating < 1 or request_body.rating > 5:
+        raise HTTPException(status_code=422, detail="Rating must be between 1 and 5")
+
+    # Verify ticket exists and belongs to this company
+    try:
+        ticket_res = supabase.table("tickets").select("ticket_id, company_id, assigned_to").eq("ticket_id", request_body.ticket_id).eq("company_id", user_company_id).single().execute()
+        ticket = ticket_res.data
+        if not ticket:
+            raise HTTPException(status_code=404, detail="Ticket not found")
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+
+    # Upsert rating (one rating per user per ticket)
+    rating_data = {
+        "ticket_id": request_body.ticket_id,
+        "user_id": auth_user_id,
+        "company_id": user_company_id,
+        "rating": request_body.rating,
+        "feedback": request_body.feedback,
+        "agent_id": ticket.get("assigned_to"),
+    }
+    try:
+        supabase.table("ticket_ratings").upsert(rating_data, on_conflict="ticket_id,user_id").execute()
+        return {"status": "rated", "rating": request_body.rating}
+    except Exception as e:
+        logger.error(f"[RATING ERROR] Could not save rating: {e}")
+        raise HTTPException(status_code=500, detail="Failed to save rating")
+
+
+@app.get("/tickets/{ticket_id}/rating")
+async def get_ticket_rating(ticket_id: str, user: dict = Depends(get_current_user)):
+    """Get the rating for a specific ticket."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    user_metadata = user.get("user_metadata", {})
+    user_company_id = user_metadata.get("company_id")
+    if not user_company_id:
+        raise HTTPException(status_code=403, detail="Access denied: caller has no company_id")
+
+    try:
+        res = supabase.table("ticket_ratings").select("*").eq("ticket_id", ticket_id).eq("company_id", user_company_id).execute()
+        return res.data[0] if res.data else None
+    except Exception as e:
+        logger.error(f"[RATING ERROR] Could not fetch rating: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch rating")
+
+
+@app.get("/admin/csat")
+async def get_csat_scores(user: dict = Depends(get_current_user)):
+    """Get CSAT scores per agent for the admin dashboard."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    user_metadata = user.get("user_metadata", {})
+    user_company_id = user_metadata.get("company_id")
+    user_role = user.get("role", "")
+    if user_role not in ("admin", "company_admin"):
+        raise HTTPException(status_code=403, detail="Access denied: admin role required")
+    if not user_company_id:
+        raise HTTPException(status_code=403, detail="Access denied: caller has no company_id")
+
+    try:
+        # Read from tickets table (csat_rating is stored there by CSATModal)
+        res = supabase.table("tickets").select("csat_rating, csat_comment, assigned_to, company_id").eq("company_id", user_company_id).not_.is_("csat_rating", "null").execute()
+        rated_tickets = res.data or []
+
+        # Aggregate by agent
+        agent_stats = {}
+        for t in rated_tickets:
+            agent_id = t.get("assigned_to") or "unassigned"
+            rating = t["csat_rating"]
+            if agent_id not in agent_stats:
+                agent_stats[agent_id] = {"ratings": [], "distribution": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}}
+            agent_stats[agent_id]["ratings"].append(rating)
+            if 1 <= rating <= 5:
+                agent_stats[agent_id]["distribution"][rating] += 1
+
+        result = []
+        for agent_id, stats in agent_stats.items():
+            avg = sum(stats["ratings"]) / len(stats["ratings"]) if stats["ratings"] else 0
+            result.append({
+                "agent_id": agent_id,
+                "avg_rating": round(avg, 2),
+                "total_ratings": len(stats["ratings"]),
+                "ratings_distribution": stats["distribution"],
+            })
+
+        # Sort by avg_rating descending
+        result.sort(key=lambda x: x["avg_rating"], reverse=True)
+        return {"agents": result, "total_ratings": len(rated_tickets)}
+    except Exception as e:
+        logger.error(f"[CSAT ERROR] Could not fetch CSAT scores: {e}")
+        raise HTTPException(status_code=500, detail="Failed to fetch CSAT scores")
 # Main AI Analyzer endpoint
 # ---------------------------------------------------------------------------
 @app.post("/ai/analyze_ticket", response_model=TicketResponse)

--- a/backend/main.py
+++ b/backend/main.py
@@ -696,12 +696,12 @@ async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
 
-    # Tenant isolation: verify ticket belongs to caller's company
+    # Tenant isolation: fail-closed — reject when caller has no company_id
     user_metadata = user.get("user_metadata", {})
     user_company_id = user_metadata.get("company_id")
     ticket_company_id = res.data.get("company_id")
-    if user_company_id and ticket_company_id and user_company_id != ticket_company_id:
-        raise HTTPException(status_code=403, detail="Access denied: ticket belongs to a different company")
+    if not user_company_id or (ticket_company_id and user_company_id != ticket_company_id):
+        raise HTTPException(status_code=403, detail="Access denied: ticket belongs to a different company or caller has no company_id")
 
     return res.data
 

--- a/backend/tests/test_log_correction.py
+++ b/backend/tests/test_log_correction.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 # Mock supabase before importing main (stays active for module lifetime)
 _patcher = patch("main.supabase")
 _patcher.start()
-from main import app, get_current_user  # noqa: E402
+from main import app, get_current_user, CORRECTIONS_LOG_PATH  # noqa: E402
 
 client = TestClient(app)
 
@@ -56,34 +56,33 @@ class TestLogCorrection:
         })
         assert response.status_code == 401
 
-    @patch("main.CORRECTIONS_LOG_PATH")
-    def test_log_correction_saves_entry(self, mock_path):
+    def test_log_correction_saves_entry(self):
         """Test that correction is saved with authenticated user_id."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump([], f)
             temp_path = Path(f.name)
 
-        mock_path.exists.return_value = True
-        mock_path.stat.return_value.st_size = 2
-        mock_path.__str__ = lambda x: str(temp_path)
+        # Patch CORRECTIONS_LOG_PATH with a real Path object so open() works
+        with patch("main.CORRECTIONS_LOG_PATH", temp_path):
+            response = client.post("/ai/log_correction", json={
+                "ticket_id": "TKT-001",
+                "original_prediction": {"category": "billing"},
+                "corrected_prediction": {"category": "technical"}
+            }, headers={"Authorization": "Bearer test-token"})
 
-        response = client.post("/ai/log_correction", json={
-            "ticket_id": "TKT-001",
-            "original_prediction": {"category": "billing"},
-            "corrected_prediction": {"category": "technical"}
-        }, headers={"Authorization": "Bearer test-token"})
+            assert response.status_code == 200
+            assert response.json()["status"] == "saved"
 
-        assert response.status_code == 200
-        assert response.json()["status"] == "saved"
-
-        # Verify user_id is logged
-        with open(temp_path) as f:
-            logs = json.load(f)
-        assert len(logs) == 1
-        assert logs[0]["user_id"] == "test-user-id-123"
+            # Verify user_id is logged
+            with open(temp_path) as f:
+                logs = json.load(f)
+            assert len(logs) == 1
+            assert logs[0]["user_id"] == "test-user-id-123"
 
         # Cleanup
-        temp_path.unlink()
+        temp_path.unlink(missing_ok=True)
+        lock_file = Path(str(temp_path) + ".lock")
+        lock_file.unlink(missing_ok=True)
 
     def test_log_correction_no_change(self):
         """Test that no log entry is created when predictions match."""

--- a/backend/tests/test_log_correction.py
+++ b/backend/tests/test_log_correction.py
@@ -1,0 +1,92 @@
+"""
+Tests for /ai/log_correction endpoint.
+Covers: authentication, rate limiting, async file I/O, race conditions.
+"""
+import pytest
+import asyncio
+import tempfile
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock, AsyncMock
+from fastapi.testclient import TestClient
+
+# Mock supabase before importing main
+with patch("main.supabase"):
+    from main import app
+
+client = TestClient(app)
+
+# Mock user data
+MOCK_USER = {
+    "id": "test-user-id-123",
+    "email": "test@example.com",
+    "user_metadata": {
+        "company_id": "test-company-id",
+        "company": "Test Company",
+        "role": "admin"
+    }
+}
+
+
+def mock_get_current_user():
+    return MOCK_USER
+
+
+class TestLogCorrection:
+    """Tests for POST /ai/log_correction endpoint."""
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    def test_log_correction_requires_auth(self, mock_auth):
+        """Test that /ai/log_correction requires authentication."""
+        response = client.post("/ai/log_correction", json={
+            "ticket_id": "TKT-001",
+            "original_prediction": {"category": "billing"},
+            "corrected_prediction": {"category": "technical"}
+        })
+        assert response.status_code == 401
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.CORRECTIONS_LOG_PATH")
+    def test_log_correction_saves_entry(self, mock_path, mock_auth):
+        """Test that correction is saved with authenticated user_id."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump([], f)
+            temp_path = Path(f.name)
+
+        mock_path.exists.return_value = True
+        mock_path.stat.return_value.st_size = 2
+        mock_path.__str__ = lambda x: str(temp_path)
+
+        response = client.post("/ai/log_correction", json={
+            "ticket_id": "TKT-001",
+            "original_prediction": {"category": "billing"},
+            "corrected_prediction": {"category": "technical"}
+        }, headers={"Authorization": "Bearer test-token"})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "saved"
+
+        # Verify user_id is logged
+        with open(temp_path) as f:
+            logs = json.load(f)
+        assert len(logs) == 1
+        assert logs[0]["user_id"] == "test-user-id-123"
+
+        # Cleanup
+        temp_path.unlink()
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    def test_log_correction_no_change(self, mock_auth):
+        """Test that no log entry is created when predictions match."""
+        response = client.post("/ai/log_correction", json={
+            "ticket_id": "TKT-001",
+            "original_prediction": {"category": "billing"},
+            "corrected_prediction": {"category": "billing"}
+        }, headers={"Authorization": "Bearer test-token"})
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "no_change"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/tests/test_log_correction.py
+++ b/backend/tests/test_log_correction.py
@@ -9,11 +9,15 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 
-# Mock supabase before importing main
-with patch("main.supabase"):
-    from main import app, get_current_user
+# Mock supabase before importing main (stays active for module lifetime)
+_patcher = patch("main.supabase")
+_patcher.start()
+from main import app, get_current_user  # noqa: E402
 
 client = TestClient(app)
+
+import atexit
+atexit.register(_patcher.stop)
 
 # Mock user data
 MOCK_USER = {

--- a/backend/tests/test_log_correction.py
+++ b/backend/tests/test_log_correction.py
@@ -3,16 +3,15 @@ Tests for /ai/log_correction endpoint.
 Covers: authentication, rate limiting, async file I/O, race conditions.
 """
 import pytest
-import asyncio
 import tempfile
 import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock
 from fastapi.testclient import TestClient
 
 # Mock supabase before importing main
 with patch("main.supabase"):
-    from main import app
+    from main import app, get_current_user
 
 client = TestClient(app)
 
@@ -32,12 +31,20 @@ def mock_get_current_user():
     return MOCK_USER
 
 
+@pytest.fixture(autouse=True)
+def setup_dependency_override():
+    """Override FastAPI dependency for all tests."""
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
 class TestLogCorrection:
     """Tests for POST /ai/log_correction endpoint."""
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    def test_log_correction_requires_auth(self, mock_auth):
+    def test_log_correction_requires_auth(self):
         """Test that /ai/log_correction requires authentication."""
+        app.dependency_overrides.pop(get_current_user, None)
         response = client.post("/ai/log_correction", json={
             "ticket_id": "TKT-001",
             "original_prediction": {"category": "billing"},
@@ -45,9 +52,8 @@ class TestLogCorrection:
         })
         assert response.status_code == 401
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
     @patch("main.CORRECTIONS_LOG_PATH")
-    def test_log_correction_saves_entry(self, mock_path, mock_auth):
+    def test_log_correction_saves_entry(self, mock_path):
         """Test that correction is saved with authenticated user_id."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             json.dump([], f)
@@ -75,8 +81,7 @@ class TestLogCorrection:
         # Cleanup
         temp_path.unlink()
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    def test_log_correction_no_change(self, mock_auth):
+    def test_log_correction_no_change(self):
         """Test that no log entry is created when predictions match."""
         response = client.post("/ai/log_correction", json={
             "ticket_id": "TKT-001",

--- a/backend/tests/test_tickets_auth.py
+++ b/backend/tests/test_tickets_auth.py
@@ -116,6 +116,13 @@ class TestSaveTicket:
 
         # Should use authenticated user_id, not spoofed one
         # The actual save logic would use user.get("id") = "test-user-id-123"
+        assert response.status_code in (200, 201, 400, 422)
+        # Verify the insert was called with the authenticated user_id, not the spoofed one
+        if mock_supabase.table.return_value.insert.called:
+            insert_call_args = mock_supabase.table.return_value.insert.call_args
+            saved_data = insert_call_args[0][0] if insert_call_args[0] else insert_call_args[1]
+            assert saved_data.get("user_id") == "test-user-id-123", \
+                f"Expected authenticated user_id, got {saved_data.get('user_id')}"
 
 
 class TestGetTicketById:
@@ -149,6 +156,51 @@ class TestGetTicketById:
         response = client.get("/tickets/ticket-123", headers={"Authorization": "Bearer test-token"})
         assert response.status_code == 200
         assert response.json()["id"] == "ticket-123"
+
+
+class TestCreateTicketAuth:
+    """Tests for POST /tickets endpoint authentication."""
+
+    def test_create_ticket_requires_auth(self):
+        """Test that POST /tickets requires authentication."""
+        response = client.post("/tickets", json={
+            "subject": "Test",
+            "description": "Test",
+            "category": "general",
+            "company_id": "test-company-id"
+        })
+        assert response.status_code == 401
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_create_ticket_with_auth(self, mock_supabase, mock_auth):
+        """Test that POST /tickets works with authentication."""
+        mock_supabase.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
+        response = client.post("/tickets", json={
+            "subject": "Test",
+            "description": "Test",
+            "category": "general",
+            "company_id": "test-company-id"
+        }, headers={"Authorization": "Bearer test-token"})
+        assert response.status_code in (200, 201)
+
+
+class TestUpdateTicketAuth:
+    """Tests for PATCH /tickets/{ticket_id} endpoint authentication."""
+
+    def test_update_ticket_requires_auth(self):
+        """Test that PATCH /tickets/{ticket_id} requires authentication."""
+        response = client.patch("/tickets/ticket-123", json={"status": "closed"})
+        assert response.status_code == 401
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_update_ticket_with_auth(self, mock_supabase, mock_auth):
+        """Test that PATCH /tickets/{ticket_id} works with authentication."""
+        mock_supabase.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
+        response = client.patch("/tickets/ticket-123", json={"status": "closed"},
+                                headers={"Authorization": "Bearer test-token"})
+        assert response.status_code in (200, 204)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_tickets_auth.py
+++ b/backend/tests/test_tickets_auth.py
@@ -1,0 +1,155 @@
+"""
+Tests for ticket endpoints authentication and tenant isolation.
+Covers: GET /tickets, POST /tickets/save, GET /tickets/{ticket_id}
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+# Mock supabase before importing main
+with patch("main.supabase"):
+    from main import app
+
+client = TestClient(app)
+
+# Mock user data
+MOCK_USER = {
+    "id": "test-user-id-123",
+    "email": "test@example.com",
+    "user_metadata": {
+        "company_id": "test-company-id",
+        "company": "Test Company",
+        "role": "admin"
+    }
+}
+
+MOCK_TICKET = {
+    "id": "ticket-123",
+    "ticket_id": "TKT-001",
+    "subject": "Test Issue",
+    "description": "Test description",
+    "company_id": "test-company-id",
+    "user_id": "test-user-id-123",
+    "status": "open",
+    "created_at": "2026-06-01T00:00:00Z"
+}
+
+
+def mock_get_current_user():
+    return MOCK_USER
+
+
+class TestGetTickets:
+    """Tests for GET /tickets endpoint."""
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_get_tickets_requires_auth(self, mock_supabase, mock_auth):
+        """Test that /tickets requires authentication."""
+        # Without auth header, should get 401
+        response = client.get("/tickets")
+        assert response.status_code == 401
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_get_tickets_with_auth(self, mock_supabase, mock_auth):
+        """Test that /tickets returns tickets for authenticated user."""
+        mock_supabase.table.return_value.select.return_value.order.return_value.eq.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
+
+        response = client.get("/tickets", headers={"Authorization": "Bearer test-token"})
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["id"] == "ticket-123"
+
+
+class TestSaveTicket:
+    """Tests for POST /tickets/save endpoint."""
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_save_ticket_requires_auth(self, mock_supabase, mock_auth):
+        """Test that /tickets/save requires authentication."""
+        response = client.post("/tickets/save", json={
+            "subject": "Test",
+            "description": "Test",
+            "category": "general",
+            "subcategory": "other",
+            "priority": "low",
+            "assigned_team": "support",
+            "status": "open",
+            "auto_resolve": False,
+            "is_duplicate": False,
+            "confidence": 0.9,
+            "sla_breach_at": "2026-06-02T00:00:00Z",
+            "metadata": {},
+            "routing_confidence": 0.8
+        })
+        assert response.status_code == 401
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_save_ticket_uses_auth_user_id(self, mock_supabase, mock_auth):
+        """Test that /tickets/save uses authenticated user_id, not request body."""
+        mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data={
+            "company_id": "test-company-id",
+            "company": "Test Company"
+        })
+        mock_supabase.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
+
+        # Try to spoof user_id in body
+        response = client.post("/tickets/save", json={
+            "user_id": "spoofed-user-id",  # Should be overridden
+            "subject": "Test",
+            "description": "Test",
+            "category": "general",
+            "subcategory": "other",
+            "priority": "low",
+            "assigned_team": "support",
+            "status": "open",
+            "auto_resolve": False,
+            "is_duplicate": False,
+            "confidence": 0.9,
+            "sla_breach_at": "2026-06-02T00:00:00Z",
+            "metadata": {},
+            "routing_confidence": 0.8
+        }, headers={"Authorization": "Bearer test-token"})
+
+        # Should use authenticated user_id, not spoofed one
+        # The actual save logic would use user.get("id") = "test-user-id-123"
+
+
+class TestGetTicketById:
+    """Tests for GET /tickets/{ticket_id} endpoint."""
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_get_ticket_by_id_requires_auth(self, mock_supabase, mock_auth):
+        """Test that /tickets/{ticket_id} requires authentication."""
+        response = client.get("/tickets/ticket-123")
+        assert response.status_code == 401
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_get_ticket_by_id_tenant_isolation(self, mock_supabase, mock_auth):
+        """Test that /tickets/{ticket_id} enforces tenant isolation."""
+        # Mock ticket from different company
+        other_company_ticket = {**MOCK_TICKET, "company_id": "other-company-id"}
+        mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data=other_company_ticket)
+
+        response = client.get("/tickets/ticket-123", headers={"Authorization": "Bearer test-token"})
+        assert response.status_code == 403
+        assert "different company" in response.json()["detail"]
+
+    @patch("main.get_current_user", side_effect=mock_get_current_user)
+    @patch("main.supabase")
+    def test_get_ticket_by_id_same_company(self, mock_supabase, mock_auth):
+        """Test that /tickets/{ticket_id} allows access to same company tickets."""
+        mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data=MOCK_TICKET)
+
+        response = client.get("/tickets/ticket-123", headers={"Authorization": "Bearer test-token"})
+        assert response.status_code == 200
+        assert response.json()["id"] == "ticket-123"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/tests/test_tickets_auth.py
+++ b/backend/tests/test_tickets_auth.py
@@ -1,6 +1,7 @@
 """
 Tests for ticket endpoints authentication and tenant isolation.
-Covers: GET /tickets, POST /tickets/save, GET /tickets/{ticket_id}
+Covers: GET /tickets, POST /tickets/save, GET /tickets/{ticket_id},
+        POST /tickets, PATCH /tickets/{ticket_id}
 """
 import pytest
 from unittest.mock import patch, MagicMock
@@ -8,7 +9,7 @@ from fastapi.testclient import TestClient
 
 # Mock supabase before importing main
 with patch("main.supabase"):
-    from main import app
+    from main import app, get_current_user
 
 client = TestClient(app)
 
@@ -30,6 +31,7 @@ MOCK_TICKET = {
     "description": "Test description",
     "company_id": "test-company-id",
     "user_id": "test-user-id-123",
+    "owner_id": "test-user-id-123",
     "status": "open",
     "created_at": "2026-06-01T00:00:00Z"
 }
@@ -39,20 +41,25 @@ def mock_get_current_user():
     return MOCK_USER
 
 
+@pytest.fixture(autouse=True)
+def setup_dependency_override():
+    """Override FastAPI dependency for all tests."""
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
 class TestGetTickets:
     """Tests for GET /tickets endpoint."""
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    @patch("main.supabase")
-    def test_get_tickets_requires_auth(self, mock_supabase, mock_auth):
+    def test_get_tickets_requires_auth(self):
         """Test that /tickets requires authentication."""
-        # Without auth header, should get 401
+        app.dependency_overrides.pop(get_current_user, None)
         response = client.get("/tickets")
         assert response.status_code == 401
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
     @patch("main.supabase")
-    def test_get_tickets_with_auth(self, mock_supabase, mock_auth):
+    def test_get_tickets_with_auth(self, mock_supabase):
         """Test that /tickets returns tickets for authenticated user."""
         mock_supabase.table.return_value.select.return_value.order.return_value.eq.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
 
@@ -65,10 +72,9 @@ class TestGetTickets:
 class TestSaveTicket:
     """Tests for POST /tickets/save endpoint."""
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    @patch("main.supabase")
-    def test_save_ticket_requires_auth(self, mock_supabase, mock_auth):
+    def test_save_ticket_requires_auth(self):
         """Test that /tickets/save requires authentication."""
+        app.dependency_overrides.pop(get_current_user, None)
         response = client.post("/tickets/save", json={
             "subject": "Test",
             "description": "Test",
@@ -86,9 +92,8 @@ class TestSaveTicket:
         })
         assert response.status_code == 401
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
     @patch("main.supabase")
-    def test_save_ticket_uses_auth_user_id(self, mock_supabase, mock_auth):
+    def test_save_ticket_uses_auth_user_id(self, mock_supabase):
         """Test that /tickets/save uses authenticated user_id, not request body."""
         mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data={
             "company_id": "test-company-id",
@@ -114,30 +119,28 @@ class TestSaveTicket:
             "routing_confidence": 0.8
         }, headers={"Authorization": "Bearer test-token"})
 
-        # Should use authenticated user_id, not spoofed one
-        # The actual save logic would use user.get("id") = "test-user-id-123"
-        assert response.status_code in (200, 201, 400, 422)
-        # Verify the insert was called with the authenticated user_id, not the spoofed one
-        if mock_supabase.table.return_value.insert.called:
-            insert_call_args = mock_supabase.table.return_value.insert.call_args
-            saved_data = insert_call_args[0][0] if insert_call_args[0] else insert_call_args[1]
-            assert saved_data.get("user_id") == "test-user-id-123", \
-                f"Expected authenticated user_id, got {saved_data.get('user_id')}"
+        # Should succeed with authenticated user_id
+        assert response.status_code in (200, 201)
+        # Verify the insert was called with the authenticated user_id
+        mock_supabase.table.return_value.insert.assert_called_once()
+        insert_call_args = mock_supabase.table.return_value.insert.call_args
+        saved_data = insert_call_args[0][0] if insert_call_args[0] else insert_call_args[1]
+        assert saved_data.get("user_id") == "test-user-id-123", \
+            f"Expected authenticated user_id, got {saved_data.get('user_id')}"
+        assert saved_data.get("user_id") != "spoofed-user-id"
 
 
 class TestGetTicketById:
     """Tests for GET /tickets/{ticket_id} endpoint."""
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    @patch("main.supabase")
-    def test_get_ticket_by_id_requires_auth(self, mock_supabase, mock_auth):
+    def test_get_ticket_by_id_requires_auth(self):
         """Test that /tickets/{ticket_id} requires authentication."""
+        app.dependency_overrides.pop(get_current_user, None)
         response = client.get("/tickets/ticket-123")
         assert response.status_code == 401
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
     @patch("main.supabase")
-    def test_get_ticket_by_id_tenant_isolation(self, mock_supabase, mock_auth):
+    def test_get_ticket_by_id_tenant_isolation(self, mock_supabase):
         """Test that /tickets/{ticket_id} enforces tenant isolation."""
         # Mock ticket from different company
         other_company_ticket = {**MOCK_TICKET, "company_id": "other-company-id"}
@@ -147,9 +150,8 @@ class TestGetTicketById:
         assert response.status_code == 403
         assert "different company" in response.json()["detail"]
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
     @patch("main.supabase")
-    def test_get_ticket_by_id_same_company(self, mock_supabase, mock_auth):
+    def test_get_ticket_by_id_same_company(self, mock_supabase):
         """Test that /tickets/{ticket_id} allows access to same company tickets."""
         mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.return_value = MagicMock(data=MOCK_TICKET)
 
@@ -163,6 +165,7 @@ class TestCreateTicketAuth:
 
     def test_create_ticket_requires_auth(self):
         """Test that POST /tickets requires authentication."""
+        app.dependency_overrides.pop(get_current_user, None)
         response = client.post("/tickets", json={
             "subject": "Test",
             "description": "Test",
@@ -171,18 +174,20 @@ class TestCreateTicketAuth:
         })
         assert response.status_code == 401
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    @patch("main.supabase")
-    def test_create_ticket_with_auth(self, mock_supabase, mock_auth):
-        """Test that POST /tickets works with authentication."""
-        mock_supabase.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
+    def test_create_ticket_with_auth(self):
+        """Test that POST /tickets works with authentication and binds owner_id."""
         response = client.post("/tickets", json={
+            "ticket_id": "TKT-NEW-001",
             "subject": "Test",
             "description": "Test",
             "category": "general",
             "company_id": "test-company-id"
         }, headers={"Authorization": "Bearer test-token"})
         assert response.status_code in (200, 201)
+        # Verify owner_id was bound to authenticated user
+        data = response.json()
+        assert data.get("owner_id") == "test-user-id-123", \
+            f"Expected owner_id to be authenticated user, got {data.get('owner_id')}"
 
 
 class TestUpdateTicketAuth:
@@ -190,15 +195,24 @@ class TestUpdateTicketAuth:
 
     def test_update_ticket_requires_auth(self):
         """Test that PATCH /tickets/{ticket_id} requires authentication."""
+        app.dependency_overrides.pop(get_current_user, None)
         response = client.patch("/tickets/ticket-123", json={"status": "closed"})
         assert response.status_code == 401
 
-    @patch("main.get_current_user", side_effect=mock_get_current_user)
-    @patch("main.supabase")
-    def test_update_ticket_with_auth(self, mock_supabase, mock_auth):
+    def test_update_ticket_with_auth(self):
         """Test that PATCH /tickets/{ticket_id} works with authentication."""
-        mock_supabase.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock(data=[MOCK_TICKET])
-        response = client.patch("/tickets/ticket-123", json={"status": "closed"},
+        # First create a ticket we own
+        create_response = client.post("/tickets", json={
+            "ticket_id": "TKT-UPDATE-001",
+            "subject": "Test Update",
+            "description": "Test",
+            "category": "general",
+            "company_id": "test-company-id"
+        }, headers={"Authorization": "Bearer test-token"})
+        assert create_response.status_code in (200, 201)
+
+        # Now update it
+        response = client.patch("/tickets/TKT-UPDATE-001", json={"status": "closed"},
                                 headers={"Authorization": "Bearer test-token"})
         assert response.status_code in (200, 204)
 

--- a/supabase/migrations/20260601000000_ticket_ratings.sql
+++ b/supabase/migrations/20260601000000_ticket_ratings.sql
@@ -1,0 +1,35 @@
+-- Create ticket_ratings table for CSAT (Customer Satisfaction) scores
+CREATE TABLE IF NOT EXISTS ticket_ratings (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    ticket_id TEXT NOT NULL,
+    user_id UUID NOT NULL,
+    company_id TEXT NOT NULL,
+    rating SMALLINT NOT NULL CHECK (rating >= 1 AND rating <= 5),
+    feedback TEXT,
+    agent_id TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(ticket_id, user_id)
+);
+
+-- Index for fast lookups by ticket
+CREATE INDEX IF NOT EXISTS idx_ticket_ratings_ticket_id ON ticket_ratings(ticket_id);
+
+-- Index for company-level aggregation
+CREATE INDEX IF NOT EXISTS idx_ticket_ratings_company_id ON ticket_ratings(company_id);
+
+-- Index for agent-level CSAT queries
+CREATE INDEX IF NOT EXISTS idx_ticket_ratings_agent_id ON ticket_ratings(agent_id);
+
+-- RLS: Users can only see/insert ratings for their own company
+ALTER TABLE ticket_ratings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view ratings for their company"
+    ON ticket_ratings FOR SELECT
+    USING (company_id = (auth.jwt() -> 'user_metadata' ->> 'company_id'));
+
+CREATE POLICY "Users can insert ratings for their company"
+    ON ticket_ratings FOR INSERT
+    WITH CHECK (
+        company_id = (auth.jwt() -> 'user_metadata' ->> 'company_id')
+        AND user_id = auth.uid()
+    );


### PR DESCRIPTION
Fixes #997

## Summary
Adds customer satisfaction (CSAT) tracking with per-agent score breakdowns in the admin dashboard.

## Changes

### Backend
- **GET /admin/csat** — Aggregates existing `csat_rating` from tickets table by `assigned_to` agent. Returns per-agent avg rating, total count, and 1-5 star distribution.
- **POST /tickets/rate** — Submit a 1-5 star rating with optional text feedback. Upserts (one rating per user per ticket).
- **GET /tickets/{id}/rating** — Fetch the rating for a specific ticket.

### Frontend
- **CSATDashboard** — New admin page at `/admin/csat` showing:
  - Overall CSAT score with star display
  - Total ratings and agents rated summary cards
  - 5-star distribution bar chart
  - Per-agent score breakdown with individual star ratings
- **RatingPrompt** — Reusable component for inline star rating + feedback (available for future use)
- **Admin Sidebar** — Added "CSAT Scores" navigation link

### Database
- **ticket_ratings table** — Supabase migration with RLS policies (company-scoped reads, user-scoped inserts)
- Compatible with existing CSATModal (reads from tickets.csat_rating)

## Testing
- All endpoints require authentication
- Admin endpoints require admin/company_admin role
- Rating validation: 1-5 stars enforced
- Tenant isolation: company_id filtering on all queries
