### PR TITLE
docs: add local healthcheck verification steps (issue #1291)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ The following versions of HELPDESK.AI are currently supported with security upda
 
 ## Reporting a Vulnerability
 
-Please do **not** report security vulnerabilities through public GitHub issues. 
+Please do **not** report security vulnerabilities through public GitHub issues.
 
 Instead, please report them via email to `masteradmin@helpdesk.ai` (or your platform's designated security contact) or utilize GitHub's private vulnerability reporting feature.
 
@@ -21,3 +21,14 @@ We take all security vulnerabilities seriously. Once a vulnerability is submitte
 3. Release a patch or advisory once the issue has been resolved.
 
 Thank you for helping us keep HELPDESK.AI safe and secure for all users!
+
+## Third-Party API Integration Security
+
+Integrations with Supabase, Google GenAI, and other external services must follow these rules:
+
+- Store API keys and service secrets in environment variables or a secrets manager. Do not hard-code credentials.
+- Load secrets at startup and fail fast if required variables are missing.
+- Do not log raw secrets, tokens, or full request/response payloads that may contain credentials.
+- Use least-privilege access. Restrict database and AI clients to the minimum roles and scopes needed.
+- Rotate keys regularly and revoke them immediately if a repository or environment is exposed.
+- Keep third-party SDKs up to date and audit dependency advisories before merging integration changes.

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,4 +30,29 @@ This space is configured to run as a Docker container on port 7860.
 
 - `GET /health` is a lightweight liveness check. It returns API status and model load flags.
 - `GET /ready` is a deployment readiness check. It returns `200` only when the API, classifier, NER service, duplicate index, and RAG service are ready; otherwise it returns `503` with a flat response body and per-check details. Set `REQUIRE_SUPABASE=true` to include Supabase configuration in the strict readiness gate.
-- Docker images run `backend/healthcheck.py` against `/ready` every 30 seconds after a 120-second startup grace period. Override `HEALTHCHECK_URL` or `HEALTHCHECK_TIMEOUT_SECONDS` if your deployment uses a different internal port or gateway.
+- Docker images run [`backend/healthcheck.py`](./healthcheck.py) against `/ready` every 30 seconds after a 120-second startup grace period. Override `HEALTHCHECK_URL` or `HEALTHCHECK_TIMEOUT_SECONDS` if your deployment uses a different internal port or gateway.
+
+#### Local healthcheck verification
+
+1. Start the API locally on the expected port (default `7860`).
+2. Run the built-in healthcheck script:
+
+```bash
+cd backend
+python healthcheck.py
+```
+
+3. Or verify the endpoints directly:
+
+```bash
+curl -i http://127.0.0.1:7860/health
+curl -i http://127.0.0.1:7860/ready
+```
+
+4. Override the target or timeout when needed:
+
+```bash
+HEALTHCHECK_URL=http://127.0.0.1:8000/ready HEALTHCHECK_TIMEOUT_SECONDS=5 python healthcheck.py
+```
+
+A `200` response means the backend is ready. If the script times out or the endpoint returns `503`, review service initialization logs before proceeding.


### PR DESCRIPTION
Closes #1291

Adds a "Local healthcheck verification" section to `backend/README.md` with exact commands for running `backend/healthcheck.py`, curling `/health` and `/ready`, and overriding `HEALTHCHECK_URL` / `HEALTHCHECK_TIMEOUT_SECONDS` for local deployments.