### PR TITLE
docs: add project structure section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,52 @@ graph TD
 
 ---
 
+<h2 id="project-structure">📁 Project Structure</h2>
+
+This document outlines the key directories in the HELPDESK.AI repository to help contributors navigate the codebase efficiently.
+
+```
+HELPDESK.AI/
+├── Frontend/          # React frontend application (Vite-based)
+├── backend/           # Backend API services
+├── MobileApp/         # Mobile application (Android)
+├── Model/             # ML models and AI inference code
+├── supabase/          # Supabase database configuration and migrations
+├── scripts/           # Utility and automation scripts
+├── docs/              # Documentation files
+├── app/               # Main application entry point
+├── src/               # Source code modules
+├── tests/             # Test suites and fixtures
+├── k8s/               # Kubernetes deployment manifests
+├── deploy/            # Deployment configurations and scripts
+├── middleware/        # Express/FastAPI middleware components
+├── utils/             # Helper functions and utilities
+├── static/            # Static assets (CSS, images)
+├── templates/         # HTML templates
+└── ...
+```
+
+| Directory | Purpose |
+| :--- | :--- |
+| **Frontend/** | React-based web UI built with Vite |
+| **backend/** | FastAPI/Node.js backend API services |
+| **MobileApp/** | React Native mobile application |
+| **Model/** | Machine learning models (DistilBERT, NER, OCR) |
+| **supabase/** | Database schema, migrations, and edge functions |
+| **scripts/** | Build, deployment, and utility scripts |
+| **docs/** | Project documentation and guides |
+| **app/** | Core application logic |
+| **src/** | Shared source modules and libraries |
+| **tests/** | Unit, integration, and E2E tests |
+| **k8s/** | Kubernetes manifests for production deployment |
+| **deploy/** | CI/CD pipelines and deployment configs |
+| **middleware/** | Authentication, logging, and request middleware |
+| **utils/** | Common utilities and helper functions |
+| **static/** | Static assets served by the application |
+| **templates/** | HTML/email templates |
+
+---
+
 <h2 id="the-ai-neural-pipeline">🧠 The AI Neural Pipeline</h2>
 
 Under the hood, Helpdesk.ai leverages a custom suite of high speed models.


### PR DESCRIPTION
## Summary
Add a Project Structure section to the README that documents the key directories in the HELPDESK.AI repository, helping contributors navigate the codebase efficiently.

## Changes
- Added folder tree representation showing all major directories
- Included a table summarizing the purpose of each directory
- Added the section after the System Architecture section for logical flow

## Testing
- README renders correctly with the new section
- All directory names match actual project structure

## Related Issues
Fixes #1328