### PR TITLE
security: Helmet.js-style headers and CORS middleware (#1169)

### DIFF
--- a/Fastapi/middleware/security.py
+++ b/Fastapi/middleware/security.py
@@ -1,0 +1,152 @@
+"""
+Helmet.js-style security headers middleware for FastAPI.
+Implements CSP, X-Frame-Options, X-Content-Type-Options, and more.
+"""
+
+from fastapi import FastAPI, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from typing import List, Optional
+import os
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to add security headers similar to Helmet.js.
+    
+    Headers added:
+    - Content-Security-Policy (CSP)
+    - X-Frame-Options
+    - X-Content-Type-Options
+    - X-XSS-Protection
+    - Strict-Transport-Security (HSTS)
+    - Referrer-Policy
+    - Permissions-Policy
+    """
+    
+    def __init__(
+        self,
+        app: FastAPI,
+        csp_directives: Optional[dict] = None,
+        frame_options: str = "DENY",
+        hsts_max_age: int = 31536000,
+        enable_hsts: bool = True,
+    ):
+        super().__init__(app)
+        self.frame_options = frame_options
+        self.hsts_max_age = hsts_max_age
+        self.enable_hsts = enable_hsts
+        
+        # Default CSP directives
+        self.csp_directives = csp_directives or {
+            "default-src": ["'self'"],
+            "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+            "style-src": ["'self'", "'unsafe-inline'", "https://fonts.googleapis.com"],
+            "img-src": ["'self'", "data:", "https:"],
+            "font-src": ["'self'", "https://fonts.gstatic.com"],
+            "connect-src": ["'self'", "https://api.supabase.io", "wss://*.supabase.co"],
+            "frame-ancestors": ["'none'"],
+            "base-uri": ["'self'"],
+            "form-action": ["'self'"],
+        }
+    
+    def _build_csp_header(self) -> str:
+        """Build CSP header string from directives."""
+        parts = []
+        for directive, sources in self.csp_directives.items():
+            parts.append(f"{directive} {' '.join(sources)}")
+        return "; ".join(parts)
+    
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        
+        # Content-Security-Policy
+        response.headers["Content-Security-Policy"] = self._build_csp_header()
+        
+        # X-Frame-Options (Clickjacking protection)
+        response.headers["X-Frame-Options"] = self.frame_options
+        
+        # X-Content-Type-Options (MIME-sniffing protection)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        
+        # X-XSS-Protection (legacy but still useful)
+        response.headers["X-XSS-Protection"] = "1; mode=block"
+        
+        # Strict-Transport-Security (HSTS)
+        if self.enable_hsts:
+            response.headers["Strict-Transport-Security"] = f"max-age={self.hsts_max_age}; includeSubDomains"
+        
+        # Referrer-Policy
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        
+        # Permissions-Policy
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=(), "
+            "payment=(), usb=(), magnetometer=(), gyroscope=()"
+        )
+        
+        return response
+
+
+def configure_cors(app: FastAPI):
+    """
+    Configure CORS from ALLOWED_ORIGINS environment variable.
+    
+    Usage:
+        ALLOWED_ORIGINS=http://localhost:3000,https://helpdesk.ai
+    """
+    from fastapi.middleware.cors import CORSMiddleware
+    
+    allowed_origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    allowed_origins = [origin.strip() for origin in allowed_origins if origin.strip()]
+    
+    # Add production domain if not in dev mode
+    environment = os.getenv("ENVIRONMENT", "development")
+    if environment == "production":
+        prod_origin = os.getenv("PRODUCTION_ORIGIN", "https://helpdesk.ai")
+        if prod_origin not in allowed_origins:
+            allowed_origins.append(prod_origin)
+    
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-Requested-With"],
+        expose_headers=["X-Request-Id"],
+        max_age=600,  # Cache preflight for 10 minutes
+    )
+
+
+def configure_security(app: FastAPI, environment: str = "development"):
+    """
+    Configure all security middleware.
+    
+    Usage:
+        from middleware.security import configure_security
+        configure_security(app, environment="production")
+    """
+    # CORS
+    configure_cors(app)
+    
+    # Security headers
+    enable_hsts = environment == "production"
+    
+    # Relax CSP in development
+    if environment == "development":
+        csp = {
+            "default-src": ["'self'"],
+            "script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'", "http://localhost:*"],
+            "style-src": ["'self'", "'unsafe-inline'"],
+            "img-src": ["'self'", "data:", "blob:"],
+            "connect-src": ["'self'", "http://localhost:*", "ws://localhost:*"],
+            "frame-ancestors": ["'self'"],
+        }
+    else:
+        csp = None  # Use strict defaults
+    
+    app.add_middleware(
+        SecurityHeadersMiddleware,
+        csp_directives=csp,
+        frame_options="DENY",
+        enable_hsts=enable_hsts,
+    )

--- a/Fastapi/tests/test_security.py
+++ b/Fastapi/tests/test_security.py
@@ -1,0 +1,133 @@
+"""
+Tests for security headers middleware.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from middleware.security import SecurityHeadersMiddleware, configure_security
+
+
+@pytest.fixture
+def app():
+    """Create test app with security middleware."""
+    app = FastAPI()
+    
+    @app.get("/test")
+    async def test_endpoint():
+        return {"message": "ok"}
+    
+    return app
+
+
+@pytest.fixture
+def client_with_security(app):
+    """Create test client with security headers."""
+    configure_security(app, environment="development")
+    return TestClient(app)
+
+
+@pytest.fixture
+def client_production(app):
+    """Create test client with production security."""
+    configure_security(app, environment="production")
+    return TestClient(app)
+
+
+class TestSecurityHeaders:
+    """Test security headers are applied."""
+    
+    def test_x_frame_options(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert response.headers["X-Frame-Options"] == "DENY"
+    
+    def test_x_content_type_options(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+    
+    def test_x_xss_protection(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert response.headers["X-XSS-Protection"] == "1; mode=block"
+    
+    def test_referrer_policy(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    
+    def test_content_security_policy(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert "Content-Security-Policy" in response.headers
+        csp = response.headers["Content-Security-Policy"]
+        assert "default-src" in csp
+        assert "'self'" in csp
+    
+    def test_permissions_policy(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert "Permissions-Policy" in response.headers
+        pp = response.headers["Permissions-Policy"]
+        assert "camera=()" in pp
+        assert "microphone=()" in pp
+    
+    def test_hsts_not_in_dev(self, client_with_security):
+        response = client_with_security.get("/test")
+        assert "Strict-Transport-Security" not in response.headers
+    
+    def test_hsts_in_production(self, client_production):
+        response = client_production.get("/test")
+        assert "Strict-Transport-Security" in response.headers
+        hsts = response.headers["Strict-Transport-Security"]
+        assert "max-age=" in hsts
+        assert "includeSubDomains" in hsts
+
+
+class TestCSPDirectives:
+    """Test CSP directive configuration."""
+    
+    def test_csp_blocks_frame_ancestors(self, client_with_security):
+        response = client_with_security.get("/test")
+        csp = response.headers["Content-Security-Policy"]
+        assert "frame-ancestors" in csp
+    
+    def test_csp_allows_self(self, client_with_security):
+        response = client_with_security.get("/test")
+        csp = response.headers["Content-Security-Policy"]
+        assert "'self'" in csp
+
+
+class TestCORSConfiguration:
+    """Test CORS configuration."""
+    
+    def test_cors_allows_configured_origins(self, client_with_security):
+        response = client_with_security.options(
+            "/test",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        # Should not error (CORS allows it)
+        assert response.status_code in [200, 204]
+    
+    def test_cors_exposes_request_id(self, client_with_security):
+        response = client_with_security.get(
+            "/test",
+            headers={"Origin": "http://localhost:3000"},
+        )
+        # Check exposed headers
+        assert "access-control-expose-headers" in response.headers
+
+
+class TestCustomMiddleware:
+    """Test SecurityHeadersMiddleware directly."""
+    
+    def test_custom_frame_options(self, app):
+        app.add_middleware(SecurityHeadersMiddleware, frame_options="SAMEORIGIN")
+        client = TestClient(app)
+        response = client.get("/test")
+        assert response.headers["X-Frame-Options"] == "SAMEORIGIN"
+    
+    def test_custom_hsts_age(self, app):
+        app.add_middleware(SecurityHeadersMiddleware, enable_hsts=True, hsts_max_age=86400)
+        client = TestClient(app)
+        response = client.get("/test")
+        hsts = response.headers["Strict-Transport-Security"]
+        assert "max-age=86400" in hsts


### PR DESCRIPTION
## Summary
Fixes #1169 — implements Helmet.js-style security headers and CORS policy for production deployments.

## Changes

### `Fastapi/middleware/security.py`

**SecurityHeadersMiddleware:**
- Content-Security-Policy (CSP) with configurable directives
- X-Frame-Options: DENY (Clickjacking protection)
- X-Content-Type-Options: nosniff (MIME-sniffing protection)
- X-XSS-Protection: 1; mode=block
- Strict-Transport-Security (HSTS) — production only
- Referrer-Policy: strict-origin-when-cross-origin
- Permissions-Policy: camera, microphone, geolocation disabled

**CORS Configuration:**
- Reads allowed origins from `ALLOWED_ORIGINS` env var
- Adds production domain automatically in production mode
- Caches preflight for 10 minutes

**`configure_security()` helper:**
- Single function to configure all security middleware
- Relaxed CSP in development, strict in production

### `Fastapi/tests/test_security.py`
- 14 test cases covering:
  - All security headers present
  - HSTS only in production
  - CSP directives
  - CORS configuration
  - Custom middleware options

## Usage
```python
from middleware.security import configure_security

app = FastAPI()
configure_security(app, environment=production)
```

## Environment Variables
- `ALLOWED_ORIGINS`: Comma-separated list of allowed CORS origins
- `ENVIRONMENT`: development|production
- `PRODUCTION_ORIGIN`: Production domain (default: https://helpdesk.ai)

## /claim #1169