### PR TITLE
feat(#1172): export SHORTCUTS_LEGEND, add showHelp/setShowHelp to hoo…

### DIFF
--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -10,14 +10,20 @@ import ShortcutsHelpModal from '../../admin/components/ShortcutsHelpModal';
  * AdminLayout Component
  * Master framework for the administrative zone.
  * Enforces a fixed-sidebar architecture with a centered, high-density content terminal.
+ *
+ * Fix for Issue #1172:
+ * Previously the hook was called twice — once with `{ isAdmin: true }` expecting
+ * `{ showHelp, setShowHelp }` (which the hook did not return), and once without
+ * arguments for navigation shortcuts.  The hook now returns `showHelp` /
+ * `setShowHelp` and handles both concerns in a single call.
  */
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-    const { showHelp, setShowHelp } = useKeyboardShortcuts({ isAdmin: true });
 
-    // Rapid keyboard navigation (G+D, G+T, …) and Ctrl+F search focus.
-    useKeyboardShortcuts();
+    // Single hook call — handles G+key navigation, Ctrl+K search, Ctrl+/ and ?
+    // shortcuts-help toggle, and Escape to close the help modal.
+    const { showHelp, setShowHelp } = useKeyboardShortcuts({}, { isAdmin: true });
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,9 +1,19 @@
 /**
  * Keyboard Shortcuts Hook
  * Provides global keyboard shortcuts for rapid navigation.
+ *
+ * Fixes for Issue #1172:
+ * 1. Added `SHORTCUTS_LEGEND` export — consumed by Help.jsx to render the
+ *    shortcuts overlay (was imported but never exported, causing a runtime error).
+ * 2. Added `showHelp` / `setShowHelp` to the hook's return value — AdminLayout
+ *    destructures these to wire up the ShortcutsHelpModal; without them the
+ *    modal could never open via Ctrl+/ or the ? key.
+ * 3. Added `?` key handler to toggle the help modal (vim-style, widely expected).
+ * 4. Consolidated the double `useKeyboardShortcuts()` call in AdminLayout into a
+ *    single call by making the hook handle both navigation and help-modal state.
  */
 
-import { useEffect, useCallback, useRef } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
 // Default shortcuts configuration
@@ -26,16 +36,44 @@ const DEFAULT_SHORTCUTS = {
 };
 
 /**
+ * Human-readable legend for the shortcuts overlay rendered in Help.jsx and
+ * ShortcutsHelpModal.jsx.  Each entry has:
+ *   combo       — the key combination shown in the <kbd> element
+ *   description — plain-English description of the action
+ *
+ * Exported as a named constant so any component can import it without
+ * duplicating the list.
+ */
+export const SHORTCUTS_LEGEND = [
+    { combo: 'G → D', description: 'Go to Dashboard' },
+    { combo: 'G → T', description: 'Go to My Tickets' },
+    { combo: 'G → N', description: 'Create New Ticket' },
+    { combo: 'G → P', description: 'Go to Profile' },
+    { combo: 'G → H', description: 'Go to Help' },
+    { combo: 'G → A', description: 'Go to Admin Dashboard' },
+    { combo: 'G → K', description: 'Go to Admin Tickets' },
+    { combo: 'G → U', description: 'Go to Admin Users' },
+    { combo: 'G → S', description: 'Go to Admin Settings' },
+    { combo: 'Ctrl + K', description: 'Open Search' },
+    { combo: 'Ctrl + /', description: 'Show Keyboard Shortcuts' },
+    { combo: '?', description: 'Toggle Shortcuts Help' },
+    { combo: 'Esc', description: 'Close Modal / Cancel Pending Key' },
+];
+
+/**
  * Hook to register keyboard shortcuts
  * @param {Object} customShortcuts - Additional shortcuts to merge with defaults
  * @param {Object} options - Configuration options
- * @param {boolean} options.enabled - Whether shortcuts are enabled (default: true)
- * @param {Function} options.onSearch - Callback for search shortcut
- * @param {Function} options.onShortcutsHelp - Callback for shortcuts help
+ * @param {boolean} options.enabled      - Whether shortcuts are enabled (default: true)
+ * @param {boolean} options.isAdmin      - Whether to include admin-only shortcuts (default: false)
+ * @param {Function} options.onSearch    - Callback for Ctrl+K search shortcut
+ * @param {Function} options.onShortcutsHelp - External callback for Ctrl+/ (optional;
+ *                                             if omitted the hook manages showHelp internally)
  */
 export const useKeyboardShortcuts = (customShortcuts = {}, options = {}) => {
     const {
         enabled = true,
+        isAdmin = false,
         onSearch = null,
         onShortcutsHelp = null,
     } = options;
@@ -44,6 +82,11 @@ export const useKeyboardShortcuts = (customShortcuts = {}, options = {}) => {
     const location = useLocation();
     const pendingKeyRef = useRef(null);
     const timeoutRef = useRef(null);
+
+    // Internal state for the shortcuts-help modal.
+    // AdminLayout (and any other consumer) can destructure { showHelp, setShowHelp }
+    // from the hook instead of maintaining its own useState.
+    const [showHelp, setShowHelp] = useState(false);
 
     // Merge default and custom shortcuts
     const shortcuts = { ...DEFAULT_SHORTCUTS, ...customShortcuts };
@@ -67,11 +110,15 @@ export const useKeyboardShortcuts = (customShortcuts = {}, options = {}) => {
         const shift = event.shiftKey;
         const alt = event.altKey;
 
-        // Handle Escape key
+        // Handle Escape key — close help modal first, then close other modals
         if (key === 'escape') {
+            if (showHelp) {
+                setShowHelp(false);
+                return;
+            }
             const action = shortcuts['escape'];
             if (action === 'close-modal') {
-                // Close any open modals
+                // Close any open modals that expose a [data-modal] close trigger
                 document.querySelectorAll('[data-modal]').forEach(modal => {
                     modal.click();
                 });
@@ -98,18 +145,27 @@ export const useKeyboardShortcuts = (customShortcuts = {}, options = {}) => {
             event.preventDefault();
             if (onShortcutsHelp) {
                 onShortcutsHelp();
+            } else {
+                setShowHelp(prev => !prev);
             }
+            return;
+        }
+
+        // Handle ? key — toggle shortcuts help modal (no modifier required)
+        if (key === '?' && !ctrl && !alt) {
+            event.preventDefault();
+            setShowHelp(prev => !prev);
             return;
         }
 
         // Handle G + key combinations (vim-style navigation)
         if (pendingKeyRef.current === 'g') {
             const combo = `g,${key}`;
-            const target = shortcuts[combo];
+            const destination = shortcuts[combo];
 
-            if (target) {
+            if (destination) {
                 event.preventDefault();
-                navigate(target);
+                navigate(destination);
             }
 
             pendingKeyRef.current = null;
@@ -128,7 +184,7 @@ export const useKeyboardShortcuts = (customShortcuts = {}, options = {}) => {
             }, 1000); // 1 second timeout for key sequence
             return;
         }
-    }, [enabled, shortcuts, navigate, location, onSearch, onShortcutsHelp]);
+    }, [enabled, shortcuts, navigate, location, onSearch, onShortcutsHelp, showHelp]);
 
     useEffect(() => {
         if (!enabled) return;
@@ -145,6 +201,14 @@ export const useKeyboardShortcuts = (customShortcuts = {}, options = {}) => {
     return {
         shortcuts,
         pendingKey: pendingKeyRef.current,
+        // Help modal state — destructure in AdminLayout / UserLayout to wire up
+        // the ShortcutsHelpModal without a separate useState call.
+        showHelp,
+        setShowHelp,
+        // Convenience: filtered legend for the current context
+        shortcutsLegend: isAdmin
+            ? SHORTCUTS_LEGEND
+            : SHORTCUTS_LEGEND.filter(s => !['G → A', 'G → K', 'G → U', 'G → S'].includes(s.combo)),
     };
 };
 
@@ -194,6 +258,7 @@ export const getShortcutDescription = (shortcut) => {
         'ctrl+k': 'Open Search',
         'ctrl+/': 'Show Shortcuts',
         'escape': 'Close Modal',
+        '?': 'Toggle Shortcuts Help',
     };
 
     return descriptions[shortcut] || shortcut;

--- a/Frontend/src/hooks/useKeyboardShortcuts.test.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.test.js
@@ -1,0 +1,267 @@
+/**
+ * Tests for useKeyboardShortcuts hook — Issue #1172 regressions
+ *
+ * Covers:
+ * 1. SHORTCUTS_LEGEND is exported and has the correct shape
+ * 2. useKeyboardShortcuts returns showHelp / setShowHelp
+ * 3. Ctrl+/ toggles showHelp
+ * 4. ? key toggles showHelp
+ * 5. Escape closes the help modal when it is open
+ * 6. G+key navigation shortcuts fire navigate()
+ * 7. Shortcuts are suppressed when focus is inside an input
+ * 8. isAdmin option is accepted without throwing
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+const mockLocation = { pathname: '/admin/dashboard' };
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => mockNavigate,
+    useLocation: () => mockLocation,
+}));
+
+// ── Import under test ──────────────────────────────────────────────────────
+
+import {
+    useKeyboardShortcuts,
+    SHORTCUTS_LEGEND,
+    formatShortcut,
+    getShortcutDescription,
+} from './useKeyboardShortcuts';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Fire a synthetic keydown event on window */
+function fireKey(key, modifiers = {}) {
+    const event = new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+        ctrlKey: modifiers.ctrl ?? false,
+        metaKey: modifiers.meta ?? false,
+        shiftKey: modifiers.shift ?? false,
+        altKey: modifiers.alt ?? false,
+    });
+    window.dispatchEvent(event);
+    return event;
+}
+
+/** Minimal React wrapper so hooks that use React context work */
+const wrapper = ({ children }) => React.createElement(React.Fragment, null, children);
+
+// ── Test suites ────────────────────────────────────────────────────────────
+
+describe('SHORTCUTS_LEGEND export', () => {
+    it('is exported as a non-empty array', () => {
+        expect(Array.isArray(SHORTCUTS_LEGEND)).toBe(true);
+        expect(SHORTCUTS_LEGEND.length).toBeGreaterThan(0);
+    });
+
+    it('every entry has a combo and description string', () => {
+        for (const entry of SHORTCUTS_LEGEND) {
+            expect(typeof entry.combo).toBe('string');
+            expect(entry.combo.length).toBeGreaterThan(0);
+            expect(typeof entry.description).toBe('string');
+            expect(entry.description.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('includes the Ctrl+/ entry', () => {
+        const found = SHORTCUTS_LEGEND.find(e => e.combo.includes('/'));
+        expect(found).toBeDefined();
+    });
+
+    it('includes the ? entry', () => {
+        const found = SHORTCUTS_LEGEND.find(e => e.combo === '?');
+        expect(found).toBeDefined();
+    });
+});
+
+describe('useKeyboardShortcuts — return value', () => {
+    it('returns showHelp (boolean) and setShowHelp (function)', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+        expect(typeof result.current.showHelp).toBe('boolean');
+        expect(typeof result.current.setShowHelp).toBe('function');
+    });
+
+    it('showHelp starts as false', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+        expect(result.current.showHelp).toBe(false);
+    });
+
+    it('returns shortcuts object', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+        expect(typeof result.current.shortcuts).toBe('object');
+    });
+
+    it('accepts isAdmin option without throwing', () => {
+        expect(() => {
+            renderHook(() => useKeyboardShortcuts({}, { isAdmin: true }), { wrapper });
+        }).not.toThrow();
+    });
+
+    it('returns shortcutsLegend array', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts({}, { isAdmin: true }), { wrapper });
+        expect(Array.isArray(result.current.shortcutsLegend)).toBe(true);
+    });
+
+    it('admin legend includes admin-only shortcuts', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts({}, { isAdmin: true }), { wrapper });
+        const combos = result.current.shortcutsLegend.map(s => s.combo);
+        expect(combos).toContain('G → A');
+    });
+
+    it('non-admin legend excludes admin-only shortcuts', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts({}, { isAdmin: false }), { wrapper });
+        const combos = result.current.shortcutsLegend.map(s => s.combo);
+        expect(combos).not.toContain('G → A');
+    });
+});
+
+describe('useKeyboardShortcuts — Ctrl+/ toggles showHelp', () => {
+    it('opens the help modal on Ctrl+/', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+        expect(result.current.showHelp).toBe(false);
+
+        act(() => { fireKey('/', { ctrl: true }); });
+
+        expect(result.current.showHelp).toBe(true);
+    });
+
+    it('closes the help modal on second Ctrl+/', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => { fireKey('/', { ctrl: true }); });
+        expect(result.current.showHelp).toBe(true);
+
+        act(() => { fireKey('/', { ctrl: true }); });
+        expect(result.current.showHelp).toBe(false);
+    });
+});
+
+describe('useKeyboardShortcuts — ? key toggles showHelp', () => {
+    it('opens the help modal on ?', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => { fireKey('?'); });
+
+        expect(result.current.showHelp).toBe(true);
+    });
+
+    it('closes the help modal on second ?', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => { fireKey('?'); });
+        act(() => { fireKey('?'); });
+
+        expect(result.current.showHelp).toBe(false);
+    });
+});
+
+describe('useKeyboardShortcuts — Escape closes help modal', () => {
+    it('closes the help modal when Escape is pressed while modal is open', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => { fireKey('?'); });
+        expect(result.current.showHelp).toBe(true);
+
+        act(() => { fireKey('Escape'); });
+        expect(result.current.showHelp).toBe(false);
+    });
+
+    it('does not throw when Escape is pressed while modal is already closed', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+        expect(result.current.showHelp).toBe(false);
+
+        expect(() => {
+            act(() => { fireKey('Escape'); });
+        }).not.toThrow();
+    });
+});
+
+describe('useKeyboardShortcuts — G+key navigation', () => {
+    beforeEach(() => { mockNavigate.mockClear(); });
+
+    it('navigates to /dashboard on G → D', () => {
+        renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => {
+            fireKey('g');
+            fireKey('d');
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    });
+
+    it('navigates to /admin/dashboard on G → A', () => {
+        renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => {
+            fireKey('g');
+            fireKey('a');
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith('/admin/dashboard');
+    });
+
+    it('does not navigate for unknown G+key combo', () => {
+        renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        act(() => {
+            fireKey('g');
+            fireKey('z');
+        });
+
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});
+
+describe('useKeyboardShortcuts — input suppression', () => {
+    it('does not toggle showHelp when ? is pressed inside an INPUT', () => {
+        const { result } = renderHook(() => useKeyboardShortcuts(), { wrapper });
+
+        // Simulate focus inside an input
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        input.focus();
+
+        act(() => {
+            const event = new KeyboardEvent('keydown', {
+                key: '?',
+                bubbles: true,
+                cancelable: true,
+            });
+            // Dispatch from the input element so event.target.tagName === 'INPUT'
+            input.dispatchEvent(event);
+        });
+
+        expect(result.current.showHelp).toBe(false);
+        document.body.removeChild(input);
+    });
+});
+
+describe('formatShortcut', () => {
+    it('returns a non-empty string for ctrl+k', () => {
+        const result = formatShortcut('ctrl+k');
+        expect(typeof result).toBe('string');
+        expect(result.length).toBeGreaterThan(0);
+    });
+});
+
+describe('getShortcutDescription', () => {
+    it('returns description for known shortcuts', () => {
+        expect(getShortcutDescription('g,d')).toBe('Go to Dashboard');
+        expect(getShortcutDescription('ctrl+/')).toBe('Show Shortcuts');
+        expect(getShortcutDescription('?')).toBe('Toggle Shortcuts Help');
+    });
+
+    it('returns the raw shortcut for unknown keys', () => {
+        expect(getShortcutDescription('unknown')).toBe('unknown');
+    });
+});

--- a/Frontend/vitest.config.js
+++ b/Frontend/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [react()],
+    test: {
+        environment: 'jsdom',
+        globals: true,
+        setupFiles: [],
+        include: ['src/**/*.test.{js,jsx,ts,tsx}'],
+    },
+});


### PR DESCRIPTION
…k, fix ? key handler

Fixes #1172 — Add Interactive Keyboard Shortcuts for Rapid Admin Dashboard Navigation

Root causes fixed:

1. SHORTCUTS_LEGEND was imported by Help.jsx but never exported from the hook, causing a silent runtime error. Added the export with 13 entries covering all G+key combos, Ctrl+K, Ctrl+/, ? and Escape.

2. useKeyboardShortcuts() did not return showHelp / setShowHelp, so AdminLayout destructured undefined values and the ShortcutsHelpModal could never open via keyboard. Added useState(false) inside the hook and returned both values.

3. AdminLayout called useKeyboardShortcuts() twice (once with { isAdmin: true } and once without arguments), creating two competing event listeners. Consolidated into a single call: useKeyboardShortcuts({}, { isAdmin: true }).

4. Added ? key handler to toggle the help modal (widely expected vim-style shortcut, also listed in ShortcutsHelpModal but never wired up).

5. Escape now closes the help modal first before falling through to the generic close-modal handler, preventing the modal from getting stuck open.

Files changed:
- Frontend/src/hooks/useKeyboardShortcuts.js  — all fixes above
- Frontend/src/admin/layout/AdminLayout.jsx   — single hook call
- Frontend/src/hooks/useKeyboardShortcuts.test.js — 24 regression tests
- Frontend/vitest.config.js                   — test runner config

Tests: 24/24 passing