### PR TITLE
security: lock down privileged SLA and settings endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -117,6 +117,7 @@ from backend.services.spam_service import SpamService
 from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sla_policy
 from backend.services.redis_cache import redis_cache
 from backend.sla_predictor import get_sla_estimate
+from backend.sanitization import get_security_headers
 from backend.auth_cookie import router as auth_cookie_router, get_current_user  # noqa: F401
 
 
@@ -1793,6 +1794,7 @@ async def log_correction(raw_request: Request, user: dict = Depends(get_current_
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 MASTER_TICKET_ROLES = {"master_admin", "super_admin", "superadmin", "owner"}
+TENANT_ADMIN_ROLES = {"admin", "company_admin", "super_admin"}
 
 
 def _get_auth_user_id(user: dict) -> str:
@@ -1816,9 +1818,30 @@ def _get_authenticated_profile(user: dict) -> dict:
     return res.data
 
 
+def _profile_role(profile: dict) -> str:
+    return str(profile.get("role") or "").lower()
+
+
 def _is_master_ticket_reader(profile: dict) -> bool:
-    role = str(profile.get("role") or "").lower()
-    return role in MASTER_TICKET_ROLES
+    return _profile_role(profile) in MASTER_TICKET_ROLES
+
+
+def _is_tenant_admin(profile: dict) -> bool:
+    return _is_master_ticket_reader(profile) or _profile_role(profile) in TENANT_ADMIN_ROLES
+
+
+def _require_tenant_admin_profile(user: dict) -> dict:
+    profile = _get_authenticated_profile(user)
+    if not _is_tenant_admin(profile):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return profile
+
+
+def _require_platform_admin_profile(user: dict) -> dict:
+    profile = _get_authenticated_profile(user)
+    if not _is_master_ticket_reader(profile):
+        raise HTTPException(status_code=403, detail="Platform admin access required")
+    return profile
 
 
 def _ticket_company_scope(profile: dict, requested_company_id: str | None = None) -> str | None:
@@ -3094,15 +3117,55 @@ class SLAStatsResponse(BaseModel):
     by_priority: dict = {}
 
 
+def _aggregate_sla_stats(tickets: list[dict]) -> dict:
+    total = len(tickets)
+    active_tickets = [
+        ticket for ticket in tickets
+        if not any(status_key in (ticket.get("status") or "").lower() for status_key in ["resolv", "closed"])
+    ]
+
+    counts = {
+        "total": total,
+        "active": len(active_tickets),
+        "breached": sum(1 for ticket in tickets if ticket.get("sla_status") == "breached"),
+        "warning": sum(1 for ticket in tickets if ticket.get("sla_status") == "warning"),
+        "met": sum(1 for ticket in tickets if ticket.get("sla_status") == "met"),
+        "by_priority": {},
+        "breach_rate": 0,
+    }
+
+    if total > 0:
+        counts["breach_rate"] = round(counts["breached"] / total * 100, 1)
+
+    for priority in ["critical", "high", "medium", "low"]:
+        priority_tickets = [ticket for ticket in active_tickets if (ticket.get("priority") or "").lower() == priority]
+        counts["by_priority"][priority] = {
+            "total": len(priority_tickets),
+            "breached": sum(1 for ticket in priority_tickets if ticket.get("sla_status") == "breached"),
+            "warning": sum(1 for ticket in priority_tickets if ticket.get("sla_status") == "warning"),
+        }
+
+    return counts
+
+
 @app.get("/sla/stats", response_model=SLAStatsResponse)
-async def sla_stats(current_user: dict = Depends(get_current_user)):
-    """Get aggregated SLA dashboard statistics across all tickets."""
+async def sla_stats(company_id: str | None = None, current_user: dict = Depends(get_current_user)):
+    """Get aggregated SLA dashboard statistics for the caller's tenant."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
-    stats = await sla_engine.get_dashboard_stats()
-    if "error" in stats:
-        raise HTTPException(status_code=500, detail=stats["error"])
-    return stats
+
+    profile = _require_tenant_admin_profile(current_user)
+    company_scope = _ticket_company_scope(profile, company_id)
+
+    try:
+        query = supabase.table("tickets").select("id, company_id, priority, sla_status, status, escalation_level")
+        if company_scope:
+            query = query.eq("company_id", company_scope)
+        res = query.execute()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return _aggregate_sla_stats(res.data or [])
 
 
 class SLATicketInfo(BaseModel):
@@ -3176,20 +3239,40 @@ class EscalationLogEntry(BaseModel):
 
 
 @app.get("/sla/escalations")
-async def sla_escalations(limit: int = 50, offset: int = 0, current_user: dict = Depends(get_current_user)):
+async def sla_escalations(
+    limit: int = 50,
+    offset: int = 0,
+    company_id: str | None = None,
+    current_user: dict = Depends(get_current_user),
+):
     """Fetch escalation log history."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
 
+    profile = _require_tenant_admin_profile(current_user)
+    company_scope = _ticket_company_scope(profile, company_id)
+
     try:
-        res = (
+        logs = (
             supabase.table("escalation_logs")
             .select("*")
             .order("triggered_at", desc=True)
-            .range(offset, offset + limit - 1)
             .execute()
-        )
-        return {"escalations": res.data or [], "total": len(res.data or [])}
+        ).data or []
+
+        if company_scope:
+            ticket_rows = (
+                supabase.table("tickets")
+                .select("id")
+                .eq("company_id", company_scope)
+                .execute()
+            ).data or []
+            allowed_ticket_ids = {str(ticket.get("id")) for ticket in ticket_rows if ticket.get("id") is not None}
+            logs = [log for log in logs if str(log.get("ticket_id")) in allowed_ticket_ids]
+
+        total = len(logs)
+        page = logs[offset:offset + limit]
+        return {"escalations": page, "total": total}
     except Exception as e:
         # Table might not exist yet
         print(f"[SLA] Escalation logs query failed: {e}")
@@ -3209,6 +3292,8 @@ class SLAPolicyInfo(BaseModel):
 @app.get("/sla/policies")
 async def sla_policies(current_user: dict = Depends(get_current_user)):
     """Get configured SLA policies."""
+    _require_tenant_admin_profile(current_user)
+
     if not supabase:
         # Return defaults from code
         policies = []
@@ -3237,7 +3322,8 @@ async def trigger_sla_check(current_user: dict = Depends(get_current_user)):
     """Manually trigger an SLA evaluation cycle (admin)."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
-    
+
+    _require_platform_admin_profile(current_user)
     asyncio.create_task(sla_engine.check_all_active_tickets())
     return {"status": "triggered", "message": "SLA check cycle started in background"}
 
@@ -3278,6 +3364,7 @@ async def check_duplicate_endpoint(
 @limiter.limit("2/minute")
 async def reindex_embeddings(current_user: dict = Depends(get_current_user)):
     """Re-generate vector embeddings for all tickets."""
+    _require_platform_admin_profile(current_user)
     result = await semantic_dupe_service.reindex_all()
     return result
 
@@ -3296,18 +3383,45 @@ async def get_knowledge_gaps(current_user: dict = Depends(get_current_user)):
     from backend.services.knowledge_gap_service import knowledge_gap_service
     return knowledge_gap_service.get_summary()
 
+def _format_system_settings_payload(rows: list[dict]) -> dict:
+    if not rows:
+        return {}
+
+    first_row = rows[0]
+    if "key" in first_row:
+        return {
+            str(row["key"]): row.get("value")
+            for row in rows
+            if row.get("key")
+        }
+
+    hidden_fields = {"id", "company_id", "created_at", "updated_at"}
+    return {
+        key: value
+        for key, value in first_row.items()
+        if key not in hidden_fields
+    }
+
+
 @app.get("/system/settings")
-async def get_system_settings_endpoint(current_user: dict = Depends(get_current_user)):
-    """Fetch all system settings."""
+async def get_system_settings_endpoint(
+    company_id: str | None = None,
+    current_user: dict = Depends(get_current_user),
+):
+    """Fetch the current tenant's system settings."""
     _logger = logging.getLogger(__name__)
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
+
+    profile = _require_tenant_admin_profile(current_user)
+    company_scope = _ticket_company_scope(profile, company_id)
+
     try:
-        res = supabase.table("system_settings").select("*").execute()
-        settings = {}
-        for row in res.data or []:
-            settings[row["key"]] = row["value"]
-        return settings
+        query = supabase.table("system_settings").select("*")
+        if company_scope:
+            query = query.eq("company_id", company_scope)
+        res = query.execute()
+        return _format_system_settings_payload(res.data or [])
     except Exception as e:
         _logger.warning(f"[SETTINGS] Query failed: {e}")
         return {}
@@ -3315,20 +3429,29 @@ async def get_system_settings_endpoint(current_user: dict = Depends(get_current_
 
 @app.patch("/system/settings")
 async def update_system_settings(body: dict, current_user: dict = Depends(get_current_user)):
-    """Update a specific system setting."""
+    """Update system settings for the current tenant."""
     if not supabase:
         raise HTTPException(status_code=503, detail="Database not connected")
-    key = body.get("key")
-    value = body.get("value")
-    if not key or value is None:
-        raise HTTPException(status_code=400, detail="key and value required")
+
+    profile = _require_tenant_admin_profile(current_user)
+    company_scope = _ticket_company_scope(profile, body.get("company_id"))
+
+    update_fields = {
+        key: value
+        for key, value in body.items()
+        if key not in {"company_id", "id", "created_at", "updated_at"}
+    }
+    if not update_fields:
+        raise HTTPException(status_code=400, detail="No settings provided")
+
+    payload = {
+        "company_id": company_scope,
+        **update_fields,
+        "updated_at": datetime.datetime.utcnow().isoformat() + "Z",
+    }
     try:
-        supabase.table("system_settings").upsert({
-            "key": key,
-            "value": value,
-            "updated_at": datetime.datetime.utcnow().isoformat() + "Z",
-        }).execute()
-        return {"status": "updated", "key": key}
+        supabase.table("system_settings").upsert(payload).execute()
+        return {"status": "updated", "company_id": company_scope}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import types
+import importlib.util
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -47,6 +48,33 @@ class FakeTable:
         self.inserted_rows = rows
         return self
 
+    def upsert(self, payload):
+        rows = payload if isinstance(payload, list) else [payload]
+        table_rows = self.db.setdefault(self.name, [])
+        merged_rows = []
+        for new_row in rows:
+            match_index = None
+            if new_row.get("company_id") is not None:
+                for index, existing_row in enumerate(table_rows):
+                    if existing_row.get("company_id") == new_row.get("company_id"):
+                        match_index = index
+                        break
+            if match_index is None and new_row.get("id") is not None:
+                for index, existing_row in enumerate(table_rows):
+                    if existing_row.get("id") == new_row.get("id"):
+                        match_index = index
+                        break
+
+            if match_index is None:
+                table_rows.append(dict(new_row))
+                merged_rows.append(table_rows[-1])
+            else:
+                table_rows[match_index].update(new_row)
+                merged_rows.append(table_rows[match_index])
+
+        self.inserted_rows = merged_rows
+        return self
+
     def eq(self, field, value):
         self.filters[field] = value
         return self
@@ -62,6 +90,11 @@ class FakeTable:
 
     def offset(self, value):
         self.offset_count = value
+        return self
+
+    def range(self, start, end):
+        self.offset_count = start
+        self.limit_count = max(end - start + 1, 0)
         return self
 
     def single(self):
@@ -156,6 +189,50 @@ def _make_stub_module(name, attrs):
 
 def _install_optional_ml_stubs():
     # Provide import-safe stand-ins for optional ML modules used by backend.main.
+    class _LimiterStub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def limit(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class _InstrumentatorStub:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def instrument(self, *args, **kwargs):
+            return self
+
+        def expose(self, *args, **kwargs):
+            return self
+
+        def add(self, *args, **kwargs):
+            return self
+
+    class _CollectorRegistryStub:
+        pass
+
+    class _RateLimitExceededStub(Exception):
+        pass
+
+    class _MetricsStub:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    class _AsyncIOSchedulerStub:
+        def add_job(self, *args, **kwargs):
+            return None
+
+        def start(self):
+            return None
+
+    class _CronTriggerStub:
+        def __init__(self, *args, **kwargs):
+            pass
+
     class _BaseStub:
         def __init__(self):
             self._loaded = True
@@ -240,10 +317,89 @@ def _install_optional_ml_stubs():
             "backend.services.rag_service",
             {"RagService": _RagStub},
         ),
+        "slowapi": _make_stub_module(
+            "slowapi",
+            {"Limiter": _LimiterStub, "_rate_limit_exceeded_handler": lambda *args, **kwargs: None},
+        ),
+        "slowapi.util": _make_stub_module(
+            "slowapi.util",
+            {"get_remote_address": lambda *args, **kwargs: "127.0.0.1"},
+        ),
+        "slowapi.errors": _make_stub_module(
+            "slowapi.errors",
+            {"RateLimitExceeded": _RateLimitExceededStub},
+        ),
+        "prometheus_client": _make_stub_module(
+            "prometheus_client",
+            {
+                "generate_latest": lambda *args, **kwargs: b"",
+                "CONTENT_TYPE_LATEST": "text/plain; version=0.0.4",
+                "CollectorRegistry": _CollectorRegistryStub,
+                "REGISTRY": object(),
+            },
+        ),
+        "prometheus_fastapi_instrumentator": _make_stub_module(
+            "prometheus_fastapi_instrumentator",
+            {
+                "Instrumentator": _InstrumentatorStub,
+                "metrics": _MetricsStub(),
+            },
+        ),
+        "apscheduler": _make_stub_module(
+            "apscheduler",
+            {},
+        ),
+        "apscheduler.schedulers": _make_stub_module(
+            "apscheduler.schedulers",
+            {},
+        ),
+        "apscheduler.schedulers.asyncio": _make_stub_module(
+            "apscheduler.schedulers.asyncio",
+            {"AsyncIOScheduler": _AsyncIOSchedulerStub},
+        ),
+        "apscheduler.triggers": _make_stub_module(
+            "apscheduler.triggers",
+            {},
+        ),
+        "apscheduler.triggers.cron": _make_stub_module(
+            "apscheduler.triggers.cron",
+            {"CronTrigger": _CronTriggerStub},
+        ),
+        "fcntl": _make_stub_module(
+            "fcntl",
+            {
+                "LOCK_EX": 0,
+                "LOCK_UN": 0,
+                "flock": lambda *args, **kwargs: None,
+            },
+        ),
+        "encryption": _make_stub_module(
+            "encryption",
+            {
+                "encrypt_pii": lambda value, *args, **kwargs: value,
+                "decrypt_pii": lambda value, *args, **kwargs: value,
+                "is_encrypted": lambda *_args, **_kwargs: False,
+            },
+        ),
     }
 
     for module_name, stub_module in stubs.items():
-        if module_name not in sys.modules:
+        if module_name.startswith("backend."):
+            should_stub = module_name not in sys.modules
+        elif module_name == "encryption":
+            try:
+                crypto_missing = importlib.util.find_spec("Crypto") is None
+            except ModuleNotFoundError:
+                crypto_missing = True
+            should_stub = module_name not in sys.modules and crypto_missing
+        else:
+            try:
+                spec_missing = importlib.util.find_spec(module_name) is None
+            except ModuleNotFoundError:
+                spec_missing = True
+            should_stub = module_name not in sys.modules and spec_missing
+
+        if should_stub:
             sys.modules[module_name] = stub_module
 
 
@@ -271,12 +427,14 @@ def fake_db():
             {
                 "id": "user_A",
                 "company_id": "company_A",
-                "company": "Company A"
+                "company": "Company A",
+                "role": "user",
             },
             {
                 "id": "user_B",
                 "company_id": "company_B",
-                "company": "Company B"
+                "company": "Company B",
+                "role": "user",
             }
         ],
         "tickets": [],

--- a/backend/tests/test_privileged_endpoints.py
+++ b/backend/tests/test_privileged_endpoints.py
@@ -1,0 +1,115 @@
+from backend.auth_cookie import get_current_user
+
+
+def authenticate_as(test_client, user_id):
+    test_client.app.dependency_overrides[get_current_user] = lambda: {"id": user_id}
+
+
+def clear_authentication(test_client):
+    test_client.app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_regular_users_cannot_access_privileged_endpoints(test_client, fake_db):
+    fake_db["profiles"][0]["role"] = "user"
+    authenticate_as(test_client, "user_A")
+
+    assert test_client.get("/system/settings").status_code == 403
+    assert test_client.patch("/system/settings", json={"admin_alerts": False}).status_code == 403
+    assert test_client.get("/sla/stats").status_code == 403
+    assert test_client.get("/sla/policies").status_code == 403
+    assert test_client.post("/sla/check").status_code == 403
+    assert test_client.post("/ai/reindex_embeddings").status_code == 403
+
+    clear_authentication(test_client)
+
+
+def test_tenant_admin_endpoints_are_scoped_to_their_company(test_client, fake_db):
+    fake_db["profiles"][0]["role"] = "admin"
+    fake_db["system_settings"] = [
+        {
+            "company_id": "company_A",
+            "ai_confidence_threshold": 0.8,
+            "duplicate_sensitivity": 0.85,
+            "enable_auto_resolve": True,
+            "admin_alerts": True,
+        },
+        {
+            "company_id": "company_B",
+            "ai_confidence_threshold": 0.4,
+            "duplicate_sensitivity": 0.5,
+            "enable_auto_resolve": False,
+            "admin_alerts": True,
+        },
+    ]
+    fake_db["tickets"] = [
+        {"id": 1, "company_id": "company_A", "priority": "critical", "sla_status": "breached", "status": "open"},
+        {"id": 2, "company_id": "company_A", "priority": "medium", "sla_status": "warning", "status": "open"},
+        {"id": 3, "company_id": "company_B", "priority": "low", "sla_status": "met", "status": "open"},
+    ]
+    fake_db["escalation_logs"] = [
+        {"id": "esc-1", "ticket_id": 1, "triggered_at": "2026-06-01T10:00:00Z"},
+        {"id": "esc-2", "ticket_id": 3, "triggered_at": "2026-06-01T09:00:00Z"},
+    ]
+
+    authenticate_as(test_client, "user_A")
+
+    settings_response = test_client.get("/system/settings")
+    assert settings_response.status_code == 200
+    assert settings_response.json() == {
+        "ai_confidence_threshold": 0.8,
+        "duplicate_sensitivity": 0.85,
+        "enable_auto_resolve": True,
+        "admin_alerts": True,
+    }
+
+    update_response = test_client.patch("/system/settings", json={"admin_alerts": False})
+    assert update_response.status_code == 200
+    assert fake_db["system_settings"][0]["admin_alerts"] is False
+    assert fake_db["system_settings"][1]["admin_alerts"] is True
+
+    stats_response = test_client.get("/sla/stats")
+    assert stats_response.status_code == 200
+    assert stats_response.json()["total"] == 2
+    assert stats_response.json()["breached"] == 1
+    assert stats_response.json()["warning"] == 1
+    assert stats_response.json()["met"] == 0
+
+    escalations_response = test_client.get("/sla/escalations")
+    assert escalations_response.status_code == 200
+    assert escalations_response.json()["total"] == 1
+    assert escalations_response.json()["escalations"][0]["ticket_id"] == 1
+
+    clear_authentication(test_client)
+
+
+def test_master_admin_can_target_another_company_settings(test_client, fake_db):
+    fake_db["profiles"].append(
+        {
+            "id": "master_admin_1",
+            "company_id": None,
+            "company": None,
+            "role": "master_admin",
+        }
+    )
+    fake_db["system_settings"] = [
+        {"company_id": "company_A", "admin_alerts": True, "digest_frequency": "daily"},
+        {"company_id": "company_B", "admin_alerts": False, "digest_frequency": "weekly"},
+    ]
+
+    authenticate_as(test_client, "master_admin_1")
+
+    settings_response = test_client.get("/system/settings?company_id=company_B")
+    assert settings_response.status_code == 200
+    assert settings_response.json() == {
+        "admin_alerts": False,
+        "digest_frequency": "weekly",
+    }
+
+    update_response = test_client.patch(
+        "/system/settings",
+        json={"company_id": "company_B", "admin_alerts": True},
+    )
+    assert update_response.status_code == 200
+    assert fake_db["system_settings"][1]["admin_alerts"] is True
+
+    clear_authentication(test_client)


### PR DESCRIPTION
## Summary
Fixes #1305.

This PR closes a critical authorization gap where authenticated users could reach privileged SLA and system-settings endpoints without sufficient server-side role checks.

## What changed
- added explicit tenant-admin and platform-admin authorization helpers
- scoped `/sla/stats` and `/sla/escalations` to the caller's tenant unless a platform admin explicitly targets another company
- required admin access for `/sla/policies`
- restricted `/sla/check` and `/ai/reindex_embeddings` to platform-admin roles
- fixed `/system/settings` to operate on per-company rows and deny cross-tenant access
- added regression tests for denial paths, tenant-scoped success, and master-admin cross-company targeting

## Validation
- `pytest backend/tests/test_privileged_endpoints.py -q`

## Notes
- while preparing the clean `gssoc` branch locally on Windows, unrelated upstream import/syntax regressions outside this authz change path blocked broader suite execution; this PR does not widen scope to fix those unrelated issues
