### PR TITLE
fix: normalize ISO-8601 timestamps for Safari compatibility (Fixes #912)

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -1,16 +1,52 @@
 /**
  * Unified Date Utility for HELPDESK.AI
  * Fixes timezone shift issues by explicitly forcing local display.
+ * Normalizes ISO-8601 timestamps for cross-browser compatibility (Safari, Chrome, Firefox).
  */
+
+/**
+ * Normalize a date string into a Safari-compatible ISO-8601 format.
+ * Safari's Date parser is stricter than Chrome/Firefox — it requires
+ * the 'T' separator between date and time and explicit timezone designators.
+ *
+ * Handles common Supabase/Postgres output variants:
+ *   - "2024-01-15 10:30:00"        → "2024-01-15T10:30:00Z"
+ *   - "2024-01-15T10:30:00"        → "2024-01-15T10:30:00Z"
+ *   - "2024-01-15T10:30:00+00:00"  → unchanged (already has TZ)
+ *   - "2024-01-15T10:30:00Z"       → unchanged (already has TZ)
+ *   - "2024-01-15"                 → "2024-01-15T00:00:00Z"
+ */
+const normalizeDateString = (dateStr) => {
+    if (typeof dateStr !== 'string') return dateStr;
+
+    // Already has a timezone indicator — return as-is
+    if (dateStr.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(dateStr) || /[+-]\d{4}$/.test(dateStr)) {
+        return dateStr;
+    }
+
+    // Replace space separator with 'T' for Safari compatibility
+    let normalized = dateStr.replace(' ', 'T');
+
+    // If it's a date-only string (YYYY-MM-DD), add time component
+    if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) {
+        return normalized + 'T00:00:00Z';
+    }
+
+    // Has time but no timezone — assume UTC (matches Supabase default)
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(normalized)) {
+        return normalized + 'Z';
+    }
+
+    return dateStr;
+};
 
 export const formatTimelineDate = (dateStr) => {
     if (!dateStr) return null;
-    
-    // Ensure the date string is interpreted as UTC if it's an ISO string from DB
+
     let date;
-    if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
-        // If it's a raw string without TZ, assume it was intended as UTC from our backend
-        date = new Date(dateStr + 'Z');
+    if (typeof dateStr === 'string') {
+        const normalized = normalizeDateString(dateStr);
+        date = new Date(normalized);
     } else {
         date = new Date(dateStr);
     }

--- a/Frontend/src/utils/dateUtils.test.js
+++ b/Frontend/src/utils/dateUtils.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { formatTimelineDate, formatFullTimestamp } from './dateUtils';
+
+describe('dateUtils', () => {
+    describe('formatTimelineDate', () => {
+        it('returns null for falsy input', () => {
+            expect(formatTimelineDate(null)).toBeNull();
+            expect(formatTimelineDate(undefined)).toBeNull();
+            expect(formatTimelineDate('')).toBeNull();
+        });
+
+        it('parses ISO-8601 with Z suffix', () => {
+            const result = formatTimelineDate('2024-01-15T10:30:00Z');
+            expect(result).not.toBe('Invalid Date');
+            expect(result).toContain('Jan');
+            expect(result).toContain('2024');
+        });
+
+        it('parses ISO-8601 without Z (space separator)', () => {
+            // Supabase sometimes returns "2024-01-15 10:30:00" without timezone
+            const result = formatTimelineDate('2024-01-15 10:30:00');
+            expect(result).not.toBe('Invalid Date');
+            expect(result).toContain('Jan');
+            expect(result).toContain('2024');
+        });
+
+        it('parses ISO-8601 with T separator but no timezone', () => {
+            const result = formatTimelineDate('2024-01-15T10:30:00');
+            expect(result).not.toBe('Invalid Date');
+            expect(result).toContain('Jan');
+        });
+
+        it('parses ISO-8601 with explicit offset', () => {
+            const result = formatTimelineDate('2024-01-15T10:30:00+05:30');
+            expect(result).not.toBe('Invalid Date');
+            expect(result).toContain('Jan');
+        });
+
+        it('parses date-only strings', () => {
+            const result = formatTimelineDate('2024-01-15');
+            expect(result).not.toBe('Invalid Date');
+            expect(result).toContain('Jan');
+            expect(result).toContain('2024');
+        });
+
+        it('returns Invalid Date for garbage input', () => {
+            expect(formatTimelineDate('not-a-date')).toBe('Invalid Date');
+        });
+    });
+
+    describe('formatFullTimestamp', () => {
+        it('returns Processing... for null input', () => {
+            expect(formatFullTimestamp(null)).toBe('Processing...');
+        });
+
+        it('appends timezone abbreviation', () => {
+            const result = formatFullTimestamp('2024-01-15T10:30:00Z');
+            expect(result).toContain('(');
+            expect(result).toContain(')');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Fixes date parsing on Safari by normalizing ISO-8601 timestamp strings before passing them to `new Date()`. Safari's parser is stricter than Chrome/Firefox and fails on common Supabase output formats.

## Problem
Safari fails to parse these valid ISO-8601 variants returned by Supabase/Postgres:
- `2024-01-15 10:30:00` — space separator (no T)
- `2024-01-15T10:30:00` — no timezone designator
- `2024-01-15` — date-only string

This causes blank timelines and render breaks on Safari viewports.

## Solution
Added `normalizeDateString()` helper that converts date strings to Safari-compatible format:
- Replaces space separator with `T`
- Appends `Z` when no timezone is present (assumes UTC, matching Supabase default)
- Handles date-only strings by adding `T00:00:00Z`
- Passes through strings that already have timezone indicators unchanged

## Changes
- `Frontend/src/utils/dateUtils.js` — added `normalizeDateString()` helper, updated `formatTimelineDate()` to use it
- `Frontend/src/utils/dateUtils.test.js` — new test suite covering all date format variants

## Testing
Tests cover: ISO with Z, ISO without TZ, space-separated, date-only, explicit offset, garbage input, null/undefined.

## Related Issues
Fixes #912