### PR TITLE
fix: default USE_MOCK to false so real backend is used by default (Fixes #1071)

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -8,4 +8,4 @@
 VITE_API_URL=http://localhost:8000
 
 # Set to 'false' to disable mock data and use real API
-VITE_USE_MOCK=true
+VITE_USE_MOCK=false

--- a/Frontend/src/config.js
+++ b/Frontend/src/config.js
@@ -18,5 +18,5 @@ export const API_CONFIG = {
     BACKEND_URL: getBackendUrl(),
     FRONTEND_URL: window.location.origin,
     IS_PROD: import.meta.env.PROD,
-    USE_MOCK: import.meta.env.VITE_USE_MOCK !== 'false'  // default true
+    USE_MOCK: import.meta.env.VITE_USE_MOCK === 'true'  // default false
 };


### PR DESCRIPTION
Fixes #1071

## Summary
Change the default value of `USE_MOCK` from `true` to `false` so the frontend uses the real Supabase backend by default instead of localStorage mock data.

## Changes
- `Frontend/src/config.js`: Change `import.meta.env.VITE_USE_MOCK !== 'false'` to `import.meta.env.VITE_USE_MOCK === 'true'`
- `Frontend/.env.example`: Update default from `VITE_USE_MOCK=true` to `VITE_USE_MOCK=false`

## Testing
- With `VITE_USE_MOCK` unset: real backend is used (GET /tickets, POST /tickets/save)
- With `VITE_USE_MOCK=true`: mock mode enabled (localStorage)
- With `VITE_USE_MOCK=false`: real backend is used explicitly
- No source code changes needed in api.js — it already handles both paths

## Impact
- Production deployments now use real Supabase data by default
- Local development can still opt into mock mode with `VITE_USE_MOCK=true`
- Eliminates confusion from seeing mock data in production