### PR TITLE
fix: remove duplicate getTimeZoneAbbr and formatFullTimestamp exports in dateUtils.js

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -201,21 +201,4 @@ export const safeParseDateForSort = (dateStr) => {
     return parseDate(dateStr) ?? new Date(0);
 };
 
-export const getTimeZoneAbbr = () => {
-    try {
-        return new Intl.DateTimeFormat('en-US', {
-            timeZoneName: 'short'
-        })
-        .formatToParts(new Date())
-        .find(part => part.type === 'timeZoneName')?.value || 'IST';
-    } catch (_e) {
-        return 'IST';
-    }
-};
 
-export const formatFullTimestamp = (dateStr) => {
-    const date = parseDate(dateStr);
-    if (!date) return 'Processing...';
-    const formatted = formatTimelineDate(dateStr);
-    return `${formatted} (${getTimeZoneAbbr()})`;
-};


### PR DESCRIPTION
## Description
Fixes Safari date parsing issue #1174 by removing duplicate export declarations that break strict ESM imports.

**Root cause:** Merge conflict artifact — two GSSoC PRs added the same `getTimeZoneAbbr` and `formatFullTimestamp` exports. When the file is loaded as a strict ESM module (Node.js, Safari, modern bundlers), the duplicate `export const` declarations throw `SyntaxError: Identifier has already been declared`, making all date formatting fail silently.

**Fix:** Removed the duplicate second set (lines 204-221). Kept the first set which:
- Falls back to `'UTC'` instead of `'IST'` (universally correct timezone fallback)
- Routes consistently through `formatTimelineDate()`

The actual Safari date parsing logic (`normalizeDateString`, `parseDate`) is unchanged — it already handles space→T replacement, microsecond truncation, compact timezone offsets, and missing Z suffix.

## Changes
- `Frontend/src/utils/dateUtils.js` — Removed 17 lines of duplicate export declarations

## Testing
- `node --test tests/dateUtils.test.js` — 3/3 pass (no regressions)
- `npm test` — Full test suite green

Closes #1174