### PR TITLE
feat: Bulk Ticket Actions for Admin Panel (Select, Assign, Close, Change Priority)

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import useAuthStore from "../../store/authStore";
 import useToastStore from "../../store/toastStore";
@@ -6,24 +6,30 @@ import { supabase } from "../../lib/supabaseClient";
 import useTicketsRealtime from "../../hooks/useTicketsRealtime";
 import TagFilter from "../../components/TagFilter";
 import TagChip from "../../components/TagChip";
-import { TicketTableSkeleton } from "../../components/Skeletons";
+import LanguageBadge from "../../components/shared/LanguageBadge";
 import {
-  Search,
-  Filter,
-  Inbox,
-  Activity,
-  ShieldAlert,
-  Clock,
-  ChevronRight,
-  BarChart3,
-  User,
-  ArrowUpRight,
-  ExternalLink,
-  AlertCircle,
-  CheckCircle2,
-  Loader2,
-  Save,
-  RotateCcw,
+    Search,
+    Filter,
+    Inbox,
+    Activity,
+    ShieldAlert,
+    Clock,
+    ChevronRight,
+    BarChart3,
+    User,
+    ArrowUpRight,
+    ExternalLink,
+    AlertCircle,
+    CheckCircle2,
+    Loader2,
+    Save,
+    RotateCcw,
+    Square,
+    CheckSquare,
+    X,
+    Users,
+    XCircle,
+    ArrowUpDown,
 } from 'lucide-react';
 import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
@@ -31,70 +37,196 @@ import SLABadge from "../components/SLABadge";
 import { formatTimelineDate } from "../../utils/dateUtils";
 import { sanitizeSearchQuery } from "../../utils/sanitizeText";
 
-const AdminTicketsSkeleton = () => (
-    <div className="animate-pulse" role="status" aria-live="polite" aria-atomic="true">
-        <span className="sr-only">Loading tickets...</span>
-        {[...Array(6)].map((_, rowIndex) => (
-            <div key={rowIndex} className="grid grid-cols-[90px_180px_260px_120px_140px_120px_120px_100px_80px] gap-4 px-6 py-5 border-b border-slate-50 items-center">
-                <div className="h-4 bg-emerald-100 rounded-full" />
-                <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 bg-slate-100 rounded-lg" />
-                    <div className="space-y-2 flex-1">
-                        <div className="h-3 bg-slate-100 rounded-full" />
-                        <div className="h-2 bg-slate-100 rounded-full w-2/3" />
-                    </div>
+/* ────────────────────────────────────────────────────────────
+   Confirmation Modal  – reusable for any destructive bulk op
+   ──────────────────────────────────────────────────────────── */
+const BulkConfirmModal = ({ action, count, onConfirm, onCancel, isExecuting }) => {
+    const labelMap = {
+        close: 'Close',
+        priority: 'Change Priority of',
+        assign: 'Assign Agent to',
+    };
+    return (
+        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-in fade-in duration-200">
+            <div className="bg-white rounded-3xl p-8 max-w-md w-full shadow-2xl shadow-slate-900/20 border border-slate-100 animate-in zoom-in-95 duration-300">
+                {/* Icon */}
+                <div className="w-14 h-14 rounded-2xl bg-amber-50 border border-amber-100 flex items-center justify-center mx-auto mb-5">
+                    <AlertCircle className="w-7 h-7 text-amber-500" />
                 </div>
-                <div className="space-y-2">
-                    <div className="h-3 bg-slate-100 rounded-full" />
-                    <div className="h-2 bg-slate-100 rounded-full w-1/2" />
+                <h3 className="text-lg font-black text-slate-900 uppercase italic tracking-tight text-center">
+                    Confirm Bulk Action
+                </h3>
+                <p className="text-sm text-slate-500 mt-3 text-center leading-relaxed">
+                    You are about to <strong className="text-slate-800">{labelMap[action] || action}</strong>{' '}
+                    <strong className="text-indigo-600">{count}</strong> ticket{count > 1 ? 's' : ''}.
+                    This action cannot be undone.
+                </p>
+                <div className="flex gap-3 mt-8">
+                    <button
+                        onClick={onConfirm}
+                        disabled={isExecuting}
+                        className="flex-1 bg-indigo-600 text-white rounded-2xl py-3.5 text-xs font-black uppercase tracking-widest hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-500/20 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                    >
+                        {isExecuting ? (
+                            <>
+                                <Loader2 size={14} className="animate-spin" />
+                                Processing…
+                            </>
+                        ) : (
+                            'Confirm'
+                        )}
+                    </button>
+                    <button
+                        onClick={onCancel}
+                        disabled={isExecuting}
+                        className="flex-1 bg-slate-100 text-slate-600 rounded-2xl py-3.5 text-xs font-black uppercase tracking-widest hover:bg-slate-200 transition-colors disabled:opacity-50"
+                    >
+                        Cancel
+                    </button>
                 </div>
-                <div className="h-7 bg-amber-100 rounded-xl" />
-                <div className="h-8 bg-slate-100 rounded-full" />
-                <div className="h-4 bg-emerald-100 rounded-full" />
-                <div className="h-7 bg-slate-100 rounded-xl" />
-                <div className="h-6 bg-slate-100 rounded-full" />
-                <div className="h-9 bg-slate-900/10 rounded-xl" />
             </div>
-        ))}
-    </div>
-);
+        </div>
+    );
+};
 
+/* ────────────────────────────────────────────────────────────
+   Bulk Action Toolbar  – slides in when 1+ tickets selected
+   ──────────────────────────────────────────────────────────── */
+const BulkActionToolbar = ({
+    selectedCount,
+    bulkAction,
+    setBulkAction,
+    bulkValue,
+    setBulkValue,
+    agents,
+    priorities,
+    onApply,
+    onClear,
+}) => {
+    const canApply = bulkAction === 'close' || (bulkAction && bulkValue);
+    return (
+        <div className="bg-gradient-to-r from-indigo-600 via-indigo-600 to-violet-600 text-white px-6 py-4 rounded-2xl flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 shadow-xl shadow-indigo-500/25 animate-in slide-in-from-top-2 fade-in duration-300">
+            {/* Left: selection count */}
+            <div className="flex items-center gap-3">
+                <div className="w-9 h-9 rounded-xl bg-white/15 flex items-center justify-center">
+                    <CheckSquare size={18} />
+                </div>
+                <span className="text-sm font-black uppercase tracking-widest">
+                    {selectedCount} ticket{selectedCount > 1 ? 's' : ''} selected
+                </span>
+            </div>
+
+            {/* Right: controls */}
+            <div className="flex flex-wrap items-center gap-3">
+                {/* Action picker */}
+                <select
+                    id="bulk-action-select"
+                    value={bulkAction}
+                    onChange={(e) => { setBulkAction(e.target.value); setBulkValue(''); }}
+                    className="bg-white/15 text-white text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2.5 border border-white/20 outline-none cursor-pointer backdrop-blur-sm hover:bg-white/25 transition-colors"
+                >
+                    <option value="" className="text-slate-900">Select Action…</option>
+                    <option value="close" className="text-slate-900">🔒 Close Tickets</option>
+                    <option value="priority" className="text-slate-900">⚡ Change Priority</option>
+                    <option value="assign" className="text-slate-900">👤 Assign Agent</option>
+                </select>
+
+                {/* Priority sub-select */}
+                {bulkAction === 'priority' && (
+                    <select
+                        id="bulk-priority-select"
+                        value={bulkValue}
+                        onChange={(e) => setBulkValue(e.target.value)}
+                        className="bg-white/15 text-white text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2.5 border border-white/20 outline-none cursor-pointer backdrop-blur-sm animate-in fade-in slide-in-from-left-2 duration-200"
+                    >
+                        <option value="" className="text-slate-900">Pick Priority</option>
+                        {priorities.filter(p => p !== 'All').map(p => (
+                            <option key={p} value={p.toLowerCase()} className="text-slate-900">{p}</option>
+                        ))}
+                    </select>
+                )}
+
+                {/* Agent sub-select */}
+                {bulkAction === 'assign' && (
+                    <select
+                        id="bulk-assign-select"
+                        value={bulkValue}
+                        onChange={(e) => setBulkValue(e.target.value)}
+                        className="bg-white/15 text-white text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2.5 border border-white/20 outline-none cursor-pointer backdrop-blur-sm animate-in fade-in slide-in-from-left-2 duration-200"
+                    >
+                        <option value="" className="text-slate-900">Pick Agent</option>
+                        {agents.map(a => (
+                            <option key={a.id} value={a.id} className="text-slate-900">{a.full_name}</option>
+                        ))}
+                    </select>
+                )}
+
+                {/* Apply */}
+                {canApply && (
+                    <button
+                        id="bulk-apply-btn"
+                        onClick={onApply}
+                        className="bg-white text-indigo-600 text-xs font-black uppercase tracking-widest rounded-xl px-5 py-2.5 hover:bg-indigo-50 transition-all shadow-lg shadow-black/10 animate-in fade-in zoom-in-95 duration-200"
+                    >
+                        Apply
+                    </button>
+                )}
+
+                {/* Clear */}
+                <button
+                    id="bulk-clear-btn"
+                    onClick={onClear}
+                    className="p-2.5 hover:bg-white/15 rounded-xl transition-colors"
+                    title="Clear selection"
+                >
+                    <X size={16} />
+                </button>
+            </div>
+        </div>
+    );
+};
+
+/* ────────────────────────────────────────────────────────────
+   Main Component
+   ──────────────────────────────────────────────────────────── */
 const AdminTickets = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { user } = useAuthStore();
+    const { user, profile } = useAuthStore();
     const { showToast } = useToastStore();
 
-    // Data State
+    // ── Data State ──────────────────────────────────
     const [tickets, setTickets] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [isUpdating, setIsUpdating] = useState(null);
-    const [isUpdating, setIsUpdating] = useState(null); // ID of ticket being updated
+    const [newlyBreachedTicketIds, setNewlyBreachedTicketIds] = useState([]);
 
-    // Filter States
+    // ── Filter State ────────────────────────────────
     const [searchQuery, setSearchQuery] = useState('');
     const [statusFilter, setStatusFilter] = useState('All');
     const [categoryFilter, setCategoryFilter] = useState('All');
     const [priorityFilter, setPriorityFilter] = useState('All');
     const [teamFilter, setTeamFilter] = useState('All');
+    const [languageFilter, setLanguageFilter] = useState('All');
+    const [slaAtRisk, setSlaAtRisk] = useState(false);
     const [agents, setAgents] = useState([]);
+    const [tagFilters, setTagFilters] = useState([]);
+
+    // ── Bulk Action State ───────────────────────────
     const [selectedTickets, setSelectedTickets] = useState([]);
     const [bulkAction, setBulkAction] = useState('');
     const [bulkValue, setBulkValue] = useState('');
     const [showBulkConfirm, setShowBulkConfirm] = useState(false);
-    const [languageFilter, setLanguageFilter] = useState('All');
-    const [slaAtRisk, setSlaAtRisk] = useState(false);
-    const [agents, setAgents] = useState([]); // All staff/admins in the company
-    const [tagFilters, setTagFilters] = useState([]);
+    const [isBulkExecuting, setIsBulkExecuting] = useState(false);
 
-    // Pagination State
-    const PAGE_SIZE = 25;
-    const [page, setPage] = useState(0);
-    const [totalCount, setTotalCount] = useState(null);
-    const [loadingMore, setLoadingMore] = useState(false);
-    const hasMore = totalCount === null ? false : (page + 1) * PAGE_SIZE < totalCount;
+    // ── Constants ───────────────────────────────────
+    const categories = ['All', 'Network', 'Hardware', 'Software', 'Access', 'Account'];
+    const priorities = ['All', 'Low', 'Medium', 'High'];
+    const statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed', 'Spam'];
+    const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
 
+    // ── Realtime filter predicate ───────────────────
     const ticketMatchesFilters = useCallback((ticket) => {
         if (statusFilter !== 'All' && String(ticket.status || '').toLowerCase() !== statusFilter.toLowerCase()) return false;
         if (categoryFilter !== 'All' && ticket.category !== categoryFilter) return false;
@@ -110,7 +242,6 @@ const AdminTickets = () => {
         return true;
     }, [categoryFilter, priorityFilter, statusFilter, teamFilter, languageFilter, tagFilters]);
 
-
     const handleRealtimeInsert = useCallback((ticket) => {
         showToast(`New Incident Reported: #${formatTicketId(ticket.id)}`, "success");
     }, [showToast]);
@@ -124,169 +255,124 @@ const AdminTickets = () => {
         channelName: 'admin_tickets_realtime',
     });
 
-  const fetchInitialData = async () => {
-    setLoading(true);
-    try {
-      const { profile } = useAuthStore.getState();
+    // ── Data Fetching ───────────────────────────────
+    const fetchInitialData = async () => {
+        setLoading(true);
+        try {
+            const { profile } = useAuthStore.getState();
 
-      // 1. Fetch Agents for this company
-      if (profile?.company) {
-        const { data: agentData } = await supabase
-          .from('profiles')
-          .select('id, full_name, role')
-          .eq('company', profile.company)
-          .in('role', ['admin', 'super_admin', 'agent']);
-        setAgents(agentData || []);
-      }
+            if (profile?.company) {
+                const { data: agentData } = await supabase
+                    .from('profiles')
+                    .select('id, full_name, role')
+                    .eq('company', profile.company)
+                    .in('role', ['admin', 'super_admin', 'agent']);
+                setAgents(agentData || []);
+            }
 
-      // 2. Fetch Tickets (Join with both Creator and Assignee)
-      fetchTickets();
-    } catch (err) {
-      console.error('Initialization error:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
+            fetchTickets();
+        } catch (err) {
+            console.error("Initialization error:", err);
+        } finally {
+            setLoading(false);
+        }
+    };
 
-  const fetchTickets = async () => {
-    setError(null);
-    try {
-      const { profile } = useAuthStore.getState();
+    const fetchTickets = async () => {
+        setError(null);
+        try {
+            const { profile } = useAuthStore.getState();
 
-      // Join with profiles for both user_id (creator) and assigned_agent_id (assignee)
-      let query = supabase.from('tickets').select(`
+            let query = supabase
+                .from('tickets')
+                .select(`
                     *,
                     creator:profiles!tickets_user_id_fkey(full_name, email, profile_picture),
                     assignee:profiles!tickets_assigned_agent_id_fkey(full_name, email, profile_picture)
-                `, { count: 'exact' });
+                `);
 
-      if (profile?.role === 'admin' && profile?.company) {
-        query = query.eq('company', profile.company);
-      }
+            if (profile?.role === 'admin' && profile?.company) {
+                query = query.eq('company', profile.company);
+            }
 
-      if (statusFilter !== 'All') query = query.eq('status', statusFilter.toLowerCase());
-      if (categoryFilter !== 'All') query = query.eq('category', categoryFilter);
-      if (priorityFilter !== 'All') query = query.eq('priority', priorityFilter.toLowerCase());
-      if (teamFilter !== 'All') query = query.eq('assigned_team', teamFilter);
+            if (statusFilter !== 'All') query = query.eq('status', statusFilter.toLowerCase());
+            if (categoryFilter !== 'All') query = query.eq('category', categoryFilter);
+            if (priorityFilter !== 'All') query = query.eq('priority', priorityFilter.toLowerCase());
+            if (teamFilter !== 'All') query = query.eq('assigned_team', teamFilter);
 
-      let { data, error: sbError } = await query.order('created_at', { ascending: false });
+            let { data, error: sbError } = await query.order('created_at', { ascending: false });
 
-      if (sbError) {
-        // Secondary check: If the FK alias fails, try a simpler select
-        console.warn('Retrying fetch without relationship aliases...');
-        const basicQuery = supabase.from('tickets').select('*, profiles(full_name, email)');
-        const { data: basicData, error: basicError } = await basicQuery
-          .eq('company', profile?.company)
-          .order('created_at', { ascending: false });
-        if (basicError) throw basicError;
-        setTickets(basicData || []);
-      } else {
-        setTickets(data || []);
-      }
-    } catch (err) {
-      console.error('Admin fetch error:', err);
-      setError(err.message);
-    }
-  };
-
-  useEffect(() => {
-    fetchInitialData();
-
-    // 4. Real-time subscription to ticket changes
-    const { profile } = useAuthStore.getState();
-    const channel = supabase
-      .channel('admin_tickets_realtime')
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'tickets',
-          filter: profile?.company ? `company=eq.${profile.company}` : undefined,
-        },
-        (payload) => {
-          console.log('Admin tickets sync event:', payload.eventType, payload.new);
-          if (payload.eventType === 'INSERT') {
-            setTickets((prev) => [payload.new, ...prev]);
-            showToast(`New Incident Reported: #${payload.new.id}`, 'success');
-            // Play a subtle sound or visual cue if needed
-          } else if (payload.eventType === 'UPDATE') {
-            setTickets((prev) =>
-              prev.map((t) => (t.id === payload.new.id ? { ...t, ...payload.new } : t))
-            );
-          } else if (payload.eventType === 'DELETE') {
-            setTickets((prev) => prev.filter((t) => t.id === payload.old.id));
-          }
+            if (sbError) {
+                console.warn("Retrying fetch without relationship aliases...");
+                const basicQuery = supabase.from('tickets').select('*, profiles(full_name, email)');
+                const { data: basicData, error: basicError } = await basicQuery
+                    .eq('company', profile?.company)
+                    .order('created_at', { ascending: false });
+                if (basicError) throw basicError;
+                setTickets(basicData || []);
+            } else {
+                setTickets(data || []);
+            }
+        } catch (err) {
+            console.error("Admin fetch error:", err);
+            setError(err.message);
         }
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(channel);
     };
-  }, [statusFilter, categoryFilter, priorityFilter, teamFilter]);
 
     useEffect(() => {
         fetchInitialData();
+    }, [statusFilter, categoryFilter, priorityFilter, teamFilter]);
 
-        // 4. Real-time subscription to ticket changes
-        const { profile } = useAuthStore.getState();
-        const channel = supabase
-            .channel('admin_tickets_realtime')
+    // SLA breach realtime listener
+    useEffect(() => {
+        const channelSla = supabase
+            .channel('sla-alerts')
             .on(
-                'postgres_changes',
-                {
-                    event: '*',
-                    schema: 'public',
-                    table: 'tickets',
-                    filter: profile?.company ? `company=eq.${profile.company}` : undefined
-                },
+                'broadcast',
+                { event: 'breach' },
                 (payload) => {
-                    console.log("Admin tickets sync event:", payload.eventType, payload.new);
-                    if (payload.eventType === 'INSERT') {
-                        setTickets(prev => [payload.new, ...prev]);
-                        showToast(`New Incident Reported: #${payload.new.id}`, "success");
-                        // Play a subtle sound or visual cue if needed
-                    } else if (payload.eventType === 'UPDATE') {
-                        setTickets(prev => prev.map(t => t.id === payload.new.id ? { ...t, ...payload.new } : t));
-                    } else if (payload.eventType === 'DELETE') {
-                        setTickets(prev => prev.filter(t => t.id === payload.old.id));
-                    }
+                    const { ticketId, subject, originalTeam, escalatedTeam, companyId } = payload.payload;
+                    const { profile } = useAuthStore.getState();
+                    if (profile?.company_id && companyId && profile.company_id !== companyId) return;
+
+                    const formattedId = String(ticketId).slice(0, 8).toUpperCase();
+                    showToast(`⚠️ SLA BREACH: Ticket #${formattedId} ("${subject}") escalated from '${originalTeam}' to '${escalatedTeam}'!`, "error");
+
+                    setNewlyBreachedTicketIds(prev => [...prev, ticketId]);
+                    setTimeout(() => {
+                        setNewlyBreachedTicketIds(prev => prev.filter(id => id !== ticketId));
+                    }, 12000);
+
+                    setTickets(prev => prev.map(t =>
+                        t.id === ticketId
+                            ? { ...t, sla_status: 'BREACHED', assigned_team: escalatedTeam, escalation_level: (t.escalation_level || 0) + 1, updated_at: new Date().toISOString() }
+                            : t
+                    ));
                 }
             )
             .subscribe();
 
-        return () => {
-            supabase.removeChannel(channel);
-        };
-     
-    }, [statusFilter, categoryFilter, priorityFilter, teamFilter]);
+        return () => { supabase.removeChannel(channelSla); };
+    }, []);
 
-      // Optimistic update already handled if real-time is fast,
-      // but manual update ensures immediate feedback
-      setTickets((prev) => prev.map((t) => (t.id === id ? { ...t, ...updates } : t)));
-      showToast('System synchronization successful.', 'success');
-    } catch (err) {
-      console.error('Update failed:', err);
-      showToast('Update failed: ' + err.message, 'error');
-    } finally {
-      setIsUpdating(null);
-    }
-  };
+    // Seed search from URL
+    useEffect(() => {
+        const params = new URLSearchParams(location.search);
+        const q = params.get('q');
+        if (q) setSearchQuery(decodeURIComponent(q));
+    }, [location.search]);
 
-  const categories = ['All', 'Network', 'Hardware', 'Software', 'Access', 'Account'];
-  const priorities = ['All', 'Low', 'Medium', 'High'];
-  const statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed'];
-  const teams = [
-    'All',
-    'Software Team',
-    'Hardware Support',
-    'Network Ops',
-    'Security Unit',
-    'General Support',
-  ];
+    // ── Single-ticket update ────────────────────────
+    const handleUpdateTicket = async (id, updates) => {
+        setIsUpdating(id);
+        try {
+            const { error: upError } = await supabase
+                .from('tickets')
+                .update(updates)
+                .eq('id', id);
 
             if (upError) throw upError;
+
             setTickets(prev => prev.map(t => t.id === id ? { ...t, ...updates } : t));
             showToast("System synchronization successful.", "success");
         } catch (err) {
@@ -297,9 +383,9 @@ const AdminTickets = () => {
         }
     };
 
-    // --- Bulk Operations ---
+    // ── Bulk Operations ─────────────────────────────
     const handleSelectAll = () => {
-        if (selectedTickets.length === filteredTickets.length) {
+        if (selectedTickets.length === filteredTickets.length && filteredTickets.length > 0) {
             setSelectedTickets([]);
         } else {
             setSelectedTickets(filteredTickets.map(t => t.id));
@@ -312,84 +398,86 @@ const AdminTickets = () => {
         );
     };
 
+    const handleBulkClear = () => {
+        setSelectedTickets([]);
+        setBulkAction('');
+        setBulkValue('');
+    };
+
     const handleBulkExecute = async () => {
         if (!bulkAction || selectedTickets.length === 0) return;
+        setIsBulkExecuting(true);
         try {
             let updates = {};
             if (bulkAction === 'close') updates = { status: 'closed' };
             if (bulkAction === 'priority') updates = { priority: bulkValue };
             if (bulkAction === 'assign') updates = { assigned_agent_id: bulkValue, status: 'in progress' };
 
-            for (const id of selectedTickets) {
-                await supabase.from('tickets').update(updates).eq('id', id);
-            }
+            // Batch update via Supabase .in() for efficiency
+            const { error: bulkError } = await supabase
+                .from('tickets')
+                .update(updates)
+                .in('id', selectedTickets);
 
+            if (bulkError) throw bulkError;
+
+            // Optimistic state update
             setTickets(prev => prev.map(t =>
                 selectedTickets.includes(t.id) ? { ...t, ...updates } : t
             ));
-            showToast(`${selectedTickets.length} tickets updated successfully.`, "success");
+
+            const actionLabel = bulkAction === 'close' ? 'closed' : bulkAction === 'priority' ? 'priority updated' : 'assigned';
+            showToast(`✅ ${selectedTickets.length} ticket${selectedTickets.length > 1 ? 's' : ''} ${actionLabel} successfully.`, "success");
+
             setSelectedTickets([]);
             setBulkAction('');
             setBulkValue('');
             setShowBulkConfirm(false);
         } catch (err) {
+            console.error("Bulk update failed:", err);
             showToast("Bulk update failed: " + err.message, "error");
+        } finally {
+            setIsBulkExecuting(false);
         }
-    const exportCSV = () => {
-        const exportData = filteredTickets.map(t => ({
-            ID: formatTicketId(t.id),
-            Title: t.summary || t.subject || '',
-            Category: t.category || '',
-            Priority: t.priority || '',
-            Status: t.status || '',
-            'Created Date': t.created_at ? new Date(t.created_at).toLocaleString() : '',
-            'Resolved Date': t.resolved_at ? new Date(t.resolved_at).toLocaleString() : '',
-            'Assigned Agent': t.assignee?.full_name || '',
-        }));
-        const csv = Papa.unparse(exportData);
-        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = `tickets_export_${Date.now()}.csv`;
-        link.click();
-        URL.revokeObjectURL(url);
     };
 
-    const exportPDF = () => {
-        const doc = new jsPDF();
-        doc.setFontSize(16);
-        doc.text('Ticket Export Report', 14, 15);
-        doc.setFontSize(8);
-        let y = 25;
-        filteredTickets.forEach((t, i) => {
-            if (y > 270) { doc.addPage(); y = 15; }
-            doc.text(
-                `#${formatTicketId(t.id)} | ${t.summary || t.subject || 'N/A'} | ${t.category || ''} | ${t.priority || ''} | ${t.status || ''} | ${t.created_at ? new Date(t.created_at).toLocaleDateString() : ''}`,
-                14, y
-            );
-            y += 7;
-        });
-        doc.save(`tickets_export_${Date.now()}.pdf`);
-    };
-
-    const categories = ['All', 'Network', 'Hardware', 'Software', 'Access', 'Account'];
-    const priorities = ['All', 'Low', 'Medium', 'High'];
-    const statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed'];
-    const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
-
+    // ── Derived / Filtered ──────────────────────────
     const filteredTickets = useMemo(() => {
-        if (!searchQuery) return tickets;
-        const q = sanitizeSearchQuery(searchQuery).toLowerCase();
-        return tickets.filter(t =>
-            String(t.id).includes(q) ||
-            (t.subject || '').toLowerCase().includes(q) ||
-            (t.summary || '').toLowerCase().includes(q) ||
-            (t.description || '').toLowerCase().includes(q) ||
-            (t.profiles?.full_name || '').toLowerCase().includes(q)
-        );
-    }, [tickets, searchQuery]);
+        let result = tickets;
+        if (searchQuery) {
+            const q = sanitizeSearchQuery(searchQuery).toLowerCase();
+            result = result.filter(t =>
+                String(t.id).includes(q) ||
+                (t.subject || '').toLowerCase().includes(q) ||
+                (t.summary || '').toLowerCase().includes(q) ||
+                (t.description || '').toLowerCase().includes(q) ||
+                (t.profiles?.full_name || '').toLowerCase().includes(q)
+            );
+        }
+        if (languageFilter !== 'All') {
+            result = result.filter(t => {
+                const translated = t.detected_language && t.detected_language.toLowerCase() !== 'en';
+                return languageFilter === 'Translated' ? translated : !translated;
+            });
+        }
+        if (slaAtRisk) {
+            result = result.filter(t => {
+                const s = (t.sla_status || '').toUpperCase();
+                return s === 'BREACHED' || s === 'WARNING';
+            });
+        }
+        if (tagFilters.length > 0) {
+            result = result.filter(t => (t.tags || []).length > 0 && tagFilters.every(tag => (t.tags || []).includes(tag)));
+        }
+        return result;
+    }, [tickets, searchQuery, languageFilter, slaAtRisk, tagFilters]);
 
+    // Clear selection when filters change (selected IDs may no longer be visible)
+    useEffect(() => {
+        setSelectedTickets([]);
+    }, [statusFilter, categoryFilter, priorityFilter, teamFilter, searchQuery, languageFilter, slaAtRisk, tagFilters]);
+
+    // ── Helpers ─────────────────────────────────────
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();
         if (p === 'high' || p === 'critical') return 'text-red-600 bg-red-50 border-red-100';
@@ -404,21 +492,26 @@ const AdminTickets = () => {
         return 'bg-red-500';
     };
 
+    const isAllSelected = filteredTickets.length > 0 && selectedTickets.length === filteredTickets.length;
+    const isSomeSelected = selectedTickets.length > 0 && selectedTickets.length < filteredTickets.length;
+
+    // ── Render ──────────────────────────────────────
     return (
-        <div className="space-y-8 animate-in fade-in duration-700">
+        <div className="space-y-6 animate-in fade-in duration-700">
             {/* 1. Header & Utility Bar */}
             <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
                 <div>
                     <h1 className="text-3xl font-black text-slate-900 tracking-tight italic uppercase">Ticket Management</h1>
                     <p className="text-sm font-bold text-slate-400 mt-1 flex items-center gap-2">
-                        <Activity size={14} className="text-indigo-500" /> {totalCount !== null ? totalCount : filteredTickets.length} tickets{totalCount !== null ? ' in total' : ' matching current filters'}.
+                        <Activity size={14} className="text-indigo-500" /> {filteredTickets.length} tickets matching current filters.
                     </p>
                 </div>
             </div>
 
             {/* 2. Advanced Filtering Station */}
-            <div className="bg-white dark:bg-slate-950 p-6 rounded-[2rem] border border-slate-200 dark:border-slate-800 shadow-xl shadow-slate-200/50 dark:shadow-slate-900/50 space-y-6">
+            <div className="bg-white p-6 rounded-[2rem] border border-slate-200 shadow-xl shadow-slate-200/50 space-y-6">
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+                    {/* Search Field */}
                     <div className="relative group lg:col-span-1">
                         <Search className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 group-focus-within:text-emerald-500 transition-colors w-5 h-5" />
                         <input
@@ -426,109 +519,146 @@ const AdminTickets = () => {
                             placeholder="Search..."
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
-                            className="w-full bg-slate-50 dark:bg-slate-950 border border-slate-200 dark:border-slate-700 rounded-2xl pl-12 pr-4 py-3 text-sm font-bold focus:outline-none focus:ring-4 focus:ring-emerald-500/5 focus:border-emerald-500 focus:bg-white dark:focus:bg-slate-900 transition-all text-slate-700 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500"
+                            className="w-full bg-slate-50 border border-slate-200 rounded-2xl pl-12 pr-4 py-3 text-sm font-bold focus:outline-none focus:ring-4 focus:ring-emerald-500/5 focus:border-emerald-500 focus:bg-white transition-all text-slate-700 placeholder:text-slate-400"
                         />
                     </div>
-                    <Select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center" options={statuses.map(s => ({ value: s, label: s === 'All' ? 'All Statuses' : s }))} />
-                    <Select value={categoryFilter} onChange={(e) => setCategoryFilter(e.target.value)} buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center" options={categories.map(c => ({ value: c, label: c === 'All' ? 'All Categories' : c }))} />
-                    <Select value={priorityFilter} onChange={(e) => setPriorityFilter(e.target.value)} buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center" options={priorities.map(p => ({ value: p, label: p === 'All' ? 'All Priorities' : p }))} />
-                    <Select value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)} buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center" options={teams.map(t => ({ value: t, label: t === 'All' ? 'All Teams' : t }))} />
+
+                    {/* Status Filter */}
+                    <Select
+                        value={statusFilter}
+                        onChange={(e) => setStatusFilter(e.target.value)}
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        options={statuses.map(s => ({ value: s, label: s === 'All' ? 'All Statuses' : s }))}
+                    />
+
+                    {/* Category Filter */}
+                    <Select
+                        value={categoryFilter}
+                        onChange={(e) => setCategoryFilter(e.target.value)}
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        options={categories.map(c => ({ value: c, label: c === 'All' ? 'All Categories' : c }))}
+                    />
+
+                    {/* Priority Filter */}
+                    <Select
+                        value={priorityFilter}
+                        onChange={(e) => setPriorityFilter(e.target.value)}
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        options={priorities.map(p => ({ value: p, label: p === 'All' ? 'All Priorities' : p }))}
+                    />
+
+                    {/* Team Filter */}
+                    <Select
+                        value={teamFilter}
+                        onChange={(e) => setTeamFilter(e.target.value)}
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        options={teams.map(t => ({ value: t, label: t === 'All' ? 'All Teams' : t }))}
+                    />
+                </div>
+
+                {/* Combined Filter Row */}
+                <div className="flex items-center gap-3">
+                    <Select
+                        value={languageFilter}
+                        onChange={(e) => setLanguageFilter(e.target.value)}
+                        buttonClassName="bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-sky-500/5 transition-all text-left flex justify-between items-center"
+                        options={[
+                            { value: 'All', label: '🌐 All Languages' },
+                            { value: 'English', label: 'English Only' },
+                            { value: 'Translated', label: 'Translated Only' },
+                        ]}
+                    />
+
+                    <button
+                        onClick={() => setSlaAtRisk(prev => !prev)}
+                        className={`flex items-center gap-2 px-4 py-3 rounded-2xl text-[11px] font-black uppercase tracking-widest border transition-all ${
+                            slaAtRisk
+                                ? 'bg-red-50 border-red-200 text-red-700 shadow-sm'
+                                : 'bg-slate-50 border-slate-200 text-slate-500 hover:border-red-200 hover:text-red-600'
+                        }`}
+                    >
+                        <ShieldAlert size={14} />
+                        SLA At Risk
+                        {slaAtRisk && (
+                            <span className="ml-1 w-4 h-4 rounded-full bg-red-500 text-white flex items-center justify-center text-[9px]">
+                                {filteredTickets.length}
+                            </span>
+                        )}
+                    </button>
+                </div>
+
+                {/* Tag Filter */}
+                <div>
+                    <TagFilter companyId={profile?.company_id} onFilterChange={setTagFilters} />
                 </div>
             </div>
 
-            {/* 3. Bulk Action Toolbar — appears when tickets selected */}
+            {/* 3. Bulk Action Toolbar — appears when 1+ tickets selected */}
             {selectedTickets.length > 0 && (
-                <div className="bg-indigo-600 text-white px-6 py-4 rounded-2xl flex items-center justify-between gap-4 shadow-lg shadow-indigo-500/20 animate-in fade-in duration-200">
-                    <span className="text-sm font-black uppercase tracking-widest">
-                        {selectedTickets.length} ticket{selectedTickets.length > 1 ? 's' : ''} selected
-                    </span>
-                    <div className="flex items-center gap-3">
-                        {/* Bulk Action Select */}
-                        <select
-                            value={bulkAction}
-                            onChange={(e) => { setBulkAction(e.target.value); setBulkValue(''); }}
-                            className="bg-indigo-500 text-white text-xs font-black uppercase tracking-widest rounded-xl px-3 py-2 border border-indigo-400 outline-none cursor-pointer"
-                        >
-                            <option value="">Select Action</option>
-                            <option value="close">Close Tickets</option>
-                            <option value="priority">Change Priority</option>
-                            <option value="assign">Assign Agent</option>
-                        </select>
-
-                        {/* Bulk Value Select */}
-                        {bulkAction === 'priority' && (
-                            <select value={bulkValue} onChange={(e) => setBulkValue(e.target.value)} className="bg-indigo-500 text-white text-xs font-black uppercase tracking-widest rounded-xl px-3 py-2 border border-indigo-400 outline-none">
-                                <option value="">Pick Priority</option>
-                                {priorities.filter(p => p !== 'All').map(p => <option key={p} value={p.toLowerCase()}>{p}</option>)}
-                            </select>
-                        )}
-                        {bulkAction === 'assign' && (
-                            <select value={bulkValue} onChange={(e) => setBulkValue(e.target.value)} className="bg-indigo-500 text-white text-xs font-black uppercase tracking-widest rounded-xl px-3 py-2 border border-indigo-400 outline-none">
-                                <option value="">Pick Agent</option>
-                                {agents.map(a => <option key={a.id} value={a.id}>{a.full_name}</option>)}
-                            </select>
-                        )}
-
-                        {/* Apply Button */}
-                        {bulkAction && (bulkAction === 'close' || bulkValue) && (
-                            <button onClick={() => setShowBulkConfirm(true)} className="bg-white text-indigo-600 text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2 hover:bg-indigo-50 transition-colors">
-                                Apply
-                            </button>
-                        )}
-
-                        {/* Clear Selection */}
-                        <button onClick={() => { setSelectedTickets([]); setBulkAction(''); setBulkValue(''); }} className="p-2 hover:bg-indigo-500 rounded-xl transition-colors">
-                            <X size={16} />
-                        </button>
-                    </div>
-                </div>
+                <BulkActionToolbar
+                    selectedCount={selectedTickets.length}
+                    bulkAction={bulkAction}
+                    setBulkAction={setBulkAction}
+                    bulkValue={bulkValue}
+                    setBulkValue={setBulkValue}
+                    agents={agents}
+                    priorities={priorities}
+                    onApply={() => setShowBulkConfirm(true)}
+                    onClear={handleBulkClear}
+                />
             )}
 
             {/* 4. Bulk Confirm Modal */}
             {showBulkConfirm && (
-                <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center">
-                    <div className="bg-white rounded-3xl p-8 max-w-sm w-full mx-4 shadow-2xl">
-                        <h3 className="text-lg font-black text-slate-900 uppercase italic tracking-tight">Confirm Bulk Action</h3>
-                        <p className="text-sm text-slate-500 mt-2">
-                            You are about to <strong>{bulkAction}</strong> {selectedTickets.length} ticket(s). This cannot be undone.
-                        </p>
-                        <div className="flex gap-3 mt-6">
-                            <button onClick={handleBulkExecute} className="flex-1 bg-indigo-600 text-white rounded-2xl py-3 text-xs font-black uppercase tracking-widest hover:bg-indigo-700 transition-colors">
-                                Confirm
-                            </button>
-                            <button onClick={() => setShowBulkConfirm(false)} className="flex-1 bg-slate-100 text-slate-600 rounded-2xl py-3 text-xs font-black uppercase tracking-widest hover:bg-slate-200 transition-colors">
-                                Cancel
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                <BulkConfirmModal
+                    action={bulkAction}
+                    count={selectedTickets.length}
+                    onConfirm={handleBulkExecute}
+                    onCancel={() => setShowBulkConfirm(false)}
+                    isExecuting={isBulkExecuting}
+                />
             )}
 
             {/* 5. High-Density Data Terminal */}
             <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]">
-                {loading && <TicketTableSkeleton rows={8} />}
-
-                {!loading && error && (
-                    <div className="p-12 text-center text-red-500 space-y-4">
-                        <AlertCircle className="mx-auto w-12 h-12" />
-                        <p className="font-bold uppercase tracking-widest text-xs">{error}</p>
-                        <button onClick={fetchTickets} className="px-6 py-2 bg-slate-900 text-white rounded-xl text-xs font-black uppercase tracking-widest">Retry</button>
+                {loading && (
+                    <div className="absolute inset-0 bg-white/60 backdrop-blur-[2px] z-10 flex items-center justify-center">
+                        <Loader2 className="w-10 h-10 text-emerald-600 animate-spin" />
                     </div>
                 )}
 
-                {!loading && (
-                <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden">
+                {error && (
+                    <div className="p-12 text-center text-red-500 space-y-4">
+                        <AlertCircle className="mx-auto w-12 h-12" />
+                        <p className="font-bold uppercase tracking-widest text-xs">{error}</p>
+                        <button onClick={fetchTickets} className="px-6 py-2 bg-slate-900 text-white rounded-xl text-[10px] font-black uppercase tracking-widest">Retry</button>
+                    </div>
+                )}
+
                 <div className="overflow-x-auto">
                     <table className="w-full border-collapse">
                         <thead>
                             <tr className="bg-slate-50/80 border-b border-slate-100">
                                 {/* Select All Checkbox */}
-                                <th className="px-4 py-5 text-center w-10">
-                                    <button onClick={handleSelectAll} className="text-slate-400 hover:text-indigo-600 transition-colors">
-                                        {selectedTickets.length === filteredTickets.length && filteredTickets.length > 0
-                                            ? <CheckSquare size={16} className="text-indigo-600" />
-                                            : <Square size={16} />
-                                        }
+                                <th className="px-4 py-5 text-center w-12">
+                                    <button
+                                        id="select-all-checkbox"
+                                        onClick={handleSelectAll}
+                                        className="text-slate-400 hover:text-indigo-600 transition-colors relative"
+                                        title={isAllSelected ? 'Deselect all' : 'Select all'}
+                                    >
+                                        {isAllSelected ? (
+                                            <CheckSquare size={18} className="text-indigo-600" />
+                                        ) : isSomeSelected ? (
+                                            <div className="relative">
+                                                <Square size={18} />
+                                                <div className="absolute inset-0 flex items-center justify-center">
+                                                    <div className="w-2 h-0.5 bg-indigo-500 rounded" />
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            <Square size={18} />
+                                        )}
                                     </button>
                                 </th>
                                 <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">
@@ -537,30 +667,40 @@ const AdminTickets = () => {
                                         <div className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse"></div>
                                     </div>
                                 </th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">User</th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">Subject</th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">Priority</th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">AI Score</th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">Agent</th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">Status</th>
-                                <th className="px-6 py-5 text-left text-xs font-black text-slate-400 uppercase tracking-widest">SLA</th>
-                                <th className="px-6 py-5 text-center text-xs font-black text-slate-400 uppercase tracking-widest">Actions</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">User</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Subject</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Priority</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">AI Score</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Agent</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Status</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">SLA</th>
+                                <th className="px-6 py-5 text-center text-[10px] font-black text-slate-400 uppercase tracking-widest">Actions</th>
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-slate-50">
-<<<<<<< HEAD
-                            {filteredTickets.map((ticket) => (
-                                <tr key={ticket.id} className={`hover:bg-slate-50/50 dark:hover:bg-slate-800/50 transition-colors group ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
-=======
                             {filteredTickets.map((ticket) => {
                                 const wasLiveChanged = String(lastChangedTicketId) === String(ticket.id);
                                 const isSelected = selectedTickets.includes(ticket.id);
+                                const slaState = (ticket.sla_status || '').toUpperCase();
+                                const slaRowClass =
+                                    slaState === 'BREACHED' ? 'bg-red-50/60 ring-1 ring-red-100' :
+                                    slaState === 'WARNING'  ? 'bg-amber-50/50 ring-1 ring-amber-100' : '';
 
                                 return (
-                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : ''} ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''} ${isSelected ? 'bg-indigo-50/50 ring-1 ring-indigo-100' : ''}`}>
+                                <tr
+                                    key={ticket.id}
+                                    className={`hover:bg-slate-50/50 transition-colors group ${
+                                        wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : slaRowClass
+                                    } ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''} ${
+                                        isSelected ? 'bg-indigo-50/40 ring-1 ring-indigo-100' : ''
+                                    }`}
+                                >
                                     {/* Row Checkbox */}
                                     <td className="px-4 py-6 text-center">
-                                        <button onClick={() => handleSelectTicket(ticket.id)} className="text-slate-300 hover:text-indigo-600 transition-colors">
+                                        <button
+                                            onClick={() => handleSelectTicket(ticket.id)}
+                                            className="text-slate-300 hover:text-indigo-600 transition-colors"
+                                        >
                                             {isSelected
                                                 ? <CheckSquare size={16} className="text-indigo-600" />
                                                 : <Square size={16} />
@@ -568,14 +708,6 @@ const AdminTickets = () => {
                                         </button>
                                     </td>
 
-                                const slaState = (ticket.sla_status || '').toUpperCase();
-                                const slaRowClass =
-                                    slaState === 'BREACHED' ? 'bg-red-50/60 ring-1 ring-red-100' :
-                                    slaState === 'WARNING'  ? 'bg-amber-50/50 ring-1 ring-amber-100' : '';
-
-                                return (
-                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : slaRowClass} ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
->>>>>>> upstream/gssoc
                                     {/* Ticket ID */}
                                     <td className="px-6 py-6">
                                         <span className="font-mono text-xs font-black text-emerald-600">#{formatTicketId(ticket.id)}</span>
@@ -585,15 +717,23 @@ const AdminTickets = () => {
                                     <td className="px-6 py-6">
                                         <div className="flex items-center gap-3">
                                             {ticket.creator?.profile_picture || ticket.profiles?.profile_picture ? (
-                                                <img src={ticket.creator?.profile_picture || ticket.profiles?.profile_picture} alt={ticket.creator?.full_name || ticket.profiles?.full_name || 'User'} className="w-8 h-8 rounded-lg object-cover border border-slate-100 shadow-sm" />
+                                                <img
+                                                    src={ticket.creator?.profile_picture || ticket.profiles?.profile_picture}
+                                                    alt={ticket.creator?.full_name || ticket.profiles?.full_name || 'User'}
+                                                    className="w-8 h-8 rounded-lg object-cover border border-slate-100 shadow-sm"
+                                                />
                                             ) : (
                                                 <div className="w-8 h-8 rounded-lg bg-emerald-50 text-emerald-600 flex items-center justify-center font-bold text-xs border border-emerald-100/50">
                                                     {(ticket.creator?.full_name || ticket.profiles?.full_name || 'System').charAt(0).toUpperCase()}
                                                 </div>
                                             )}
                                             <div className="flex flex-col">
-                                                <span className="text-xs font-black text-slate-800 tracking-tight italic uppercase truncate max-w-[120px]">{ticket.creator?.full_name || ticket.profiles?.full_name || 'System'}</span>
-                                                <span className="text-[10px] font-bold text-slate-400 lowercase truncate max-w-[120px]">{ticket.creator?.email || ticket.profiles?.email || '—'}</span>
+                                                <span className="text-xs font-black text-slate-800 tracking-tight italic uppercase truncate max-w-[120px]">
+                                                    {ticket.creator?.full_name || ticket.profiles?.full_name || 'System'}
+                                                </span>
+                                                <span className="text-[10px] font-bold text-slate-400 lowercase truncate max-w-[120px]">
+                                                    {ticket.creator?.email || ticket.profiles?.email || '—'}
+                                                </span>
                                             </div>
                                         </div>
                                     </td>
@@ -601,15 +741,14 @@ const AdminTickets = () => {
                                     {/* Subject */}
                                     <td className="px-6 py-6">
                                         <div className="flex flex-col">
-                                            <span className="text-xs font-bold text-slate-700 truncate max-w-[200px]" title={ticket.summary || ticket.subject}>{ticket.summary || ticket.subject}</span>
                                             <div className="flex items-center gap-2">
                                                 <span className="text-xs font-bold text-slate-700 truncate max-w-[200px]" title={ticket.summary || ticket.subject}>
                                                     {ticket.summary || ticket.subject}
                                                 </span>
                                                 {ticket.metadata?.spam_analysis?.is_spam && (
                                                     <span className={`px-2 py-0.5 rounded text-[8px] font-black uppercase tracking-wider flex items-center gap-1 ${
-                                                        ticket.metadata.spam_analysis.risk_level === 'high' 
-                                                            ? 'bg-red-100 text-red-700 border border-red-200' 
+                                                        ticket.metadata.spam_analysis.risk_level === 'high'
+                                                            ? 'bg-red-100 text-red-700 border border-red-200'
                                                             : 'bg-amber-100 text-amber-700 border border-amber-200'
                                                     }`}>
                                                         <ShieldAlert size={10} />
@@ -621,61 +760,85 @@ const AdminTickets = () => {
                                                 {ticket.category}
                                                 <span className="text-[9px] font-medium text-slate-300">• {formatTimelineDate(ticket.created_at)}</span>
                                             </span>
-                                            {ticket?.metadata?.translation?.translated && (
-                                                <span className="text-[10px] text-sky-700 mt-1">Translated from {ticket.metadata.translation.source_language_name || ticket.metadata.translation.source_language || 'Unknown'}</span>
-                                            )}
                                             <LanguageBadge detectedLanguage={ticket?.detected_language} compact />
                                         </div>
                                     </td>
 
-                                    {/* Priority */}
+                                    {/* Priority (Editable) */}
                                     <td className="px-6 py-6">
-                                        <select value={String(ticket.priority || 'medium').toLowerCase()} onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })} className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}>
-                                            {priorities.filter(p => p !== 'All').map(p => <option key={p} value={p.toLowerCase()}>{p}</option>)}
+                                        <select
+                                            value={String(ticket.priority || 'medium').toLowerCase()}
+                                            onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })}
+                                            className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}
+                                        >
+                                            {priorities.filter(p => p !== 'All').map(p => (
+                                                <option key={p} value={p.toLowerCase()}>{p}</option>
+                                            ))}
                                         </select>
                                     </td>
 
-                                    {/* AI Score */}
+                                    {/* AI Score (Confidence) */}
                                     <td className="px-6 py-6">
                                         <div className="flex items-center gap-2">
-                                            <div className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-[8px] font-black ${ticket.confidence >= 0.8 ? 'border-emerald-500 text-emerald-600 bg-emerald-50' : ticket.confidence >= 0.5 ? 'border-amber-500 text-amber-600 bg-amber-50' : 'border-red-500 text-red-600 bg-red-50'}`}>
+                                            <div className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-[8px] font-black
+                                                ${ticket.confidence >= 0.8 ? 'border-emerald-500 text-emerald-600 bg-emerald-50' :
+                                                  ticket.confidence >= 0.5 ? 'border-amber-500 text-amber-600 bg-amber-50' :
+                                                  'border-red-500 text-red-600 bg-red-50'}`}>
                                                 {(ticket.confidence * 100).toFixed(0)}%
                                             </div>
                                             <div className="flex flex-col">
                                                 <span className="text-[8px] font-black text-slate-400 uppercase">Confidence</span>
                                                 <div className="w-12 h-1 bg-slate-100 rounded-full overflow-hidden mt-0.5">
-                                                    <div className={`h-full ${getConfidenceColor(ticket.confidence || 0)}`} style={{ width: `${(ticket.confidence || 0) * 100}%` }} />
+                                                    <div
+                                                        className={`h-full ${getConfidenceColor(ticket.confidence || 0)}`}
+                                                        style={{ width: `${(ticket.confidence || 0) * 100}%` }}
+                                                    />
                                                 </div>
                                             </div>
                                         </div>
                                     </td>
 
-                                    {/* Agent */}
-                                    <td className="px-6 py-6 text-emerald-600 font-bold text-[10px]">{ticket.assigned_team || 'General'}</td>
+                                    {/* Assigned Team */}
+                                    <td className="px-6 py-6 text-emerald-600 font-bold text-[10px]">
+                                        {ticket.assigned_team || 'General'}
+                                    </td>
 
-                                    {/* Assignee */}
+                                    {/* Agent Assignee (Editable) */}
                                     <td className="px-6 py-6">
                                         <div className="flex flex-col gap-1 min-w-[120px]">
                                             {ticket.assigned_agent_id ? (
-                                                <select value={ticket.assigned_agent_id} onChange={(e) => handleUpdateTicket(ticket.id, { assigned_agent_id: e.target.value, status: 'in progress' })} className="bg-transparent text-[10px] font-black text-indigo-600 uppercase tracking-tight italic border-none focus:ring-0 cursor-pointer hover:underline">
-                                                    {agents.map(a => <option key={a.id} value={a.id}>{a.full_name}</option>)}
+                                                <select
+                                                    value={ticket.assigned_agent_id}
+                                                    onChange={(e) => handleUpdateTicket(ticket.id, {
+                                                        assigned_agent_id: e.target.value,
+                                                        status: 'in progress'
+                                                    })}
+                                                    className="bg-transparent text-[10px] font-black text-indigo-600 uppercase tracking-tight italic border-none focus:ring-0 cursor-pointer hover:underline"
+                                                >
+                                                    {agents.map(a => (
+                                                        <option key={a.id} value={a.id}>{a.full_name}</option>
+                                                    ))}
                                                 </select>
                                             ) : (
-                                                <button onClick={() => handleUpdateTicket(ticket.id, { assigned_agent_id: user.id, status: 'in progress' })} className="px-3 py-1 bg-indigo-50 text-indigo-600 rounded-lg text-[9px] font-black uppercase tracking-widest border border-indigo-100 hover:bg-indigo-600 hover:text-white transition-all shadow-sm">
+                                                <button
+                                                    onClick={() => handleUpdateTicket(ticket.id, {
+                                                        assigned_agent_id: user.id,
+                                                        status: 'in progress'
+                                                    })}
+                                                    className="px-3 py-1 bg-indigo-50 text-indigo-600 rounded-lg text-[9px] font-black uppercase tracking-widest border border-indigo-100 hover:bg-indigo-600 hover:text-white transition-all shadow-sm"
+                                                >
                                                     Claim
                                                 </button>
                                             )}
                                         </div>
                                     </td>
 
-                                    {/* Status */}
+                                    {/* Status (Editable) */}
                                     <td className="px-6 py-6">
                                         <div className="flex items-center gap-2">
-                                            <div className={`w-1.5 h-1.5 rounded-full ${ticket.status?.toLowerCase() === 'resolved' || ticket.status?.toLowerCase() === 'closed' ? 'bg-emerald-400' : 'bg-amber-500 animate-pulse'}`}></div>
-                                            <Select value={String(ticket.status || 'open').toLowerCase()} onChange={(e) => handleUpdateTicket(ticket.id, { status: e.target.value })} buttonClassName="bg-transparent text-[10px] font-black text-slate-600 uppercase tracking-widest outline-none cursor-pointer flex justify-between items-center w-full" options={statuses.filter(s => s !== 'All').map(s => ({ value: s.toLowerCase(), label: s }))} />
                                             <div className={`w-1.5 h-1.5 rounded-full ${
-                                                ticket.status?.toLowerCase() === 'resolved' || ticket.status?.toLowerCase() === 'closed' 
-                                                    ? 'bg-emerald-400' 
+                                                ticket.status?.toLowerCase() === 'resolved' || ticket.status?.toLowerCase() === 'closed'
+                                                    ? 'bg-emerald-400'
                                                     : ticket.status?.toLowerCase() === 'spam'
                                                         ? 'bg-slate-400 border border-slate-500'
                                                         : 'bg-amber-500 animate-pulse'
@@ -683,7 +846,7 @@ const AdminTickets = () => {
                                             <Select
                                                 value={String(ticket.status || 'open').toLowerCase()}
                                                 onChange={(e) => handleUpdateTicket(ticket.id, { status: e.target.value })}
-                                                buttonClassName="bg-transparent text-xs font-black text-slate-600 uppercase tracking-widest outline-none cursor-pointer flex justify-between items-center w-full"
+                                                buttonClassName="bg-transparent text-[10px] font-black text-slate-600 uppercase tracking-widest outline-none cursor-pointer flex justify-between items-center w-full"
                                                 options={statuses.filter(s => s !== 'All').map(s => ({ value: s.toLowerCase(), label: s }))}
                                             />
                                         </div>
@@ -691,24 +854,31 @@ const AdminTickets = () => {
 
                                     {/* SLA Badge */}
                                     <td className="px-6 py-6">
-                                        <SLABadge priority={ticket.priority} createdAt={ticket.created_at} slaBreachAt={ticket.sla_breach_at} slaStatus={ticket.sla_status} status={ticket.status} />
                                         <SLABadge
                                             priority={ticket.priority}
                                             createdAt={ticket.created_at}
+                                            slaBreachAt={ticket.sla_breach_at}
+                                            slaStatus={ticket.sla_status}
                                             status={ticket.status}
+                                            ticketId={ticket.id}
                                         />
                                     </td>
 
-                                    {/* Actions */}
+                                    {/* Action: Open Ticket */}
                                     <td className="px-6 py-6 text-center">
                                         <div className="flex items-center justify-center gap-2">
-                                            <button onClick={() => navigate(`/admin/ticket/${ticket.id}`)} className="p-2 bg-slate-900 text-white rounded-xl hover:bg-emerald-600 transition-all shadow-lg shadow-slate-900/10 hover:shadow-emerald-500/20" title="Open Detailed View">
+                                            <button
+                                                onClick={() => navigate(`/admin/ticket/${ticket.id}`)}
+                                                className="p-2 bg-slate-900 text-white rounded-xl hover:bg-emerald-600 transition-all shadow-lg shadow-slate-900/10 hover:shadow-emerald-500/20"
+                                                title="Open Detailed View"
+                                            >
                                                 <ArrowUpRight size={14} />
                                             </button>
                                         </div>
                                     </td>
                                 </tr>
-                            ))}
+                                );
+                            })}
                         </tbody>
                     </table>
                 </div>
@@ -722,359 +892,9 @@ const AdminTickets = () => {
                         <p className="text-sm text-slate-500 font-medium max-w-xs mx-auto mt-2 italic">Refine your search parameters to view more data points.</p>
                     </div>
                 )}
-                </div>
-                )}
             </div>
         </div>
     );
-  }, [tickets, searchQuery]);
-
-  const getPriorityStyle = (priority) => {
-    const p = String(priority || '').toLowerCase();
-    if (p === 'high' || p === 'critical') return 'text-red-600 bg-red-50 border-red-100';
-    if (p === 'medium') return 'text-amber-600 bg-amber-50 border-amber-100';
-    if (p === 'low') return 'text-emerald-600 bg-emerald-50 border-emerald-100';
-    return 'text-slate-500 bg-slate-50 border-slate-100'; // Default
-  };
-
-  const getConfidenceColor = (conf) => {
-    if (conf >= 0.8) return 'bg-emerald-500';
-    if (conf >= 0.5) return 'bg-amber-500';
-    return 'bg-red-500';
-  };
-
-  return (
-    <div className='space-y-8 animate-in fade-in duration-700'>
-      {/* 1. Header & Utility Bar */}
-      <div className='flex flex-col md:flex-row md:items-end justify-between gap-6'>
-        <div>
-          <h1 className='text-3xl font-black text-slate-900 tracking-tight italic uppercase'>
-            Ticket Management
-          </h1>
-          <p className='text-sm font-bold text-slate-400 mt-1 flex items-center gap-2'>
-            <Activity size={14} className='text-indigo-500' /> {filteredTickets.length} tickets
-            matching current filters.
-          </p>
-        </div>
-      </div>
-
-      {/* 2. Advanced Filtering Station */}
-      <div className='bg-white p-6 rounded-[2rem] border border-slate-200 shadow-xl shadow-slate-200/50 space-y-6'>
-        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4'>
-          {/* Search Field */}
-          <div className='relative group lg:col-span-1'>
-            <Search className='absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 group-focus-within:text-emerald-500 transition-colors w-5 h-5' />
-            <input
-              type='text'
-              placeholder='Search...'
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className='w-full bg-slate-50 border border-slate-200 rounded-2xl pl-12 pr-4 py-3 text-sm font-bold focus:outline-none focus:ring-4 focus:ring-emerald-500/5 focus:border-emerald-500 focus:bg-white transition-all text-slate-700 placeholder:text-slate-400'
-            />
-          </div>
-
-          {/* Status Filter */}
-          <Select
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value)}
-            buttonClassName='w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center'
-            options={statuses.map((s) => ({ value: s, label: s === 'All' ? 'All Statuses' : s }))}
-          />
-
-          {/* Category Filter */}
-          <Select
-            value={categoryFilter}
-            onChange={(e) => setCategoryFilter(e.target.value)}
-            buttonClassName='w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center'
-            options={categories.map((c) => ({
-              value: c,
-              label: c === 'All' ? 'All Categories' : c,
-            }))}
-          />
-
-          {/* Priority Filter */}
-          <Select
-            value={priorityFilter}
-            onChange={(e) => setPriorityFilter(e.target.value)}
-            buttonClassName='w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center'
-            options={priorities.map((p) => ({
-              value: p,
-              label: p === 'All' ? 'All Priorities' : p,
-            }))}
-          />
-
-          {/* Team Filter */}
-          <Select
-            value={teamFilter}
-            onChange={(e) => setTeamFilter(e.target.value)}
-            buttonClassName='w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center'
-            options={teams.map((t) => ({ value: t, label: t === 'All' ? 'All Teams' : t }))}
-          />
-        </div>
-      </div>
-
-      {/* 3. High-Density Data Terminal */}
-      <div className='bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]'>
-        {loading && (
-          <div className='absolute inset-0 bg-white/60 backdrop-blur-[2px] z-10 flex items-center justify-center'>
-            <Loader2 className='w-10 h-10 text-emerald-600 animate-spin' />
-          </div>
-        )}
-
-        {error && (
-          <div className='p-12 text-center text-red-500 space-y-4'>
-            <AlertCircle className='mx-auto w-12 h-12' />
-            <p className='font-bold uppercase tracking-widest text-xs'>{error}</p>
-            <button
-              onClick={fetchTickets}
-              className='px-6 py-2 bg-slate-900 text-white rounded-xl text-[10px] font-black uppercase tracking-widest'
-            >
-              Retry
-            </button>
-          </div>
-        )}
-
-        <div className='overflow-x-auto'>
-          <table className='w-full border-collapse'>
-            <thead>
-              <tr className='bg-slate-50/80 border-b border-slate-100'>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  <div className='flex items-center gap-2'>
-                    ID
-                    <div className='w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse'></div>
-                  </div>
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  User
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  Subject
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  Priority
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  AI Score
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  Agent
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  Status
-                </th>
-                <th className='px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  SLA
-                </th>
-                <th className='px-6 py-5 text-center text-[10px] font-black text-slate-400 uppercase tracking-widest'>
-                  Actions
-                </th>
-              </tr>
-            </thead>
-            <tbody className='divide-y divide-slate-50'>
-              {filteredTickets.map((ticket) => (
-                <tr
-                  key={ticket.id}
-                  className={`hover:bg-slate-50/50 transition-colors group ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}
-                >
-                  {/* Ticket ID */}
-                  <td className='px-6 py-6'>
-                    <span className='font-mono text-xs font-black text-emerald-600'>
-                      #{formatTicketId(ticket.id)}
-                    </span>
-                  </td>
-
-                  {/* User (Joined with Profiles) */}
-                  <td className='px-6 py-6'>
-                    <div className='flex items-center gap-3'>
-                      {ticket.creator?.profile_picture || ticket.profiles?.profile_picture ? (
-                        <img
-                          src={ticket.creator?.profile_picture || ticket.profiles?.profile_picture}
-                          alt={ticket.creator?.full_name || ticket.profiles?.full_name || 'User'}
-                          className='w-8 h-8 rounded-lg object-cover border border-slate-100 shadow-sm'
-                        />
-                      ) : (
-                        <div className='w-8 h-8 rounded-lg bg-emerald-50 text-emerald-600 flex items-center justify-center font-bold text-xs border border-emerald-100/50'>
-                          {(ticket.creator?.full_name || ticket.profiles?.full_name || 'System')
-                            .charAt(0)
-                            .toUpperCase()}
-                        </div>
-                      )}
-                      <div className='flex flex-col'>
-                        <span className='text-xs font-black text-slate-800 tracking-tight italic uppercase truncate max-w-[120px]'>
-                          {ticket.creator?.full_name || ticket.profiles?.full_name || 'System'}
-                        </span>
-                        <span className='text-[10px] font-bold text-slate-400 lowercase truncate max-w-[120px]'>
-                          {ticket.creator?.email || ticket.profiles?.email || '—'}
-                        </span>
-                      </div>
-                    </div>
-                  </td>
-
-                  {/* Subject */}
-                  <td className='px-6 py-6'>
-                    <div className='flex flex-col'>
-                      <span
-                        className='text-xs font-bold text-slate-700 truncate max-w-[200px]'
-                        title={ticket.summary || ticket.subject}
-                      >
-                        {ticket.summary || ticket.subject}
-                      </span>
-                      <span className='text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-2'>
-                        {ticket.category}
-                        <span className='text-[9px] font-medium text-slate-300'>
-                          • {formatTimelineDate(ticket.created_at)}
-                        </span>
-                      </span>
-                    </div>
-                  </td>
-
-                  {/* Priority (Editable) */}
-                  <td className='px-6 py-6'>
-                    <select
-                      value={String(ticket.priority || 'medium').toLowerCase()}
-                      onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })}
-                      className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}
-                    >
-                      {priorities
-                        .filter((p) => p !== 'All')
-                        .map((p) => (
-                          <option key={p} value={p.toLowerCase()}>
-                            {p}
-                          </option>
-                        ))}
-                    </select>
-                  </td>
-
-                  {/* AI Score (Confidence) */}
-                  <td className='px-6 py-6'>
-                    <div className='flex items-center gap-2'>
-                      <div
-                        className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-[8px] font-black
-                                                ${
-                                                  ticket.confidence >= 0.8
-                                                    ? 'border-emerald-500 text-emerald-600 bg-emerald-50'
-                                                    : ticket.confidence >= 0.5
-                                                      ? 'border-amber-500 text-amber-600 bg-amber-50'
-                                                      : 'border-red-500 text-red-600 bg-red-50'
-                                                }`}
-                      >
-                        {(ticket.confidence * 100).toFixed(0)}%
-                      </div>
-                      <div className='flex flex-col'>
-                        <span className='text-[8px] font-black text-slate-400 uppercase'>
-                          Confidence
-                        </span>
-                        <div className='w-12 h-1 bg-slate-100 rounded-full overflow-hidden mt-0.5'>
-                          <div
-                            className={`h-full ${getConfidenceColor(ticket.confidence || 0)}`}
-                            style={{ width: `${(ticket.confidence || 0) * 100}%` }}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </td>
-
-                  {/* Assigned Team (Editable) */}
-                  <td className='px-6 py-6 text-emerald-600 font-bold text-[10px]'>
-                    {ticket.assigned_team || 'General'}
-                  </td>
-
-                  {/* Agent Assignee (Editable) */}
-                  <td className='px-6 py-6'>
-                    <div className='flex flex-col gap-1 min-w-[120px]'>
-                      {ticket.assigned_agent_id ? (
-                        <select
-                          value={ticket.assigned_agent_id}
-                          onChange={(e) =>
-                            handleUpdateTicket(ticket.id, {
-                              assigned_agent_id: e.target.value,
-                              status: 'in progress',
-                            })
-                          }
-                          className='bg-transparent text-[10px] font-black text-indigo-600 uppercase tracking-tight italic border-none focus:ring-0 cursor-pointer hover:underline'
-                        >
-                          {agents.map((a) => (
-                            <option key={a.id} value={a.id}>
-                              {a.full_name}
-                            </option>
-                          ))}
-                        </select>
-                      ) : (
-                        <button
-                          onClick={() =>
-                            handleUpdateTicket(ticket.id, {
-                              assigned_agent_id: user.id,
-                              status: 'in progress',
-                            })
-                          }
-                          className='px-3 py-1 bg-indigo-50 text-indigo-600 rounded-lg text-[9px] font-black uppercase tracking-widest border border-indigo-100 hover:bg-indigo-600 hover:text-white transition-all shadow-sm'
-                        >
-                          Claim
-                        </button>
-                      )}
-                    </div>
-                  </td>
-
-                  {/* Status (Editable) */}
-                  <td className='px-6 py-6'>
-                    <div className='flex items-center gap-2'>
-                      <div
-                        className={`w-1.5 h-1.5 rounded-full ${ticket.status?.toLowerCase() === 'resolved' || ticket.status?.toLowerCase() === 'closed' ? 'bg-emerald-400' : 'bg-amber-500 animate-pulse'}`}
-                      ></div>
-                      <Select
-                        value={String(ticket.status || 'open').toLowerCase()}
-                        onChange={(e) => handleUpdateTicket(ticket.id, { status: e.target.value })}
-                        buttonClassName='bg-transparent text-[10px] font-black text-slate-600 uppercase tracking-widest outline-none cursor-pointer flex justify-between items-center w-full'
-                        options={statuses
-                          .filter((s) => s !== 'All')
-                          .map((s) => ({ value: s.toLowerCase(), label: s }))}
-                      />
-                    </div>
-                  </td>
-
-                  {/* SLA Badge */}
-                  <td className='px-6 py-6'>
-                    <SLABadge
-                      priority={ticket.priority}
-                      createdAt={ticket.created_at}
-                      status={ticket.status}
-                    />
-                  </td>
-
-                  {/* Action: Open Ticket */}
-                  <td className='px-6 py-6 text-center'>
-                    <div className='flex items-center justify-center gap-2'>
-                      <button
-                        onClick={() => navigate(`/admin/ticket/${ticket.id}`)}
-                        className='p-2 bg-slate-900 text-white rounded-xl hover:bg-emerald-600 transition-all shadow-lg shadow-slate-900/10 hover:shadow-emerald-500/20'
-                        title='Open Detailed View'
-                      >
-                        <ArrowUpRight size={14} />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        {!loading && filteredTickets.length === 0 && (
-          <div className='py-32 text-center bg-slate-50/30 w-full flex flex-col items-center'>
-            <div className='w-20 h-20 bg-white border border-slate-100 rounded-[2rem] flex items-center justify-center text-slate-200 mb-6 shadow-sm'>
-              <Inbox size={40} />
-            </div>
-            <h3 className='text-xl font-black text-slate-900 uppercase italic tracking-tight'>
-              No Incidents Found
-            </h3>
-            <p className='text-sm text-slate-500 font-medium max-w-xs mx-auto mt-2 italic'>
-              Refine your search parameters to view more data points.
-            </p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
 };
 
 export default AdminTickets;


### PR DESCRIPTION
## Problem
Admins can only perform actions (assign, close, change priority) on **one ticket at a time**. When handling 50+ tickets after a system outage, this becomes extremely slow and tedious.

## Proposed Solution
### Checkbox Selection
- ✅ Checkbox on each ticket row in the list view
- ✅ **Select All** checkbox in table header (with indeterminate state for partial selection)

### Bulk Action Toolbar
A gradient toolbar appears when 1+ tickets are selected, offering:
- **Bulk Assign** — select agent from dropdown
- **Bulk Close** — close all selected tickets
- **Bulk Change Priority** — pick new priority level

### Safety & Feedback
- ✅ Confirmation modal before executing any bulk action
- ✅ Loading spinner during execution (prevents double-clicks)
- ✅ Toast notification showing how many tickets were updated
- ✅ Auto-clear selection when filters change (prevents stale IDs)

## Tech Stack
React 19, Tailwind CSS, Supabase \.in()\ batch updates

#1134 