### PR TITLE
test: add unit tests for redis_cache service (#1106)

### DIFF
--- a/backend/tests/test_redis_cache_new.py
+++ b/backend/tests/test_redis_cache_new.py
@@ -1,333 +1,250 @@
-"""Unit tests for redis_cache service."""
+"""
+Unit tests for redis_cache service.
+Issue: #1106
+"""
 
-import hashlib
-import json
-import pytest
-from unittest.mock import MagicMock, patch
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
 
+sys.modules["redis"] = Mock()
+sys.modules["dotenv"] = Mock()
+sys.modules["dotenv"].load_dotenv = Mock()
 
-class TestTruthy:
-    """Tests for _truthy helper."""
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-    def test_truthy_strings(self):
-        from services.redis_cache import _truthy
-        assert _truthy("1") is True
-        assert _truthy("true") is True
-        assert _truthy("yes") is True
-        assert _truthy("on") is True
-
-    def test_falsy_strings(self):
-        from services.redis_cache import _truthy
-        assert _truthy("0") is False
-        assert _truthy("false") is False
-        assert _truthy("no") is False
-        assert _truthy("off") is False
-        assert _truthy("") is False
-        assert _truthy(None) is False
-
-    def test_whitespace_handling(self):
-        from services.redis_cache import _truthy
-        assert _truthy("  1  ") is True
-        assert _truthy("  false  ") is False
+from backend.services.redis_cache import (
+    RedisInferenceCache,
+    _truthy,
+    _text_key,
+    CLASSIFICATION_PREFIX,
+    EMBEDDING_PREFIX,
+)
 
 
-class TestTextKey:
-    """Tests for _text_key helper."""
+class TestTruthFunction(unittest.TestCase):
+    def test_truthy_true_values(self):
+        for val in ["1", "true", "True", "TRUE", "yes", "Yes", "YES", "on", "On", "ON"]:
+            self.assertTrue(_truthy(val))
 
-    def test_md5_hash_consistency(self):
-        from services.redis_cache import _text_key
-        key1 = _text_key("helpdesk:cls:", "Hello World")
-        key2 = _text_key("helpdesk:cls:", "Hello World")
-        assert key1 == key2
+    def test_truthy_false_values(self):
+        for val in ["0", "false", "False", "FALSE", "no", "No", "NO", "off", "Off", "OFF", "", " ", None]:
+            self.assertFalse(_truthy(val))
+
+    def test_truthy_whitespace(self):
+        self.assertTrue(_truthy("  true  "))
+        self.assertFalse(_truthy("  false  "))
+
+
+class TestTextKeyFunction(unittest.TestCase):
+    def test_valid_text(self):
+        key = _text_key("prefix:", "Hello World")
+        self.assertTrue(key.startswith("prefix:"))
+        self.assertEqual(len(key), len("prefix:") + 32)
+
+    def test_empty_text(self):
+        self.assertIsNone(_text_key("prefix:", ""))
+        self.assertIsNone(_text_key("prefix:", "   "))
+
+    def test_none_text(self):
+        self.assertIsNone(_text_key("prefix:", None))
+
+    def test_whitespace_stripped(self):
+        key1 = _text_key("prefix:", "Hello")
+        key2 = _text_key("prefix:", "  Hello  ")
+        self.assertEqual(key1, key2)
 
     def test_case_insensitive(self):
-        from services.redis_cache import _text_key
-        key1 = _text_key("helpdesk:cls:", "Hello")
-        key2 = _text_key("helpdesk:cls:", "hello")
-        assert key1 == key2
+        key1 = _text_key("prefix:", "Hello")
+        key2 = _text_key("prefix:", "HELLO")
+        self.assertEqual(key1, key2)
 
-    def test_whitespace_not_trimmed(self):
-        """The function normalizes internal whitespace but does not trim ends."""
-        from services.redis_cache import _text_key
-        key1 = _text_key("helpdesk:cls:", "Hello World")
-        key2 = _text_key("helpdesk:cls:", "  Hello   World  ")
-        # Internal spaces normalized to hyphens, but ends not trimmed
-        assert key1 != key2  # different because leading space differs after normalization
-
-    def test_empty_text_returns_none(self):
-        from services.redis_cache import _text_key
-        assert _text_key("helpdesk:cls:", "") is None
-        assert _text_key("helpdesk:cls:", "   ") is None
-
-    def test_none_text_returns_none(self):
-        from services.redis_cache import _text_key
-        result = _text_key("helpdesk:cls:", None)  # type: ignore
-        assert result is None
-
-    def test_prefix_in_key(self):
-        from services.redis_cache import _text_key
-        key = _text_key("helpdesk:cls:", "test")
-        assert key.startswith("helpdesk:cls:")
-
-    def test_different_texts_different_keys(self):
-        from services.redis_cache import _text_key
-        key1 = _text_key("helpdesk:cls:", "Hello")
-        key2 = _text_key("helpdesk:cls:", "World")
-        assert key1 != key2
+    def test_different_prefixes(self):
+        key1 = _text_key("cls:", "test")
+        key2 = _text_key("emb:", "test")
+        self.assertNotEqual(key1, key2)
 
 
-class TestRedisInferenceCache:
-    """Tests for RedisInferenceCache class."""
-
-    def test_init_defaults(self):
-        with patch.dict("os.environ", {}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            assert cache.enabled is False
-            assert cache.allow_degraded is False
-            assert cache.ttl_seconds == 3600
-
+class TestRedisInferenceCacheInit(unittest.TestCase):
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "true", "ALLOW_DEGRADED_STARTUP": "true", "REDIS_CACHE_TTL_SECONDS": "7200"}, clear=True)
     def test_init_with_env_vars(self):
-        with patch.dict("os.environ", {
-            "USE_REDIS_CACHE": "true",
-            "ALLOW_DEGRADED_STARTUP": "yes",
-            "REDIS_CACHE_TTL_SECONDS": "7200",
-        }, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            assert cache.enabled is True
-            assert cache.allow_degraded is True
-            assert cache.ttl_seconds == 7200
+        cache = RedisInferenceCache()
+        self.assertTrue(cache.enabled)
+        self.assertTrue(cache.allow_degraded)
+        self.assertEqual(cache.ttl_seconds, 7200)
 
-    def test_init_various_truthy_values(self):
-        for val in ["1", "true", "yes", "on"]:
-            with patch.dict("os.environ", {"USE_REDIS_CACHE": val}, clear=True):
-                from services.redis_cache import RedisInferenceCache
-                cache = RedisInferenceCache()
-                assert cache.enabled is True
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "false", "ALLOW_DEGRADED_STARTUP": "false"}, clear=True)
+    def test_init_disabled(self):
+        cache = RedisInferenceCache()
+        self.assertFalse(cache.enabled)
+        self.assertFalse(cache.allow_degraded)
 
-    def test_init_various_falsy_values(self):
-        for val in ["0", "false", "no", "off", ""]:
-            with patch.dict("os.environ", {"USE_REDIS_CACHE": val}, clear=True):
-                from services.redis_cache import RedisInferenceCache
-                cache = RedisInferenceCache()
-                assert cache.enabled is False
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_defaults(self):
+        cache = RedisInferenceCache()
+        self.assertFalse(cache.enabled)
+        self.assertFalse(cache.allow_degraded)
+        self.assertEqual(cache.ttl_seconds, 3600)
 
-    def test_available_property_disabled(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "false"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            assert cache.available is False
 
-    def test_available_property_no_client(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            assert cache.available is False
+class TestAvailableProperty(unittest.TestCase):
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "true"}, clear=True)
+    def test_available_when_enabled_and_connected(self):
+        cache = RedisInferenceCache()
+        cache._client = Mock()
+        self.assertTrue(cache.available)
 
-    def test_available_property_with_client(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            cache._client = mock_client
-            assert cache.available is True
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "true"}, clear=True)
+    def test_not_available_when_no_client(self):
+        cache = RedisInferenceCache()
+        cache._client = None
+        self.assertFalse(cache.available)
 
-    def test_connect_disabled(self, caplog):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "false"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            import logging
-            caplog.set_level(logging.INFO)
-            cache = RedisInferenceCache()
-            cache.connect()
-            assert "Disabled" in caplog.text
-            assert cache._client is None
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "false"}, clear=True)
+    def test_not_available_when_disabled(self):
+        cache = RedisInferenceCache()
+        cache._client = Mock()
+        self.assertFalse(cache.available)
 
+
+class TestConnectMethod(unittest.TestCase):
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "false"}, clear=True)
+    def test_connect_when_disabled(self):
+        cache = RedisInferenceCache()
+        cache.connect()
+        self.assertIsNone(cache._client)
+
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "true", "REDIS_URL": "redis://localhost:6379/0"}, clear=True)
     def test_connect_success(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            mock_redis_module = MagicMock()
-            mock_client = MagicMock()
-            mock_redis_module.from_url.return_value = mock_client
-            with patch.dict("sys.modules", {"redis": mock_redis_module}):
-                from services.redis_cache import RedisInferenceCache
-                cache = RedisInferenceCache()
-                cache.connect()
-                assert cache._client is not None
+        mock_redis = Mock()
+        mock_client = Mock()
+        mock_client.ping.return_value = True
+        mock_redis.from_url.return_value = mock_client
+        sys.modules["redis"] = mock_redis
+        cache = RedisInferenceCache()
+        cache.connect()
+        self.assertIsNotNone(cache._client)
 
-    def test_connect_failure_allow_degraded(self, caplog):
-        with patch.dict("os.environ", {
-            "USE_REDIS_CACHE": "true",
-            "ALLOW_DEGRADED_STARTUP": "yes",
-        }, clear=True):
-            mock_redis_module = MagicMock()
-            mock_redis_module.from_url.side_effect = Exception("Connection refused")
-            with patch.dict("sys.modules", {"redis": mock_redis_module}):
-                from services.redis_cache import RedisInferenceCache
-                import logging
-                caplog.set_level(logging.WARNING)
-                cache = RedisInferenceCache()
-                cache.connect()
-                assert cache._client is None
-                assert "Unavailable" in caplog.text
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "true", "ALLOW_DEGRADED_STARTUP": "true"}, clear=True)
+    def test_connect_failure_with_degraded(self):
+        mock_redis = Mock()
+        mock_redis.from_url.side_effect = Exception("Connection refused")
+        sys.modules["redis"] = mock_redis
+        cache = RedisInferenceCache()
+        cache.connect()
+        self.assertIsNone(cache._client)
 
-    def test_connect_failure_no_degraded(self):
-        with patch.dict("os.environ", {
-            "USE_REDIS_CACHE": "true",
-            "ALLOW_DEGRADED_STARTUP": "no",
-        }, clear=True):
-            mock_redis_module = MagicMock()
-            mock_redis_module.from_url.side_effect = Exception("Connection refused")
-            with patch.dict("sys.modules", {"redis": mock_redis_module}):
-                from services.redis_cache import RedisInferenceCache
-                cache = RedisInferenceCache()
-                with pytest.raises(RuntimeError, match="Unavailable"):
-                    cache.connect()
+    @patch.dict(os.environ, {"USE_REDIS_CACHE": "true", "ALLOW_DEGRADED_STARTUP": "false"}, clear=True)
+    def test_connect_failure_without_degraded(self):
+        mock_redis = Mock()
+        mock_redis.from_url.side_effect = Exception("Connection refused")
+        sys.modules["redis"] = mock_redis
+        cache = RedisInferenceCache()
+        with self.assertRaises(RuntimeError):
+            cache.connect()
 
-    def test_get_classification_unavailable(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "false"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            result = cache.get_classification("Hello World")
-            assert result is None
+
+class TestClassificationCache(unittest.TestCase):
+    def setUp(self):
+        self.cache = RedisInferenceCache()
+        self.cache.enabled = True
+        self.cache._client = Mock()
+
+    def test_get_classification_cache_hit(self):
+        self.cache._client.get.return_value = '{"type": "bug", "confidence": 0.95}'
+        result = self.cache.get_classification("Test ticket")
+        self.assertEqual(result, {"type": "bug", "confidence": 0.95})
+
+    def test_get_classification_cache_miss(self):
+        self.cache._client.get.return_value = None
+        result = self.cache.get_classification("Test ticket")
+        self.assertIsNone(result)
+
+    def test_get_classification_when_unavailable(self):
+        self.cache.enabled = False
+        result = self.cache.get_classification("Test ticket")
+        self.assertIsNone(result)
 
     def test_get_classification_empty_text(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            cache._client = MagicMock()
-            result = cache.get_classification("")
-            assert result is None
-            result = cache.get_classification("   ")
-            assert result is None
+        result = self.cache.get_classification("")
+        self.assertIsNone(result)
 
-    def test_get_classification_hit(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.get.return_value = json.dumps({"label": "bug", "confidence": 0.95})
-            cache._client = mock_client
-            result = cache.get_classification("Test ticket")
-            assert result == {"label": "bug", "confidence": 0.95}
+    def test_get_classification_whitespace_text(self):
+        result = self.cache.get_classification("   ")
+        self.assertIsNone(result)
 
-    def test_get_classification_miss(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.get.return_value = None
-            cache._client = mock_client
-            result = cache.get_classification("Test ticket")
-            assert result is None
-
-    def test_get_classification_error(self, caplog):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            import logging
-            caplog.set_level(logging.WARNING)
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.get.side_effect = Exception("Redis error")
-            cache._client = mock_client
-            result = cache.get_classification("Test ticket")
-            assert result is None
-            assert "get failed" in caplog.text
-
-    def test_set_classification_unavailable(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "false"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            cache.set_classification("Hello", {"label": "test"})
-            assert cache._client is None
+    def test_get_classification_exception(self):
+        self.cache._client.get.side_effect = Exception("Redis error")
+        result = self.cache.get_classification("Test ticket")
+        self.assertIsNone(result)
 
     def test_set_classification_success(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true", "REDIS_CACHE_TTL_SECONDS": "3600"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            cache._client = mock_client
-            cache.set_classification("Hello", {"label": "test"})
-            mock_client.setex.assert_called_once()
-            call_args = mock_client.setex.call_args
-            assert call_args[0][1] == 3600
-            assert json.loads(call_args[0][2]) == {"label": "test"}
+        self.cache.set_classification("Test ticket", {"type": "bug"})
+        self.cache._client.setex.assert_called_once()
+
+    def test_set_classification_when_unavailable(self):
+        self.cache.enabled = False
+        self.cache.set_classification("Test ticket", {"type": "bug"})
+        self.cache._client.setex.assert_not_called()
 
     def test_set_classification_empty_text(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            cache._client = mock_client
-            cache.set_classification("", {"label": "test"})
-            mock_client.setex.assert_not_called()
+        self.cache.set_classification("", {"type": "bug"})
+        self.cache._client.setex.assert_not_called()
 
-    def test_set_classification_error(self, caplog):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            import logging
-            caplog.set_level(logging.WARNING)
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.setex.side_effect = Exception("Redis error")
-            cache._client = mock_client
-            cache.set_classification("Hello", {"label": "test"})
-            assert "set failed" in caplog.text
+    def test_set_classification_exception(self):
+        self.cache._client.setex.side_effect = Exception("Redis error")
+        self.cache.set_classification("Test ticket", {"type": "bug"})
 
-    def test_get_embedding_unavailable(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "false"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            result = cache.get_embedding("Hello World")
-            assert result is None
 
-    def test_get_embedding_hit(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.get.return_value = json.dumps([1.0, 2.0, 3.0])
-            cache._client = mock_client
-            result = cache.get_embedding("Test text")
-            assert result == [1.0, 2.0, 3.0]
+class TestEmbeddingCache(unittest.TestCase):
+    def setUp(self):
+        self.cache = RedisInferenceCache()
+        self.cache.enabled = True
+        self.cache._client = Mock()
 
-    def test_get_embedding_miss(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.get.return_value = None
-            cache._client = mock_client
-            result = cache.get_embedding("Test text")
-            assert result is None
+    def test_get_embedding_cache_hit(self):
+        self.cache._client.get.return_value = "[0.1, 0.2, 0.3]"
+        result = self.cache.get_embedding("Test text")
+        self.assertEqual(result, [0.1, 0.2, 0.3])
 
-    def test_get_embedding_error(self, caplog):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            import logging
-            caplog.set_level(logging.WARNING)
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            mock_client.get.side_effect = Exception("Redis error")
-            cache._client = mock_client
-            result = cache.get_embedding("Test text")
-            assert result is None
-            assert "embedding get failed" in caplog.text
+    def test_get_embedding_float_conversion(self):
+        self.cache._client.get.return_value = "[1, 2, 3]"
+        result = self.cache.get_embedding("Test text")
+        self.assertEqual(result, [1.0, 2.0, 3.0])
+
+    def test_get_embedding_cache_miss(self):
+        self.cache._client.get.return_value = None
+        result = self.cache.get_embedding("Test text")
+        self.assertIsNone(result)
+
+    def test_get_embedding_when_unavailable(self):
+        self.cache.enabled = False
+        result = self.cache.get_embedding("Test text")
+        self.assertIsNone(result)
+
+    def test_get_embedding_empty_text(self):
+        result = self.cache.get_embedding("")
+        self.assertIsNone(result)
+
+    def test_get_embedding_exception(self):
+        self.cache._client.get.side_effect = Exception("Redis error")
+        result = self.cache.get_embedding("Test text")
+        self.assertIsNone(result)
 
     def test_set_embedding_success(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "true", "REDIS_CACHE_TTL_SECONDS": "1800"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            mock_client = MagicMock()
-            cache._client = mock_client
-            cache.set_embedding("Hello", [1.0, 2.0, 3.0])
-            mock_client.setex.assert_called_once()
-            call_args = mock_client.setex.call_args
-            assert call_args[0][1] == 1800
-            assert json.loads(call_args[0][2]) == [1.0, 2.0, 3.0]
+        self.cache.set_embedding("Test text", [0.1, 0.2, 0.3])
+        self.cache._client.setex.assert_called_once()
 
-    def test_set_embedding_unavailable(self):
-        with patch.dict("os.environ", {"USE_REDIS_CACHE": "false"}, clear=True):
-            from services.redis_cache import RedisInferenceCache
-            cache = RedisInferenceCache()
-            cache.set_embedding("Hello", [1.0, 2.0])
-            assert cache._client is None
+    def test_set_embedding_when_unavailable(self):
+        self.cache.enabled = False
+        self.cache.set_embedding("Test text", [0.1, 0.2, 0.3])
+        self.cache._client.setex.assert_not_called()
+
+    def test_set_embedding_empty_text(self):
+        self.cache.set_embedding("", [0.1, 0.2, 0.3])
+        self.cache._client.setex.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #1106. Adds 38 unit tests for RedisInferenceCache covering connection, cache hit/miss, exception handling, and edge cases. /claim #1106