### PR TITLE
fix: prevent memory leak in startHeartbeat by clearing existing timers (Fixes #1109)

### DIFF
--- a/Frontend/src/hooks/useWebSocket.js
+++ b/Frontend/src/hooks/useWebSocket.js
@@ -80,13 +80,16 @@ export default function useWebSocket(companyId) {
   // ---- Start heartbeat timers (called after connect) --------------------
 
   const startHeartbeat = useCallback(() => {
+    // Clear any existing timers first to prevent duplicates on reconnect
+    clearTimers();
+
     // Periodic pings
     pingTimerRef.current = setInterval(() => {
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
         wsRef.current.send(JSON.stringify({ type: "ping" }));
       }
     }, PING_INTERVAL_MS);
-  }, []);
+  }, [clearTimers]);
 
   // ---- WebSocket lifecycle & Reconnection ---------------------------------
 


### PR DESCRIPTION
Fixes #1109

## Problem
The `startHeartbeat` function in `useWebSocket.js` sets a new interval via `setInterval` without clearing any previously set interval. On WebSocket reconnect, this creates duplicate intervals that accumulate and leak memory.

## Solution
Added `clearTimers()` call at the start of `startHeartbeat` to clear any existing ping/pong/reconnect timers before setting new ones. This prevents duplicate interval accumulation on reconnect.

## Changes
- `Frontend/src/hooks/useWebSocket.js`: Added `clearTimers()` at the beginning of `startHeartbeat` callback
- Updated `useCallback` dependency array to include `clearTimers`

## Testing
- Verified that on WebSocket reconnect, previous interval is cleared before new one is created
- No duplicate timers accumulate after multiple reconnections