### PR TITLE
feat: add keyboard shortcuts for admin navigation (Fixes #1172)

### DIFF
--- a/Frontend/src/admin/components/AdminHeader.jsx
+++ b/Frontend/src/admin/components/AdminHeader.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Search, Bell, Menu, User, ChevronDown, Settings, LogOut, UserCircle, X, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
+import { Search, Bell, Menu, User, ChevronDown, Settings, LogOut, UserCircle, X, PanelLeftClose, PanelLeftOpen, Keyboard } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import NotificationPopover from '../../user/components/NotificationPopover';
 import useAuthStore from '../../store/authStore';
@@ -11,7 +11,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "../../components/ui/avatar"
  * Features a solid white background, specific search placeholder, 
  * and a functional avatar dropdown menu.
  */
-const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar }) => {
+const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar, onToggleShortcutsHelp }) => {
     const [isProfileOpen, setIsProfileOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const dropdownRef = useRef(null);
@@ -95,6 +95,14 @@ const AdminHeader = ({ onMobileNavToggle, isSidebarCollapsed, onToggleSidebar })
                         </button>
                     )}
                 </div>
+
+                <button
+                    onClick={onToggleShortcutsHelp}
+                    title="Keyboard shortcuts"
+                    className="hidden md:flex p-2 hover:bg-slate-50 rounded-xl text-slate-400 hover:text-emerald-600 transition-colors"
+                >
+                    <Keyboard size={18} />
+                </button>
             </div>
 
             {/* Header Operations */}

--- a/Frontend/src/admin/components/KeyboardShortcutsHelp.jsx
+++ b/Frontend/src/admin/components/KeyboardShortcutsHelp.jsx
@@ -1,0 +1,60 @@
+import { useState, useEffect } from 'react';
+import { SHORTCUTS } from '../hooks/useKeyboardShortcuts';
+
+export default function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    if (open) window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open]);
+
+  const sequences = SHORTCUTS.filter((s) => s.combo);
+  const globals = SHORTCUTS.filter((s) => !s.combo);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setOpen(false)}>
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl" onClick={(e) => e.stopPropagation()}>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">Keyboard Shortcuts</h2>
+          <button className="text-gray-500 hover:text-gray-700" onClick={() => setOpen(false)}>
+            ✕
+          </button>
+        </div>
+        <div className="space-y-4 text-sm text-gray-700">
+          <div>
+            <p className="mb-1 font-medium text-gray-900">Navigation</p>
+            <ul className="space-y-1">
+              {sequences.map((s) => (
+                <li key={s.combo} className="flex items-center justify-between">
+                  <span>{s.label}</span>
+                  <kbd className="rounded border bg-gray-100 px-2 py-0.5 font-mono text-xs">
+                    {s.combo}
+                  </kbd>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <p className="mb-1 font-medium text-gray-900">Global</p>
+            <ul className="space-y-1">
+              {globals.map((s) => (
+                <li key={s.key} className="flex items-center justify-between">
+                  <span>{s.label}</span>
+                  <kbd className="rounded border bg-gray-100 px-2 py-0.5 font-mono text-xs">
+                    {s.key}
+                  </kbd>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import KeyboardShortcutsHelp from '../components/KeyboardShortcutsHelp';
 
 /**
  * AdminLayout Component
@@ -12,6 +13,7 @@ import NotificationToast from '../../user/components/NotificationToast';
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
@@ -30,6 +32,7 @@ const AdminLayout = () => {
                     onMobileNavToggle={() => setIsMobileNavOpen(!isMobileNavOpen)} 
                     isSidebarCollapsed={isSidebarCollapsed}
                     onToggleSidebar={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+                    onToggleShortcutsHelp={() => setShowShortcutsHelp(true)}
                 />
 
                 {/* Operational Workspace */}
@@ -44,13 +47,16 @@ const AdminLayout = () => {
             {/* Real-time System Notifications */}
             <NotificationToast />
 
+            {/* Keyboard Shortcuts Help Overlay */}
+            <KeyboardShortcutsHelp open={showShortcutsHelp} onClose={() => setShowShortcutsHelp(false)} />
+
             {/* Mobile Nav Overlay (Emergency protocols) */}
             {isMobileNavOpen && (
                 <div
                     className="fixed inset-0 bg-slate-900/80 backdrop-blur-md z-50 lg:hidden flex transition-opacity duration-300"
                     onClick={() => setIsMobileNavOpen(false)}
                 >
-                    <div
+                    <div 
                         className="w-[85%] max-w-[280px] h-full shadow-2xl animate-in slide-in-from-left duration-300"
                         onClick={(e) => e.stopPropagation()}
                     >

--- a/Frontend/src/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SEQUENCE_SHORTCUTS = [
+  { keys: ['g', 'd'], label: 'Go to Dashboard', path: '/admin/dashboard' },
+  { keys: ['g', 't'], label: 'Go to Tickets',    path: '/admin/tickets' },
+  { keys: ['g', 'u'], label: 'Go to Users',      path: '/admin/users' },
+  { keys: ['g', 'a'], label: 'Go to Analytics',  path: '/admin/analytics' },
+  { keys: ['g', 's'], label: 'Go to Settings',   path: '/admin/settings' },
+];
+
+const GLOBAL_SHORTCUTS = [
+  { key: '/', label: 'Focus search' },
+  { key: '?', label: 'Toggle shortcuts help' },
+];
+
+export const SHORTCUTS = [...SEQUENCE_SHORTCUTS.map((s) => ({ ...s, combo: s.keys.join('+') })), ...GLOBAL_SHORTCUTS];
+
+export default function useKeyboardShortcuts({ onToggleHelp } = {}) {
+  const navigate = useNavigate();
+  const sequenceRef = useRef([]);
+  const timerRef = useRef(null);
+
+  const resetSequence = useCallback(() => {
+    sequenceRef.current = [];
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const editable = ['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName) || e.target.isContentEditable;
+
+      // Global shortcuts
+      if (!e.metaKey && !e.ctrlKey && !e.altKey) {
+        if (e.key === '?' && !editable) {
+          e.preventDefault();
+          onToggleHelp?.();
+          return;
+        }
+        if (e.key === '/' && !editable) {
+          e.preventDefault();
+          const searchInput = document.querySelector('input[type="search"], input[placeholder*="Search" i], input[aria-label*="search" i]');
+          searchInput?.focus();
+          return;
+        }
+      }
+
+      // Two-key sequences (e.g. g then d)
+      if (!e.metaKey && !e.ctrlKey && !e.altKey && !editable) {
+        if (sequenceRef.current.length === 0) {
+          const first = e.key.toLowerCase();
+          if (SEQUENCE_SHORTCUTS.some((s) => s.keys[0] === first)) {
+            sequenceRef.current = [first];
+            timerRef.current = setTimeout(resetSequence, 1500);
+            return;
+          }
+        } else if (sequenceRef.current.length === 1) {
+          const combo = [sequenceRef.current[0], e.key.toLowerCase()];
+          const match = SEQUENCE_SHORTCUTS.find((s) => s.keys[0] === combo[0] && s.keys[1] === combo[1]);
+          if (match) {
+            e.preventDefault();
+            navigate(match.path);
+            resetSequence();
+            return;
+          }
+        }
+        resetSequence();
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [navigate, onToggleHelp, resetSequence]);
+}


### PR DESCRIPTION
Fixes #1172

## Changes
- Add `useKeyboardShortcuts` hook for sequence shortcuts (`g+d/t/u/a/s`) and global keys (`/` focus search, `?` help)
- Add `KeyboardShortcutsHelp` modal in admin layout
- Wire keyboard icon button in `AdminHeader` to open help

## Notes
- Behaviors are opt-in via prop; minimal changes to existing pages