### PR TITLE
test: add rag_service unit tests

### DIFF
--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -9,8 +9,8 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def mock_ai_services():
+    """Override the app-wide autouse fixture; these tests stub RAG imports directly."""
     yield
-    sys.modules.pop("backend.services.rag_service", None)
 
 
 class EncodedVector:
@@ -43,22 +43,39 @@ def import_rag_service(monkeypatch, *, supabase_client=None, transformer_factory
     monkeypatch.setitem(sys.modules, "dotenv", dotenv_module)
 
     module = importlib.import_module("backend.services.rag_service")
-    return module, transformer_factory, supabase_module.create_client, dotenv_module.load_dotenv
+    return SimpleNamespace(
+        module=module,
+        transformer_factory=transformer_factory,
+        create_client=supabase_module.create_client,
+        load_dotenv=dotenv_module.load_dotenv,
+    )
+
+
+def configure_loaded_service(service, *, model=None, supabase=None):
+    service._loaded = True
+    service._load_failed = False
+    service.model = model if model is not None else Mock()
+    if supabase is not None:
+        service.supabase = supabase
+    return service
 
 
 def test_init_creates_supabase_client_when_credentials_are_configured(monkeypatch):
     monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
     monkeypatch.setenv("SUPABASE_SERVICE_KEY", "service-key")
     supabase_client = Mock(name="client")
-    module, _, create_client, load_dotenv = import_rag_service(
+    context = import_rag_service(
         monkeypatch,
         supabase_client=supabase_client,
     )
 
-    service = module.RagService()
+    service = context.module.RagService()
 
-    load_dotenv.assert_called_once_with()
-    create_client.assert_called_once_with("https://example.supabase.co", "service-key")
+    context.load_dotenv.assert_called_once_with()
+    context.create_client.assert_called_once_with(
+        "https://example.supabase.co",
+        "service-key",
+    )
     assert service.supabase is supabase_client
     assert service.model is None
     assert service.is_available() is False
@@ -67,39 +84,45 @@ def test_init_creates_supabase_client_when_credentials_are_configured(monkeypatc
 def test_init_leaves_supabase_unconfigured_when_credentials_are_missing(monkeypatch):
     monkeypatch.delenv("SUPABASE_URL", raising=False)
     monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
-    module, _, create_client, _ = import_rag_service(monkeypatch)
+    context = import_rag_service(monkeypatch)
 
-    service = module.RagService()
+    service = context.module.RagService()
 
-    create_client.assert_not_called()
+    context.create_client.assert_not_called()
     assert service.supabase is None
 
 
-def test_is_available_requires_loaded_model_without_previous_load_failure(monkeypatch):
-    module, _, _, _ = import_rag_service(monkeypatch)
-    service = module.RagService()
+def test_is_available_reflects_successful_and_failed_loads(monkeypatch):
+    context = import_rag_service(monkeypatch)
+    service = context.module.RagService()
 
-    service._loaded = True
-    service._load_failed = False
+    service.load()
     assert service.is_available() is True
 
-    service._load_failed = True
-    assert service.is_available() is False
+    monkeypatch.delenv("ALLOW_DEGRADED_STARTUP", raising=False)
+    failed_context = import_rag_service(monkeypatch)
+    monkeypatch.setattr(failed_context.module, "_HAS_SENTENCE", False)
+    monkeypatch.setattr(failed_context.module, "SentenceTransformer", None)
+    failed_service = failed_context.module.RagService()
 
+    with pytest.raises(ImportError):
+        failed_service.load()
+
+    assert failed_service.is_available() is False
 
 def test_load_uses_default_sentence_transformer_when_no_local_path_is_configured(monkeypatch):
     monkeypatch.delenv("SENTENCE_TRANSFORMER_MODEL_PATH", raising=False)
     model = Mock(name="model")
     transformer_factory = Mock(return_value=model)
-    module, transformer_factory, _, _ = import_rag_service(
+    context = import_rag_service(
         monkeypatch,
         transformer_factory=transformer_factory,
     )
-    service = module.RagService()
+    service = context.module.RagService()
 
     service.load()
 
-    transformer_factory.assert_called_once_with("all-MiniLM-L6-v2")
+    context.transformer_factory.assert_called_once_with("all-MiniLM-L6-v2")
     assert service.model is model
     assert service.is_available() is True
 
@@ -110,15 +133,15 @@ def test_load_prefers_existing_local_sentence_transformer_path(monkeypatch, tmp_
     monkeypatch.setenv("SENTENCE_TRANSFORMER_MODEL_PATH", str(model_dir))
     model = Mock(name="local_model")
     transformer_factory = Mock(return_value=model)
-    module, transformer_factory, _, _ = import_rag_service(
+    context = import_rag_service(
         monkeypatch,
         transformer_factory=transformer_factory,
     )
-    service = module.RagService()
+    service = context.module.RagService()
 
     service.load()
 
-    transformer_factory.assert_called_once_with(str(model_dir))
+    context.transformer_factory.assert_called_once_with(str(model_dir))
     assert service.model is model
     assert service.is_available() is True
 
@@ -126,75 +149,70 @@ def test_load_prefers_existing_local_sentence_transformer_path(monkeypatch, tmp_
 def test_load_is_idempotent_after_model_is_loaded(monkeypatch):
     model = Mock(name="model")
     transformer_factory = Mock(return_value=model)
-    module, transformer_factory, _, _ = import_rag_service(
+    context = import_rag_service(
         monkeypatch,
         transformer_factory=transformer_factory,
     )
-    service = module.RagService()
+    service = context.module.RagService()
 
     service.load()
     service.load()
 
-    transformer_factory.assert_called_once_with("all-MiniLM-L6-v2")
+    context.transformer_factory.assert_called_once_with("all-MiniLM-L6-v2")
     assert service.model is model
 
 
 def test_load_degrades_without_sentence_transformers_when_allowed(monkeypatch):
     monkeypatch.setenv("ALLOW_DEGRADED_STARTUP", "1")
     transformer_factory = Mock()
-    module, transformer_factory, _, _ = import_rag_service(
+    context = import_rag_service(
         monkeypatch,
         transformer_factory=transformer_factory,
     )
-    monkeypatch.setattr(module, "_HAS_SENTENCE", False)
-    monkeypatch.setattr(module, "SentenceTransformer", None)
-    service = module.RagService()
+    monkeypatch.setattr(context.module, "_HAS_SENTENCE", False)
+    monkeypatch.setattr(context.module, "SentenceTransformer", None)
+    service = context.module.RagService()
 
     service.load()
 
-    transformer_factory.assert_not_called()
+    context.transformer_factory.assert_not_called()
     assert service.model is None
-    assert service._loaded is False
-    assert service._load_failed is True
     assert service.is_available() is False
 
 
 def test_load_raises_without_sentence_transformers_when_degraded_startup_is_disabled(monkeypatch):
     monkeypatch.delenv("ALLOW_DEGRADED_STARTUP", raising=False)
-    module, _, _, _ = import_rag_service(monkeypatch)
-    monkeypatch.setattr(module, "_HAS_SENTENCE", False)
-    monkeypatch.setattr(module, "SentenceTransformer", None)
-    service = module.RagService()
+    context = import_rag_service(monkeypatch)
+    monkeypatch.setattr(context.module, "_HAS_SENTENCE", False)
+    monkeypatch.setattr(context.module, "SentenceTransformer", None)
+    service = context.module.RagService()
 
     with pytest.raises(ImportError, match="sentence-transformers is required"):
         service.load()
 
-    assert service._load_failed is True
     assert service.is_available() is False
 
 
 def test_search_knowledge_base_returns_none_when_model_or_supabase_is_unavailable(monkeypatch):
-    module, _, _, _ = import_rag_service(monkeypatch)
-    service = module.RagService()
+    context = import_rag_service(monkeypatch)
+    service = context.module.RagService()
     model = Mock()
     service.model = model
-    service._loaded = False
 
     assert service.search_knowledge_base("reset password") is None
     model.encode.assert_not_called()
 
-    service._loaded = True
+    configure_loaded_service(service, model=model)
     service.supabase = None
     assert service.search_knowledge_base("reset password") is None
     model.encode.assert_not_called()
 
 
 def test_search_knowledge_base_returns_first_matching_article(monkeypatch):
-    module, _, _, _ = import_rag_service(monkeypatch)
-    service = module.RagService()
-    service._loaded = True
-    service.model = Mock()
-    service.model.encode.return_value = EncodedVector([0.1, 0.2, 0.3])
+    context = import_rag_service(monkeypatch)
+    service = context.module.RagService()
+    model = Mock()
+    model.encode.return_value = EncodedVector([0.1, 0.2, 0.3])
 
     rpc_call = Mock()
     rpc_call.execute.return_value = SimpleNamespace(
@@ -213,8 +231,9 @@ def test_search_knowledge_base_returns_first_matching_article(monkeypatch):
             },
         ]
     )
-    service.supabase = Mock()
-    service.supabase.rpc.return_value = rpc_call
+    supabase = Mock()
+    supabase.rpc.return_value = rpc_call
+    configure_loaded_service(service, model=model, supabase=supabase)
 
     result = service.search_knowledge_base(
         "How do I reset my password?",
@@ -222,8 +241,8 @@ def test_search_knowledge_base_returns_first_matching_article(monkeypatch):
         match_count=3,
     )
 
-    service.model.encode.assert_called_once_with("How do I reset my password?")
-    service.supabase.rpc.assert_called_once_with(
+    model.encode.assert_called_once_with("How do I reset my password?")
+    supabase.rpc.assert_called_once_with(
         "match_articles",
         {
             "query_embedding": [0.1, 0.2, 0.3],
@@ -240,32 +259,32 @@ def test_search_knowledge_base_returns_first_matching_article(monkeypatch):
 
 
 def test_search_knowledge_base_returns_none_when_no_matches_are_found(monkeypatch):
-    module, _, _, _ = import_rag_service(monkeypatch)
-    service = module.RagService()
-    service._loaded = True
-    service.model = Mock()
-    service.model.encode.return_value = EncodedVector([0.5])
+    context = import_rag_service(monkeypatch)
+    service = context.module.RagService()
+    model = Mock()
+    model.encode.return_value = EncodedVector([0.5])
     rpc_call = Mock()
     rpc_call.execute.return_value = SimpleNamespace(data=[])
-    service.supabase = Mock()
-    service.supabase.rpc.return_value = rpc_call
+    supabase = Mock()
+    supabase.rpc.return_value = rpc_call
+    configure_loaded_service(service, model=model, supabase=supabase)
 
     assert service.search_knowledge_base("unknown question") is None
 
 
 def test_search_knowledge_base_handles_embedding_or_rpc_errors(monkeypatch):
-    module, _, _, _ = import_rag_service(monkeypatch)
-    service = module.RagService()
-    service._loaded = True
-    service.model = Mock()
-    service.model.encode.side_effect = RuntimeError("embedding failed")
-    service.supabase = Mock()
+    context = import_rag_service(monkeypatch)
+    service = context.module.RagService()
+    model = Mock()
+    model.encode.side_effect = RuntimeError("embedding failed")
+    supabase = Mock()
+    configure_loaded_service(service, model=model, supabase=supabase)
 
     assert service.search_knowledge_base("broken") is None
-    service.supabase.rpc.assert_not_called()
+    supabase.rpc.assert_not_called()
 
-    service.model.encode.side_effect = None
-    service.model.encode.return_value = EncodedVector([0.9])
-    service.supabase.rpc.side_effect = RuntimeError("rpc failed")
+    model.encode.side_effect = None
+    model.encode.return_value = EncodedVector([0.9])
+    supabase.rpc.side_effect = RuntimeError("rpc failed")
 
     assert service.search_knowledge_base("rpc failure") is None

--- a/backend/tests/test_rag_service.py
+++ b/backend/tests/test_rag_service.py
@@ -1,0 +1,271 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_ai_services():
+    yield
+    sys.modules.pop("backend.services.rag_service", None)
+
+
+class EncodedVector:
+    def __init__(self, values):
+        self._values = values
+
+    def tolist(self):
+        return list(self._values)
+
+
+def import_rag_service(monkeypatch, *, supabase_client=None, transformer_factory=None):
+    sys.modules.pop("backend.services.rag_service", None)
+
+    if supabase_client is None:
+        supabase_client = Mock(name="supabase_client")
+    if transformer_factory is None:
+        transformer_factory = Mock(return_value=Mock(name="sentence_model"))
+
+    sentence_module = types.ModuleType("sentence_transformers")
+    sentence_module.SentenceTransformer = transformer_factory
+    monkeypatch.setitem(sys.modules, "sentence_transformers", sentence_module)
+
+    supabase_module = types.ModuleType("supabase")
+    supabase_module.Client = object
+    supabase_module.create_client = Mock(return_value=supabase_client)
+    monkeypatch.setitem(sys.modules, "supabase", supabase_module)
+
+    dotenv_module = types.ModuleType("dotenv")
+    dotenv_module.load_dotenv = Mock()
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_module)
+
+    module = importlib.import_module("backend.services.rag_service")
+    return module, transformer_factory, supabase_module.create_client, dotenv_module.load_dotenv
+
+
+def test_init_creates_supabase_client_when_credentials_are_configured(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "service-key")
+    supabase_client = Mock(name="client")
+    module, _, create_client, load_dotenv = import_rag_service(
+        monkeypatch,
+        supabase_client=supabase_client,
+    )
+
+    service = module.RagService()
+
+    load_dotenv.assert_called_once_with()
+    create_client.assert_called_once_with("https://example.supabase.co", "service-key")
+    assert service.supabase is supabase_client
+    assert service.model is None
+    assert service.is_available() is False
+
+
+def test_init_leaves_supabase_unconfigured_when_credentials_are_missing(monkeypatch):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
+    module, _, create_client, _ = import_rag_service(monkeypatch)
+
+    service = module.RagService()
+
+    create_client.assert_not_called()
+    assert service.supabase is None
+
+
+def test_is_available_requires_loaded_model_without_previous_load_failure(monkeypatch):
+    module, _, _, _ = import_rag_service(monkeypatch)
+    service = module.RagService()
+
+    service._loaded = True
+    service._load_failed = False
+    assert service.is_available() is True
+
+    service._load_failed = True
+    assert service.is_available() is False
+
+
+def test_load_uses_default_sentence_transformer_when_no_local_path_is_configured(monkeypatch):
+    monkeypatch.delenv("SENTENCE_TRANSFORMER_MODEL_PATH", raising=False)
+    model = Mock(name="model")
+    transformer_factory = Mock(return_value=model)
+    module, transformer_factory, _, _ = import_rag_service(
+        monkeypatch,
+        transformer_factory=transformer_factory,
+    )
+    service = module.RagService()
+
+    service.load()
+
+    transformer_factory.assert_called_once_with("all-MiniLM-L6-v2")
+    assert service.model is model
+    assert service.is_available() is True
+
+
+def test_load_prefers_existing_local_sentence_transformer_path(monkeypatch, tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    monkeypatch.setenv("SENTENCE_TRANSFORMER_MODEL_PATH", str(model_dir))
+    model = Mock(name="local_model")
+    transformer_factory = Mock(return_value=model)
+    module, transformer_factory, _, _ = import_rag_service(
+        monkeypatch,
+        transformer_factory=transformer_factory,
+    )
+    service = module.RagService()
+
+    service.load()
+
+    transformer_factory.assert_called_once_with(str(model_dir))
+    assert service.model is model
+    assert service.is_available() is True
+
+
+def test_load_is_idempotent_after_model_is_loaded(monkeypatch):
+    model = Mock(name="model")
+    transformer_factory = Mock(return_value=model)
+    module, transformer_factory, _, _ = import_rag_service(
+        monkeypatch,
+        transformer_factory=transformer_factory,
+    )
+    service = module.RagService()
+
+    service.load()
+    service.load()
+
+    transformer_factory.assert_called_once_with("all-MiniLM-L6-v2")
+    assert service.model is model
+
+
+def test_load_degrades_without_sentence_transformers_when_allowed(monkeypatch):
+    monkeypatch.setenv("ALLOW_DEGRADED_STARTUP", "1")
+    transformer_factory = Mock()
+    module, transformer_factory, _, _ = import_rag_service(
+        monkeypatch,
+        transformer_factory=transformer_factory,
+    )
+    monkeypatch.setattr(module, "_HAS_SENTENCE", False)
+    monkeypatch.setattr(module, "SentenceTransformer", None)
+    service = module.RagService()
+
+    service.load()
+
+    transformer_factory.assert_not_called()
+    assert service.model is None
+    assert service._loaded is False
+    assert service._load_failed is True
+    assert service.is_available() is False
+
+
+def test_load_raises_without_sentence_transformers_when_degraded_startup_is_disabled(monkeypatch):
+    monkeypatch.delenv("ALLOW_DEGRADED_STARTUP", raising=False)
+    module, _, _, _ = import_rag_service(monkeypatch)
+    monkeypatch.setattr(module, "_HAS_SENTENCE", False)
+    monkeypatch.setattr(module, "SentenceTransformer", None)
+    service = module.RagService()
+
+    with pytest.raises(ImportError, match="sentence-transformers is required"):
+        service.load()
+
+    assert service._load_failed is True
+    assert service.is_available() is False
+
+
+def test_search_knowledge_base_returns_none_when_model_or_supabase_is_unavailable(monkeypatch):
+    module, _, _, _ = import_rag_service(monkeypatch)
+    service = module.RagService()
+    model = Mock()
+    service.model = model
+    service._loaded = False
+
+    assert service.search_knowledge_base("reset password") is None
+    model.encode.assert_not_called()
+
+    service._loaded = True
+    service.supabase = None
+    assert service.search_knowledge_base("reset password") is None
+    model.encode.assert_not_called()
+
+
+def test_search_knowledge_base_returns_first_matching_article(monkeypatch):
+    module, _, _, _ = import_rag_service(monkeypatch)
+    service = module.RagService()
+    service._loaded = True
+    service.model = Mock()
+    service.model.encode.return_value = EncodedVector([0.1, 0.2, 0.3])
+
+    rpc_call = Mock()
+    rpc_call.execute.return_value = SimpleNamespace(
+        data=[
+            {
+                "id": "article-1",
+                "title": "Reset Password",
+                "content": "Use the forgot password flow.",
+                "similarity": 0.94,
+            },
+            {
+                "id": "article-2",
+                "title": "Other",
+                "content": "Lower-ranked article",
+                "similarity": 0.88,
+            },
+        ]
+    )
+    service.supabase = Mock()
+    service.supabase.rpc.return_value = rpc_call
+
+    result = service.search_knowledge_base(
+        "How do I reset my password?",
+        threshold=0.7,
+        match_count=3,
+    )
+
+    service.model.encode.assert_called_once_with("How do I reset my password?")
+    service.supabase.rpc.assert_called_once_with(
+        "match_articles",
+        {
+            "query_embedding": [0.1, 0.2, 0.3],
+            "match_threshold": 0.7,
+            "match_count": 3,
+        },
+    )
+    assert result == {
+        "id": "article-1",
+        "title": "Reset Password",
+        "content": "Use the forgot password flow.",
+        "similarity": 0.94,
+    }
+
+
+def test_search_knowledge_base_returns_none_when_no_matches_are_found(monkeypatch):
+    module, _, _, _ = import_rag_service(monkeypatch)
+    service = module.RagService()
+    service._loaded = True
+    service.model = Mock()
+    service.model.encode.return_value = EncodedVector([0.5])
+    rpc_call = Mock()
+    rpc_call.execute.return_value = SimpleNamespace(data=[])
+    service.supabase = Mock()
+    service.supabase.rpc.return_value = rpc_call
+
+    assert service.search_knowledge_base("unknown question") is None
+
+
+def test_search_knowledge_base_handles_embedding_or_rpc_errors(monkeypatch):
+    module, _, _, _ = import_rag_service(monkeypatch)
+    service = module.RagService()
+    service._loaded = True
+    service.model = Mock()
+    service.model.encode.side_effect = RuntimeError("embedding failed")
+    service.supabase = Mock()
+
+    assert service.search_knowledge_base("broken") is None
+    service.supabase.rpc.assert_not_called()
+
+    service.model.encode.side_effect = None
+    service.model.encode.return_value = EncodedVector([0.9])
+    service.supabase.rpc.side_effect = RuntimeError("rpc failed")
+
+    assert service.search_knowledge_base("rpc failure") is None


### PR DESCRIPTION
## Summary
- Add a dedicated `backend/tests/test_rag_service.py` test module.
- Cover Supabase client setup, model loading paths, degraded startup behavior, service availability, successful knowledge-base retrieval, empty results, and error handling.
- Stub external ML, Supabase, and dotenv dependencies so tests run without model downloads, network access, or real credentials.

## Testing
- `python -m pytest -q --tb=short backend/tests/test_rag_service.py`

Closes #1086

## Payment Details
- Method: USDC
- Address: `0x43991A9dC8Ddf492eab6E55685644c2cb9B001D2`
- Network: Base