### PR TITLE
fix(backend): make FRONTEND_BASE_URL configurable in webhook_service

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -98,6 +98,8 @@ except Exception as e:
 
 # Ensure project root is on path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "https://helpdeskaiv1.vercel.app").rstrip("/")
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 from backend.auth.tenant_middleware import security_manager
@@ -1308,7 +1310,7 @@ async def root():
                 </a>
                 
                 <!-- Frontend Button -->
-                <a href="https://helpdeskaiv1.vercel.app/" target="_blank" class="btn-hover block w-full bg-slate-800/80 border border-slate-700 hover:border-blue-500/50 hover:bg-slate-700/80 rounded-xl p-5 group">
+                <a href="{FRONTEND_BASE_URL}/" target="_blank" class="btn-hover block w-full bg-slate-800/80 border border-slate-700 hover:border-blue-500/50 hover:bg-slate-700/80 rounded-xl p-5 group">
                     <h3 class="font-bold text-white mb-1 group-hover:text-blue-400 transition-colors">Client Web Portal</h3>
                     <p class="text-slate-400 text-sm text-center md:text-left">Access the React/Vite dashboard</p>
                 </a>
@@ -1884,12 +1886,12 @@ def trigger_webhook_for_new_ticket(company_id: str, ticket: dict) -> None:
             assigned_team = ticket.get("assigned_team") or "Unassigned"
             
             payload = {
-                "text": f"🚨 *New {priority.upper()} Ticket Alert*: {ticket_ref} - {subject}\nPriority: {priority.upper()}\nLink: https://helpdeskaiv1.vercel.app/tickets/{ticket_id}",
+                "text": f"🚨 *New {priority.upper()} Ticket Alert*: {ticket_ref} - {subject}\nPriority: {priority.upper()}\nLink: {FRONTEND_BASE_URL}/tickets/{ticket_id}",
                 "attachments": [
                     {
                         "color": "#FF0000" if priority == "critical" else "#FFA500",
                         "title": f"New Ticket: {ticket_ref}",
-                        "title_link": f"https://helpdeskaiv1.vercel.app/tickets/{ticket_id}",
+                        "title_link": f"{FRONTEND_BASE_URL}/tickets/{ticket_id}",
                         "fields": [
                             {"title": "Subject", "value": subject, "short": True},
                             {"title": "Priority", "value": priority.upper(), "short": True},

--- a/backend/services/digest_service.py
+++ b/backend/services/digest_service.py
@@ -379,6 +379,7 @@ def send_digest_email(admin_email: str, stats: dict, ai_summary: str) -> bool:
 
     # Load template and substitute values
     template_str = _load_email_template()
+    frontend_base_url = os.environ.get("FRONTEND_BASE_URL", "https://helpdeskaiv1.vercel.app").rstrip("/")
 
     # Use string.Template for safe substitution ($-based)
     tmpl = Template(template_str)
@@ -397,6 +398,7 @@ def send_digest_email(admin_email: str, stats: dict, ai_summary: str) -> bool:
         resolved_tickets=stats.get("resolved_tickets", 0),
         category_list_html=category_list_html,
         team_performance_html=team_performance_html,
+        frontend_base_url=frontend_base_url,
     )
 
     # Dispatch via Resend API POST

--- a/backend/services/sla_engine.py
+++ b/backend/services/sla_engine.py
@@ -19,6 +19,8 @@ from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "https://helpdeskaiv1.vercel.app").rstrip("/")
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -369,7 +371,7 @@ class SLAEngine:
             "status": result["sla_status"],
             "escalation_level": result["escalation_level"],
             "remaining_seconds": result["remaining_seconds"],
-            "ticket_url": f"https://helpdeskaiv1.vercel.app/admin/ticket/{ticket['id']}",
+            "ticket_url": f"{FRONTEND_BASE_URL}/admin/ticket/{ticket['id']}",
             "assigned_team": ticket.get("assigned_team", "Unassigned"),
             "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
         }

--- a/backend/services/webhook_service.py
+++ b/backend/services/webhook_service.py
@@ -1,1 +1,193 @@
-@backend/services/webhook_service.py
+"""
+Generic Webhook Service for Slack & Microsoft Teams.
+Handles storing webhook URLs in Supabase and sending notifications.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+FRONTEND_BASE_URL = os.environ.get("FRONTEND_BASE_URL", "https://helpdeskaiv1.vercel.app").rstrip("/")
+
+
+def build_slack_payload(ticket: dict[str, Any]) -> dict:
+    ticket_id = str(ticket.get("id", "???"))
+    ticket_ref = f"#T-{ticket_id[-4:]}" if len(ticket_id) >= 4 else f"#T-{ticket_id}"
+    subject = ticket.get("subject") or "Untitled ticket"
+    priority = str(ticket.get("priority") or "unknown").upper()
+    assigned_team = ticket.get("assigned_team") or "Unassigned"
+    company = ticket.get("company") or ticket.get("company_id") or "UNKNOWN"
+    breach_at = ticket.get("sla_breach_at") or "N/A"
+    color = "#FF0000" if priority in ("CRITICAL", "HIGH") else "#FFA500"
+
+    return {
+        "attachments": [
+            {
+                "color": color,
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": f"🚨 Critical Ticket Alert: {ticket_ref}",
+                            "emoji": True,
+                        },
+                    },
+                    {
+                        "type": "section",
+                        "fields": [
+                            {"type": "mrkdwn", "text": f"*Ticket:*\n<{FRONTEND_BASE_URL}/tickets/{ticket_id}|{ticket_ref}>"},
+                            {"type": "mrkdwn", "text": f"*Priority:*\n{priority}"},
+                            {"type": "mrkdwn", "text": f"*Subject:*\n{subject}"},
+                            {"type": "mrkdwn", "text": f"*Assigned Team:*\n{assigned_team}"},
+                            {"type": "mrkdwn", "text": f"*Company:*\n{company}"},
+                            {"type": "mrkdwn", "text": f"*Breach Time:*\n{breach_at}"},
+                        ],
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "🔔 *Action required* — This ticket requires immediate attention.",
+                            }
+                        ],
+                    },
+                    {"type": "divider"},
+                ],
+            }
+        ]
+    }
+
+
+def build_teams_payload(ticket: dict[str, Any]) -> dict:
+    ticket_id = str(ticket.get("id", "???"))
+    ticket_ref = f"#T-{ticket_id[-4:]}" if len(ticket_id) >= 4 else f"#T-{ticket_id}"
+    subject = ticket.get("subject") or "Untitled ticket"
+    priority = str(ticket.get("priority") or "unknown").upper()
+    assigned_team = ticket.get("assigned_team") or "Unassigned"
+    company = ticket.get("company") or ticket.get("company_id") or "UNKNOWN"
+    breach_at = ticket.get("sla_breach_at") or "N/A"
+    color = "FF0000" if priority in ("CRITICAL", "HIGH") else "FFA500"
+
+    return {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "themeColor": color,
+        "summary": f"Critical Ticket Alert: {ticket_ref}",
+        "sections": [
+            {
+                "activityTitle": f"🚨 Critical Ticket Alert: {ticket_ref}",
+                "activitySubtitle": subject,
+                "facts": [
+                    {"name": "Priority", "value": priority},
+                    {"name": "Assigned Team", "value": assigned_team},
+                    {"name": "Company", "value": company},
+                    {"name": "Breach Time", "value": breach_at},
+                ],
+                "markdown": True,
+            }
+        ],
+        "potentialAction": [
+            {
+                "@type": "OpenUri",
+                "name": "View Ticket",
+                "targets": [
+                    {
+                        "os": "default",
+                        "uri": f"{FRONTEND_BASE_URL}/tickets/{ticket_id}",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def detect_webhook_type(url: str) -> str:
+    """Detect if URL is for Slack or Teams."""
+    if "hooks.slack.com" in url:
+        return "slack"
+    elif "webhook.office.com" in url or "outlook.office.com" in url:
+        return "teams"
+    return "slack"  # default
+
+
+def send_webhook_notification(webhook_url: str, ticket: dict[str, Any]) -> bool:
+    """
+    Send notification to Slack or Teams based on webhook URL.
+
+    Args:
+        webhook_url: The webhook URL (Slack or Teams)
+        ticket: Ticket details dict
+
+    Returns:
+        True if sent successfully, False otherwise.
+    """
+    if not webhook_url:
+        logger.debug("Webhook notification skipped: no URL provided")
+        return False
+
+    webhook_type = detect_webhook_type(webhook_url)
+
+    if webhook_type == "teams":
+        payload = build_teams_payload(ticket)
+    else:
+        payload = build_slack_payload(ticket)
+
+    data = json.dumps(payload).encode("utf-8")
+    req = Request(
+        webhook_url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urlopen(req, timeout=10) as resp:
+            logger.info(
+                "Webhook alert sent (%s) for ticket %s (HTTP %s)",
+                webhook_type,
+                ticket.get("id"),
+                resp.status,
+            )
+            return True
+    except HTTPError as e:
+        logger.error("Webhook HTTP error %s: %s", e.code, e.reason)
+    except URLError as e:
+        logger.error("Webhook connection error: %s", e.reason)
+    except OSError as e:
+        logger.error("Webhook OS error: %s", e)
+
+    return False
+
+
+def notify_critical_ticket(ticket: dict[str, Any], webhook_url: Optional[str] = None) -> bool:
+    """
+    Entry point for critical ticket notifications.
+    Uses provided webhook_url or falls back to env variable.
+
+    Args:
+        ticket: Ticket details dict
+        webhook_url: Optional override webhook URL (from Supabase/settings)
+
+    Returns:
+        True if notification sent successfully.
+    """
+    url = webhook_url or os.environ.get("SLACK_WEBHOOK_URL", "").strip() or None
+
+    if not url:
+        logger.info("No webhook URL configured — notification skipped")
+        return False
+
+    sent = send_webhook_notification(url, ticket)
+    if sent:
+        logger.info("Critical ticket notified for ticket %s", ticket.get("id"))
+    else:
+        logger.warning("Webhook notification failed for ticket %s", ticket.get("id"))
+
+    return sent

--- a/backend/templates/weekly_digest.html
+++ b/backend/templates/weekly_digest.html
@@ -100,14 +100,14 @@
 
       <!-- CTA -->
       <div style="text-align: center; margin-top: 24px;">
-        <a href="https://helpdeskaiv1.vercel.app/" class="btn">Launch Admin Dashboard</a>
+        <a href="${frontend_base_url}/" class="btn">Launch Admin Dashboard</a>
       </div>
     </div>
 
     <!-- Footer -->
     <div class="footer">
       <p>This email was automatically generated and sent to you because you are a company administrator for ${company_name}.</p>
-      <p>To opt-out, update your <a href="https://helpdeskaiv1.vercel.app/admin-settings">Admin Settings</a>.</p>
+      <p>To opt-out, update your <a href="${frontend_base_url}/admin-settings">Admin Settings</a>.</p>
     </div>
   </div>
 </body>

--- a/backend/tests/test_webhook_service.py
+++ b/backend/tests/test_webhook_service.py
@@ -1,1 +1,312 @@
-@backend/tests/test_webhook_service.py
+"""
+Unit tests for webhook_service.py
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from backend.services.webhook_service import (
+    build_slack_payload,
+    build_teams_payload,
+    detect_webhook_type,
+    send_webhook_notification,
+    notify_critical_ticket,
+)
+
+
+class TestBuildSlackPayload:
+    def test_build_slack_payload_critical_priority(self):
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Server down",
+            "priority": "critical",
+            "assigned_team": "Ops",
+            "company": "ACME Corp",
+            "sla_breach_at": "2026-05-30T15:00:00Z",
+        }
+        payload = build_slack_payload(ticket)
+
+        assert "attachments" in payload
+        assert len(payload["attachments"]) == 1
+        attachment = payload["attachments"][0]
+        assert attachment["color"] == "#FF0000"
+
+        blocks = attachment["blocks"]
+        header_block = blocks[0]
+        assert header_block["type"] == "header"
+        assert "critical" in header_block["text"]["text"].lower()
+
+    def test_build_slack_payload_high_priority(self):
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Database slow",
+            "priority": "high",
+            "assigned_team": "DBA",
+            "company": "ACME Corp",
+            "sla_breach_at": "2026-05-30T18:00:00Z",
+        }
+        payload = build_slack_payload(ticket)
+        attachment = payload["attachments"][0]
+        assert attachment["color"] == "#FF0000"
+
+    def test_build_slack_payload_medium_priority(self):
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "UI glitch",
+            "priority": "medium",
+            "assigned_team": "Frontend",
+            "company": "ACME Corp",
+            "sla_breach_at": None,
+        }
+        payload = build_slack_payload(ticket)
+        attachment = payload["attachments"][0]
+        assert attachment["color"] == "#FFA500"
+
+    def test_build_slack_payload_missing_fields(self):
+        ticket = {
+            "id": "1234",
+        }
+        payload = build_slack_payload(ticket)
+        assert "attachments" in payload
+        attachment = payload["attachments"][0]
+        assert attachment["color"] == "#FFA500"
+
+    def test_build_slack_payload_short_id(self):
+        ticket = {
+            "id": "abc",
+            "subject": "Test",
+            "priority": "critical",
+            "assigned_team": "Team",
+            "company": "Co",
+            "sla_breach_at": None,
+        }
+        payload = build_slack_payload(ticket)
+        assert "attachments" in payload
+
+
+class TestBuildTeamsPayload:
+    def test_build_teams_payload_critical_priority(self):
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Server down",
+            "priority": "critical",
+            "assigned_team": "Ops",
+            "company": "ACME Corp",
+            "sla_breach_at": "2026-05-30T15:00:00Z",
+        }
+        payload = build_teams_payload(ticket)
+
+        assert payload["@type"] == "MessageCard"
+        assert payload["themeColor"] == "FF0000"
+        assert len(payload["sections"]) == 1
+
+    def test_build_teams_payload_high_priority(self):
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Database slow",
+            "priority": "high",
+            "assigned_team": "DBA",
+            "company": "ACME Corp",
+            "sla_breach_at": None,
+        }
+        payload = build_teams_payload(ticket)
+        assert payload["themeColor"] == "FF0000"
+
+    def test_build_teams_payload_low_priority(self):
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Minor issue",
+            "priority": "low",
+            "assigned_team": "Support",
+            "company": "ACME Corp",
+            "sla_breach_at": None,
+        }
+        payload = build_teams_payload(ticket)
+        assert payload["themeColor"] == "FFA500"
+
+    def test_build_teams_payload_missing_fields(self):
+        ticket = {
+            "id": "1234",
+        }
+        payload = build_teams_payload(ticket)
+        assert payload["@type"] == "MessageCard"
+
+
+class TestDetectWebhookType:
+    def test_detect_slack_webhook(self):
+        url = "https://hooks.slack.com/services/ABC/DEF/123"
+        assert detect_webhook_type(url) == "slack"
+
+    def test_detect_teams_webhook(self):
+        url = "https://webhook.office.com/testwebhook"
+        assert detect_webhook_type(url) == "teams"
+
+    def test_detect_teams_webhook_outlook(self):
+        url = "https://outlook.office.com/webhook/test"
+        assert detect_webhook_type(url) == "teams"
+
+    def test_detect_default_slack(self):
+        url = "https://other.service.com/webhook"
+        assert detect_webhook_type(url) == "slack"
+
+
+class TestSendWebhookNotification:
+    @patch("backend.services.webhook_service.urlopen")
+    def test_send_webhook_notification_success_slack(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Test",
+            "priority": "critical",
+            "assigned_team": "Team",
+            "company": "Co",
+            "sla_breach_at": None,
+        }
+        url = "https://hooks.slack.com/services/ABC/DEF/123"
+
+        result = send_webhook_notification(url, ticket)
+
+        assert result is True
+        mock_urlopen.assert_called_once()
+
+    @patch("backend.services.webhook_service.urlopen")
+    def test_send_webhook_notification_success_teams(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        ticket = {
+            "id": "1234567890abcdef",
+            "subject": "Test",
+            "priority": "critical",
+            "assigned_team": "Team",
+            "company": "Co",
+            "sla_breach_at": None,
+        }
+        url = "https://webhook.office.com/testwebhook"
+
+        result = send_webhook_notification(url, ticket)
+
+        assert result is True
+
+    @patch("backend.services.webhook_service.urlopen")
+    def test_send_webhook_notification_http_error(self, mock_urlopen):
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            url="http://test",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=None,
+        )
+
+        ticket = {"id": "1234", "subject": "Test", "priority": "high"}
+        url = "https://hooks.slack.com/services/ABC/DEF/123"
+
+        result = send_webhook_notification(url, ticket)
+
+        assert result is False
+
+    @patch("backend.services.webhook_service.urlopen")
+    def test_send_webhook_notification_url_error(self, mock_urlopen):
+        from urllib.error import URLError
+
+        mock_urlopen.side_effect = URLError("Connection refused")
+
+        ticket = {"id": "1234", "subject": "Test", "priority": "high"}
+        url = "https://hooks.slack.com/services/ABC/DEF/123"
+
+        result = send_webhook_notification(url, ticket)
+
+        assert result is False
+
+    def test_send_webhook_notification_no_url(self):
+        result = send_webhook_notification("", {"id": "1234"})
+        assert result is False
+
+
+class TestNotifyCriticalTicket:
+    @patch.dict("os.environ", {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/test"})
+    @patch("backend.services.webhook_service.send_webhook_notification")
+    def test_notify_critical_ticket_with_env_url(self, mock_send):
+        mock_send.return_value = True
+
+        ticket = {"id": "1234567890abcdef", "subject": "Test", "priority": "critical"}
+        result = notify_critical_ticket(ticket)
+
+        assert result is True
+        mock_send.assert_called_once()
+        call_args = mock_send.call_args[0]
+        assert call_args[0] == "https://hooks.slack.com/test"
+        assert call_args[1]["id"] == "1234567890abcdef"
+
+    @patch("backend.services.webhook_service.send_webhook_notification")
+    def test_notify_critical_ticket_with_provided_url(self, mock_send):
+        mock_send.return_value = True
+
+        ticket = {"id": "1234567890abcdef", "subject": "Test", "priority": "critical"}
+        webhook_url = "https://hooks.slack.com/provided"
+        result = notify_critical_ticket(ticket, webhook_url=webhook_url)
+
+        assert result is True
+        mock_send.assert_called_once_with(webhook_url, ticket)
+
+    @patch("os.environ.get", return_value="")
+    def test_notify_critical_ticket_no_url(self, mock_get):
+        result = notify_critical_ticket({"id": "1234"})
+        assert result is False
+
+    @patch("backend.services.webhook_service.send_webhook_notification")
+    def test_notify_critical_ticket_send_fails(self, mock_send):
+        mock_send.return_value = False
+
+        ticket = {"id": "1234567890abcdef", "subject": "Test", "priority": "critical"}
+        webhook_url = "https://hooks.slack.com/test"
+        result = notify_critical_ticket(ticket, webhook_url=webhook_url)
+
+        assert result is False
+
+
+class TestConfigurableFrontendURL:
+    def test_build_slack_payload_uses_custom_frontend_url(self):
+        custom_url = "https://custom-helpdesk.com"
+        ticket = {"id": "1234567890abcdef", "subject": "Test"}
+        
+        with patch("backend.services.webhook_service.FRONTEND_BASE_URL", custom_url):
+            payload = build_slack_payload(ticket)
+            
+            attachment = payload["attachments"][0]
+            ticket_field = attachment["blocks"][1]["fields"][0]["text"]
+            assert custom_url in ticket_field
+            assert "https://helpdeskaiv1.vercel.app" not in ticket_field
+
+    def test_build_teams_payload_uses_custom_frontend_url(self):
+        custom_url = "https://custom-helpdesk.com"
+        ticket = {"id": "1234567890abcdef", "subject": "Test"}
+        
+        with patch("backend.services.webhook_service.FRONTEND_BASE_URL", custom_url):
+            payload = build_teams_payload(ticket)
+            
+            target_uri = payload["potentialAction"][0]["targets"][0]["uri"]
+            assert custom_url in target_uri
+            assert "https://helpdeskaiv1.vercel.app" not in target_uri
+
+    def test_build_slack_payload_uses_default_frontend_url(self):
+        # Ensure it uses default if env var is not set
+        ticket = {"id": "1234567890abcdef", "subject": "Test"}
+        
+        # We patch it to the default value to be sure
+        default_url = "https://helpdeskaiv1.vercel.app"
+        with patch("backend.services.webhook_service.FRONTEND_BASE_URL", default_url):
+            payload = build_slack_payload(ticket)
+            
+            attachment = payload["attachments"][0]
+            ticket_field = attachment["blocks"][1]["fields"][0]["text"]
+            assert default_url in ticket_field


### PR DESCRIPTION
Fixes #1110.

### Description
This PR replaces the hardcoded frontend URL (`https://helpdeskaiv1.vercel.app`) with a configurable environment variable `FRONTEND_BASE_URL`. 

### Key Changes
- **webhook_service.py**: Ticket links in Slack/Teams payloads now use `FRONTEND_BASE_URL`.
- **sla_engine.py**: Consistent update for ticket links in SLA notifications.
- **main.py**: Updated root landing page and manual webhook triggers.
- **digest_service.py**: Updated weekly operations digest email links.
- **Tests**: Restored corrupted test files and added new tests to verify configuration handling.

### Verification
- Ran `pytest backend/tests/test_webhook_service.py` -> **25 Passed**.
- Verified default fallback works correctly.

Targeting the `gssoc` branch as per contribution guidelines.