### PR TITLE
fix: secure ticket API and image upload handling (#1386, #1387, #1388)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ The following versions of HELPDESK.AI are currently supported with security upda
 
 ## Reporting a Vulnerability
 
-Please do **not** report security vulnerabilities through public GitHub issues. 
+Please do **not** report security vulnerabilities through public GitHub issues.
 
 Instead, please report them via email to `masteradmin@helpdesk.ai` (or your platform's designated security contact) or utilize GitHub's private vulnerability reporting feature.
 
@@ -21,3 +21,14 @@ We take all security vulnerabilities seriously. Once a vulnerability is submitte
 3. Release a patch or advisory once the issue has been resolved.
 
 Thank you for helping us keep HELPDESK.AI safe and secure for all users!
+
+## Third-Party API Integration Security
+
+Integrations with Supabase, Google GenAI, and other external services must follow these rules:
+
+- Store API keys and service secrets in environment variables or a secrets manager. Do not hard-code credentials.
+- Load secrets at startup and fail fast if required variables are missing.
+- Do not log raw secrets, tokens, or full request/response payloads that may contain credentials.
+- Use least-privilege access. Restrict database and AI clients to the minimum roles and scopes needed.
+- Rotate keys regularly and revoke them immediately if a repository or environment is exposed.
+- Keep third-party SDKs up to date and audit dependency advisories before merging integration changes.

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,4 +30,29 @@ This space is configured to run as a Docker container on port 7860.
 
 - `GET /health` is a lightweight liveness check. It returns API status and model load flags.
 - `GET /ready` is a deployment readiness check. It returns `200` only when the API, classifier, NER service, duplicate index, and RAG service are ready; otherwise it returns `503` with a flat response body and per-check details. Set `REQUIRE_SUPABASE=true` to include Supabase configuration in the strict readiness gate.
-- Docker images run `backend/healthcheck.py` against `/ready` every 30 seconds after a 120-second startup grace period. Override `HEALTHCHECK_URL` or `HEALTHCHECK_TIMEOUT_SECONDS` if your deployment uses a different internal port or gateway.
+- Docker images run [`backend/healthcheck.py`](./healthcheck.py) against `/ready` every 30 seconds after a 120-second startup grace period. Override `HEALTHCHECK_URL` or `HEALTHCHECK_TIMEOUT_SECONDS` if your deployment uses a different internal port or gateway.
+
+#### Local healthcheck verification
+
+1. Start the API locally on the expected port (default `7860`).
+2. Run the built-in healthcheck script:
+
+```bash
+cd backend
+python healthcheck.py
+```
+
+3. Or verify the endpoints directly:
+
+```bash
+curl -i http://127.0.0.1:7860/health
+curl -i http://127.0.0.1:7860/ready
+```
+
+4. Override the target or timeout when needed:
+
+```bash
+HEALTHCHECK_URL=http://127.0.0.1:8000/ready HEALTHCHECK_TIMEOUT_SECONDS=5 python healthcheck.py
+```
+
+A `200` response means the backend is ready. If the script times out or the endpoint returns `503`, review service initialization logs before proceeding.

--- a/backend/main.py
+++ b/backend/main.py
@@ -94,9 +94,11 @@ class TicketRequest(BaseModel):
     @field_validator('image_base64')
     @classmethod
     def limit_image_base64_size(cls, value: str) -> str:
-        max_chars = 15_000_000  # ~11 MB binary after base64 decode
+        max_chars = 15_000_000
         if value and len(value) > max_chars:
-            raise ValueError(f"image_base64 exceeds maximum allowed size ({max_chars} chars)")
+            raise ValueError(
+                f"image_base64 exceeds maximum allowed size ({max_chars} chars)"
+            )
         return value
 
 class TicketSaveRequest(BaseModel):

--- a/backend/main.py
+++ b/backend/main.py
@@ -677,13 +677,27 @@ async def create_ticket(ticket: TicketRecord):
 
 
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict):
-    """Partially update a ticket's fields (e.g., status, viewed_at)."""
+async def update_ticket(
+    ticket_id: str,
+    updates: dict,
+    user: dict = Depends(get_current_user),
+):
+    """Partially update a ticket's fields (e.g. status, viewed_at)."""
+    allowed_fields = {
+        "status",
+        "last_user_viewed_at",
+        "priority",
+        "assigned_team",
+        "category",
+        "subcategory",
+    }
+    filtered = {k: v for k, v in updates.items() if k in allowed_fields}
+    if not filtered:
+        raise HTTPException(status_code=400, detail="No valid update fields provided")
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):
-            # Convert to dict, update, then back to model
-            ticket_dict = ticket.dict()
-            ticket_dict.update(updates)
+            ticket_dict = ticket.model_dump()
+            ticket_dict.update(filtered)
             updated_ticket = TicketRecord(**ticket_dict)
             TICKETS_DB[i] = updated_ticket
             return updated_ticket
@@ -1201,7 +1215,13 @@ async def auth_signup(body: SignupBody, response: Response):
     return {"user": user_payload, "message": "Signup complete"}
 
 @app.post("/auth/logout")
-async def auth_logout(response: Response):
+async def auth_logout(response: Response, request: Request):
+    token = extract_token(request)
+    if token and supabase:
+        try:
+            supabase.auth.admin.sign_out(token)
+        except Exception:
+            pass
     _clear_session_cookies(response)
     return {"ok": True}
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
 import asyncio
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from dotenv import load_dotenv
 
 # Load environment variables from backend/.env
@@ -90,6 +90,14 @@ class TicketRequest(BaseModel):
     image_url: str | None = None
     confidence_threshold: float = 0.20
     duplicate_sensitivity: float = 0.85
+
+    @field_validator('image_base64')
+    @classmethod
+    def limit_image_base64_size(cls, value: str) -> str:
+        max_chars = 15_000_000  # ~11 MB binary after base64 decode
+        if value and len(value) > max_chars:
+            raise ValueError(f"image_base64 exceeds maximum allowed size ({max_chars} chars)")
+        return value
 
 class TicketSaveRequest(BaseModel):
     user_id: str

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -35,13 +35,40 @@ class GeminiService:
             return {
                 "image_description": "[Gemini API Key Missing] Could not analyze image.",
                 "ocr_text": "",
-                "detected_problem": ""
+                "detected_problem": "",
             }
 
         try:
-            # Decode base64 image (actually the new SDK handles base64 easily if we just pass bytes, 
-            # but we can also use PIL if we need to process it)
+            # Enforce queued request size limit first to avoid decode-then-reject.
+            max_input = 15_000_000
+            if image_base64 and len(image_base64) > max_input:
+                raise ValueError("image_base64 payload exceeds the allowed size limit")
+
             image_bytes = base64.b64decode(image_base64)
+            if not image_bytes:
+                return {
+                    "image_description": "No image data provided.",
+                    "ocr_text": "",
+                    "detected_problem": "",
+                }
+
+            max_bytes = 10 * 1024 * 1024
+            if len(image_bytes) > max_bytes:
+                raise ValueError(
+                    f"Decoded image payload is too large ({len(image_bytes)} bytes); max is {max_bytes} bytes"
+                )
+
+            Image.MAX_IMAGE_PIXELS = 80_000_000
+
+            magic = image_bytes[:4]
+            if not (
+                magic.startswith(b"\xff\xd8\xff")
+                or magic.startswith(b"\x89PNG")
+                or magic.startswith(b"GIF8")
+                or magic.startswith(b"RIFF")
+            ):
+                raise ValueError("Unsupported image format")
+
             img = Image.open(io.BytesIO(image_bytes))
 
             prompt = (


### PR DESCRIPTION
Closes #1386
Closes #1387
Closes #1388

- `update_ticket` now requires auth and only accepts a whitelist of ticket fields; rejects empty/unknown updates with `400`.
- Switched model mutation to Pydantic v2 `model_dump()` while keeping the existing in-memory behavior.
- `auth_logout` now invalidates the Supabase session server-side before clearing cookies, reducing the window where stolen tokens remain usable.
- `TicketRequest.image_base64` now has a Pydantic size limit to reject obviously oversized uploads at validation time.
- `GeminiService.analyze_image()` adds a decoded byte-size check, sets `Image.MAX_IMAGE_PIXELS`, verifies image magic bytes, and no longer blindly decodes unknown image data.
