### PR TITLE
fix: add priority validation in SLA prediction service (Fixes #1112)

### DIFF
--- a/backend/services/sla_prediction_service.py
+++ b/backend/services/sla_prediction_service.py
@@ -11,6 +11,9 @@ from backend.sla_predictor import get_sla_estimate
 
 logger = logging.getLogger(__name__)
 
+# Valid priority values (must match sla_predictor._BASELINE_MINUTES keys)
+_VALID_PRIORITIES = frozenset({"critical", "high", "medium", "low"})
+
 class SLABreachPredictionService:
     def __init__(self, supabase_client):
         self.supabase = supabase_client
@@ -29,10 +32,15 @@ class SLABreachPredictionService:
             if not ticket:
                 return {"error": "Ticket not found"}
 
-            # 2. Get estimate from SLA Predictor
+            # 2. Validate priority
+            priority = ticket.get("priority")
+            if priority and str(priority).strip().lower() not in _VALID_PRIORITIES:
+                return {"error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(_VALID_PRIORITIES))}"}
+
+            # 3. Get estimate from SLA Predictor
             estimate = get_sla_estimate(ticket, self.supabase)
             
-            # 3. Calculate Risk Level
+            # 4. Calculate Risk Level
             # Risk is 'High' if estimated resolution is > 90% of remaining SLA time.
             # Risk is 'Medium' if between 60% and 90%.
             


### PR DESCRIPTION
Fixes #1112

## Problem
The `predict_risk` method in `SLABreachPredictionService` silently accepted invalid priority values. An invalid priority like 'invalid' would use the default 72-hour baseline via the `_priority_key` fallback in `sla_predictor.py` instead of raising an error.

## Solution
Added explicit priority validation at the start of `predict_risk` that checks against known priority values (`critical`, `high`, `medium`, `low`). Returns a clear error message for unknown priorities.

## Changes
- `backend/services/sla_prediction_service.py`:
  - Added `_VALID_PRIORITIES` constant matching `sla_predictor._BASELINE_MINUTES` keys
  - Added priority validation before SLA estimation
  - Returns descriptive error for invalid priorities
  - Fixed step numbering in comments

## Testing
- Valid priorities (critical, high, medium, low) continue to work normally
- Invalid/unknown priorities return a clear error message listing valid options
- `None`/missing priority is handled gracefully (falls through to sla_predictor default)