### PR TITLE
devops: add monitoring stack docker-compose and Grafana provisioning (#1168)

### DIFF
--- a/deploy/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,16 @@
+# Grafana Dashboard Provisioning
+# Auto-loads dashboards from /var/lib/grafana/dashboards/
+
+apiVersion: 1
+
+providers:
+  - name: "HELPDESK.AI Dashboards"
+    orgId: 1
+    folder: "HELPDESK.AI"
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/datasources/prometheus.yml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,15 @@
+# Grafana Datasource Provisioning
+# Auto-configures Prometheus as the default datasource
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      timeInterval: "15s"

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,65 @@
+version: "3.8"
+
+# HELPDESK.AI Monitoring Stack
+# Usage: docker compose -f docker-compose.monitoring.yml up -d
+# Access: Grafana at http://localhost:3001 (admin/admin)
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: helpdesk-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./deploy/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=30d"
+      - "--storage.tsdb.retention.size=5GB"
+      - "--web.enable-lifecycle"
+    networks:
+      - monitoring
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  grafana:
+    image: grafana/grafana:10.4.1
+    container_name: helpdesk-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/helpdesk-dashboard.json
+    volumes:
+      - ./deploy/grafana/dashboard.json:/var/lib/grafana/dashboards/helpdesk-dashboard.json:ro
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    networks:
+      - monitoring
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  prometheus_data:
+    driver: local
+  grafana_data:
+    driver: local
+
+networks:
+  monitoring:
+    driver: bridge
+    name: helpdesk-monitoring


### PR DESCRIPTION
Fixes #1168

## Summary
- ✅ **Docker Compose**: One-command deployment of Prometheus + Grafana monitoring stack
- ✅ **Grafana Provisioning**: Auto-configured Prometheus datasource and dashboard loading
- ✅ **Production Ready**: Health checks, persistent volumes, network isolation

## What's Already Implemented
The backend already has full Prometheus integration:
- `prometheus-fastapi-instrumentator` in `backend/main.py`
- Secure `/metrics` endpoint with token authentication (`METRICS_TOKEN`)
- Comprehensive Grafana dashboard (16 panels) at `deploy/grafana/dashboard.json`
- Production-grade Prometheus config at `deploy/prometheus/prometheus.yml`

## What This PR Adds

### docker-compose.monitoring.yml
One-command deployment of the complete monitoring stack:
```bash
docker compose -f docker-compose.monitoring.yml up -d
```

Services:
- **Prometheus** (:9090) — scrapes /metrics from backend, 30-day retention
- **Grafana** (:3001) — auto-provisioned with HELPDESK.AI dashboard

### Grafana Provisioning
Auto-configures Grafana on first startup:

**Datasource** (`deploy/grafana/provisioning/datasources/prometheus.yml`):
- Prometheus as default datasource
- 15s scrape interval

**Dashboard** (`deploy/grafana/provisioning/dashboards/dashboards.yml`):
- Auto-loads from `/var/lib/grafana/dashboards/`
- 30-second refresh interval
- Editable in UI

## Dashboard Panels (16 total)
1. **Request Latency & Rate**: p50/p95/p99 latency, current p99, request rate
2. **CPU & Memory Load**: CPU usage, memory usage, open file descriptors
3. **AI Model Usage**: Inference latency per model, request rate, error rate, total inferences

## Quick Start
```bash
# Start monitoring stack
docker compose -f docker-compose.monitoring.yml up -d

# Access Grafana (default: admin/admin)
open http://localhost:3001

# The HELPDESK.AI dashboard is auto-loaded as the home page
```

## Environment Variables
- `METRICS_TOKEN` — Bearer token for /metrics endpoint (optional, set in .env)
- Grafana admin password can be changed via `GF_SECURITY_ADMIN_PASSWORD`