### PR TITLE
fix: Safari date parsing in dateUtils.js

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -17,8 +17,6 @@ const parseDate = (dateStr) => {
     if (dateStr instanceof Date) {
         return isNaN(dateStr.getTime()) ? null : dateStr;
     }
-    return dateStr;
-  }
 
     // Convert to string if needed
     const str = String(dateStr).trim();
@@ -80,25 +78,30 @@ const parseDate = (dateStr) => {
     return date;
 };
 
+/**
+ * Normalize date string for Safari compatibility.
+ * Safari requires ISO-8601 format with 'T' separator.
+ * @param {string} dateStr - Raw date string
+ * @returns {string|null} - Normalized ISO string or null
+ */
+const normalizeDateString = (dateStr) => {
+    const date = parseDate(dateStr);
+    if (!date) return null;
+    return date.toISOString();
+};
+
 export const formatTimelineDate = (dateStr) => {
     const date = parseDate(dateStr);
     if (!date) return 'Invalid Date';
 
-export const formatTimelineDate = (dateStr) => {
-  const normalized = normalizeDateString(dateStr);
-  if (!normalized) return null;
-
-  const date = new Date(normalized);
-  if (isNaN(date.getTime())) return 'Invalid Date';
-
-  return date.toLocaleString(undefined, {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: true,
-  });
+    return date.toLocaleString(undefined, {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+    });
 };
 
 /**
@@ -108,13 +111,14 @@ export const formatTimelineDate = (dateStr) => {
  * @returns {string}
  */
 export const getTimeZoneAbbr = () => {
-  try {
-    return (
-      new Intl.DateTimeFormat('en-US', {
-        timeZoneName: 'short',
-      })
-        .formatToParts(new Date())
-        .find(part => part.type === 'timeZoneName')?.value || 'UTC';
+    try {
+        return (
+            new Intl.DateTimeFormat('en-US', {
+                timeZoneName: 'short',
+            })
+                .formatToParts(new Date())
+                .find(part => part.type === 'timeZoneName')?.value || 'UTC'
+        );
     } catch (_e) {
         return 'UTC';
     }
@@ -128,9 +132,9 @@ export const getTimeZoneAbbr = () => {
  * @returns {string}
  */
 export const formatFullTimestamp = (dateStr) => {
-  const formatted = formatTimelineDate(dateStr);
-  if (!formatted) return 'Processing...';
-  return `${formatted} (${getTimeZoneAbbr()})`;
+    const formatted = formatTimelineDate(dateStr);
+    if (!formatted || formatted === 'Invalid Date') return 'Processing...';
+    return `${formatted} (${getTimeZoneAbbr()})`;
 };
 
 /**
@@ -165,3 +169,16 @@ export const getRelativeTime = (dateStr) => {
 
     return formatTimelineDate(dateStr);
 };
+
+/**
+ * Format date for Safari-compatible ISO string
+ * @param {string|Date} dateStr - Date to format
+ * @returns {string} - Safari-compatible ISO string
+ */
+export const toSafariISOString = (dateStr) => {
+    const date = parseDate(dateStr);
+    if (!date) return '';
+    return date.toISOString();
+};
+
+export { parseDate, normalizeDateString };


### PR DESCRIPTION
## Summary
Fixes Safari date parsing issues in dateUtils.js that caused blank timelines and page render breaks.

## Changes
- Fixed syntax errors in parseDate function (unclosed code blocks)
- Removed duplicate ormatTimelineDate function definition
- Added 
ormalizeDateString helper for Safari compatibility
- Added 	oSafariISOString export for consistent date formatting
- Improved error handling for invalid dates

## Testing
- Tested with various ISO-8601 date formats
- Verified Safari compatibility with date strings containing spaces instead of 'T'
- Confirmed fallback handling for edge cases

Fixes #912