### PR TITLE
fix: replace overflow-y:scroll with scrollbar-gutter to restore sticky navbar (Fixes #1082)

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -108,7 +108,11 @@
 }
 
 html {
-  overflow-y: scroll;
+  /* scrollbar-gutter reserves space for the scrollbar without creating a
+     scroll container — unlike overflow-y:scroll which breaks position:sticky
+     on every descendant (CSS spec: sticky is disabled when any ancestor has
+     overflow:scroll|hidden|auto). */
+  scrollbar-gutter: stable;
 }
 
 body{


### PR DESCRIPTION
## Summary
The navbar was not sticky on any page because `overflow-y: scroll` on the `<html>` element broke CSS `position: sticky` globally.

## Root Cause
Per the [CSS specification](https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky), `position: sticky` is disabled when **any ancestor** has `overflow: scroll`, `overflow: hidden`, or `overflow: auto`.

Since `<html>` is the ultimate ancestor of every DOM element, this single CSS rule broke sticky positioning for the navbar on:
- Landing page
- User dashboard (TopNav)
- Admin dashboard (AdminHeader)
- Every other page with a sticky header

## Fix
Replace `overflow-y: scroll` with `scrollbar-gutter: stable` in `index.css`:

```css
/* Before (breaks sticky globally) */
html { overflow-y: scroll; }

/* After (reserves scrollbar space without breaking sticky) */
html { scrollbar-gutter: stable; }
```

**Why scrollbar-gutter: stable?** The original `overflow-y: scroll` was likely added to prevent layout shift when the scrollbar appears/disappears. `scrollbar-gutter: stable` achieves the same goal — it reserves space for the scrollbar — without creating a scroll container that disables sticky positioning.

## Changes
- `Frontend/src/index.css`: Replace `overflow-y: scroll` with `scrollbar-gutter: stable` on `html` element

## Testing
1. Visit any page with a navbar (landing page, dashboard, etc.)
2. Scroll down
3. Navbar should remain fixed at the top of the viewport
4. Scrollbar gutter should remain consistent (no layout shift)

## Related Issues
Fixes #1082