### PR TITLE
Fix seed company settings script

### DIFF
--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -27,10 +27,14 @@ import os
 import sys
 import argparse
 import logging
-import argparse
 from datetime import datetime, timezone
 
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    def load_dotenv() -> None:
+        return None
+
 
 # Load environment variables
 load_dotenv()
@@ -67,6 +71,8 @@ def _build_client():
             "Set them in .env or export them before running this script."
         )
 
+    from supabase import create_client
+
     return create_client(url, key)
 
 
@@ -97,13 +103,14 @@ def _fetch_all_pages(supabase, table: str, column: str = "*") -> list[dict]:
     return all_rows
 
 
-def seed_company_settings(dry_run: bool = False) -> dict:
+def seed_company_settings(dry_run: bool = False, supabase=None) -> dict:
     """Main function to seed company settings for all companies.
 
     Args:
         dry_run: If True, log intended inserts without writing to the database.
     """
-    supabase = _build_client()
+    if supabase is None:
+        supabase = _build_client()
 
     logger.info("Starting company settings seed script...")
     if dry_run:
@@ -227,7 +234,7 @@ def verify_seed(supabase=None) -> bool:
 
 # ─── CLI ──────────────────────────────────────────────────────────────────────
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Seed default system_settings for all companies."
     )
@@ -236,39 +243,29 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Preview inserts without writing to the database.",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Seed system_settings for all companies.")
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Preview what would be inserted without writing to the database.",
-    )
-    args = parser.parse_args()
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    supabase = _build_client()
+    result = seed_company_settings(dry_run=args.dry_run, supabase=supabase)
 
-    # Run seed
-    result = seed_company_settings(dry_run=args.dry_run)
-
-    # Skip verification on dry run
     if args.dry_run:
-        sys.exit(0)
+        return 0
 
-    # Verify
-    verified = verify_seed()
+    verified = verify_seed(supabase)
 
-    # Exit with appropriate code
     if verified and result.get("status") in ["success", "complete"]:
         logger.info("Seed script completed successfully!")
-        sys.exit(0)
-    elif result.get("status") == "no_tickets":
+        return 0
+    if result.get("status") == "no_tickets":
         logger.warning("Nothing seeded — no tickets in database.")
-        sys.exit(0)
-    else:
-        logger.error("Seed script completed with issues")
-        sys.exit(1)
+        return 0
+
+    logger.error("Seed script completed with issues")
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -306,6 +306,7 @@ def mock_ai_services(request):
         "test_metrics_service.py",
         "test_audit_service.py",
         "test_correction_log_async.py",
+        "test_seed_company_settings.py",
     }:
         yield
         return

--- a/backend/tests/test_seed_company_settings.py
+++ b/backend/tests/test_seed_company_settings.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.scripts import seed_company_settings as seed_mod
+
+
+@dataclass
+class FakeResponse:
+    data: list[dict]
+
+
+class FakeQuery:
+    def __init__(self, client, table_name: str):
+        self.client = client
+        self.table_name = table_name
+        self.selected_column = "*"
+        self.insert_records = None
+        self.start = 0
+        self.end = 0
+
+    def select(self, column: str):
+        self.selected_column = column
+        return self
+
+    def range(self, start: int, end: int):
+        self.start = start
+        self.end = end
+        return self
+
+    def insert(self, records: list[dict]):
+        self.insert_records = records
+        return self
+
+    def execute(self):
+        if self.insert_records is not None:
+            self.client.insert_calls.append((self.table_name, self.insert_records))
+            return FakeResponse([])
+
+        self.client.range_calls.append((self.table_name, self.selected_column, self.start, self.end))
+        rows = self.client.tables.get(self.table_name, [])
+        page = rows[self.start : self.end + 1]
+        return FakeResponse(page)
+
+
+class FakeSupabase:
+    def __init__(self, tables: dict[str, list[dict]]):
+        self.tables = tables
+        self.range_calls = []
+        self.insert_calls = []
+
+    def table(self, table_name: str):
+        return FakeQuery(self, table_name)
+
+
+def test_fetch_all_pages_reads_past_supabase_default_limit(monkeypatch):
+    monkeypatch.setattr(seed_mod, "PAGE_SIZE", 2)
+    client = FakeSupabase({
+        "tickets": [
+            {"company_id": "c1"},
+            {"company_id": "c2"},
+            {"company_id": "c3"},
+        ]
+    })
+
+    rows = seed_mod._fetch_all_pages(client, "tickets", "company_id")
+
+    assert [row["company_id"] for row in rows] == ["c1", "c2", "c3"]
+    assert client.range_calls == [
+        ("tickets", "company_id", 0, 1),
+        ("tickets", "company_id", 2, 3),
+    ]
+
+
+def test_seed_batch_inserts_missing_company_settings(monkeypatch):
+    monkeypatch.setattr(seed_mod, "PAGE_SIZE", 2)
+    client = FakeSupabase({
+        "tickets": [
+            {"company_id": "c1"},
+            {"company_id": "c2"},
+            {"company_id": "c1"},
+            {"company_id": None},
+        ],
+        "system_settings": [{"company_id": "c1"}],
+    })
+
+    result = seed_mod.seed_company_settings(supabase=client)
+
+    assert result == {"status": "success", "created_count": 1}
+    assert len(client.insert_calls) == 1
+    table_name, records = client.insert_calls[0]
+    assert table_name == "system_settings"
+    assert records[0]["company_id"] == "c2"
+    assert records[0]["auto_close_enabled"] is True
+    assert records[0]["auto_close_days"] == 7
+    assert records[0]["created_at"]
+
+
+def test_dry_run_skips_insert_but_reports_pending_records():
+    client = FakeSupabase({
+        "tickets": [{"company_id": "c1"}],
+        "system_settings": [],
+    })
+
+    result = seed_mod.seed_company_settings(dry_run=True, supabase=client)
+
+    assert result == {"status": "dry_run", "created_count": 1}
+    assert client.insert_calls == []
+
+
+def test_build_client_reports_missing_environment(monkeypatch):
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+
+    with pytest.raises(EnvironmentError) as exc_info:
+        seed_mod._build_client()
+
+    message = str(exc_info.value)
+    assert "SUPABASE_URL" in message
+    assert "SUPABASE_SERVICE_ROLE_KEY" in message
+
+
+def test_main_reuses_one_client_for_seed_and_verify():
+    client = FakeSupabase({
+        "tickets": [{"company_id": "c1"}],
+        "system_settings": [],
+    })
+
+    with patch.object(seed_mod, "_build_client", return_value=client) as build_client:
+        with patch.object(seed_mod, "verify_seed", return_value=True) as verify_seed:
+            exit_code = seed_mod.main([])
+
+    assert exit_code == 0
+    build_client.assert_called_once_with()
+    verify_seed.assert_called_once_with(client)
+
+
+def test_main_dry_run_skips_verify():
+    client = FakeSupabase({
+        "tickets": [{"company_id": "c1"}],
+        "system_settings": [],
+    })
+
+    with patch.object(seed_mod, "_build_client", return_value=client):
+        with patch.object(seed_mod, "verify_seed") as verify_seed:
+            exit_code = seed_mod.main(["--dry-run"])
+
+    assert exit_code == 0
+    verify_seed.assert_not_called()


### PR DESCRIPTION
Summary:
- make seed_company_settings.py import and run cleanly
- reuse one Supabase client across seed and verify
- keep dry-run, paginated fetches, batch insert, env guard, and created_at behavior covered by tests

Fixes #1095

Testing:
- python3 -m py_compile backend/scripts/seed_company_settings.py backend/tests/test_seed_company_settings.py backend/tests/conftest.py
- PYTHONPATH=. python3 -m pytest backend/tests/test_seed_company_settings.py -q