### PR TITLE
fix: standardize Helmet.js security headers and CORS policy via ALLOWED_ORIGINS env var (Fixes #1406)

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
 
 <head>
- 
+  <!-- Security: Content Security Policy -->
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co https://helpdeskaiv1.vercel.app; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" />
+
   <!-- Google Fonts: Syne + Inter -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,8 @@ SENTENCE_TRANSFORMER_MODEL_PATH=
 # Readiness Check
 # Set REQUIRE_SUPABASE=true to include Supabase configuration in the strict readiness gate
 REQUIRE_SUPABASE=false
+
+# CORS Allowed Origins
+# Comma-separated list of allowed origins for CORS policy
+# Example: https://helpdeskaiv1.vercel.app,http://localhost:5173,http://localhost:3000
+ALLOWED_ORIGINS=https://helpdeskaiv1.vercel.app,http://localhost:5173,http://localhost:3000

--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from slowapi.errors import RateLimitExceeded
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
+import helmet
 import asyncio
 from pathlib import Path
 from pydantic import BaseModel
@@ -274,14 +275,27 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-# CORS — locked to production + local dev only
+# Security headers via Helmet
 app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
+    helmet.middleware.HelmetMiddleware,
+)
+
+# CORS — refactored to use ALLOWED_ORIGINS environment variable
+def get_allowed_origins() -> list[str]:
+    """Parse ALLOWED_ORIGINS from environment variable, comma-separated."""
+    env_origins = os.environ.get("ALLOWED_ORIGINS", "")
+    if env_origins:
+        return [origin.strip() for origin in env_origins.split(",") if origin.strip()]
+    # Fallback to hardcoded defaults for backward compatibility
+    return [
         "https://helpdeskaiv1.vercel.app",
         "http://localhost:5173",
         "http://localhost:3000",
-    ],
+    ]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=get_allowed_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ easyocr
 slowapi>=0.1.9
 supabase==2.22.4
 storage3==2.22.4
+helmet>=7.1.0


### PR DESCRIPTION
## Summary
Standardize Helmet.js security headers and refactor CORS to use ALLOWED_ORIGINS environment variable for production deployments.

## Changes
- **FastAPI Helmet middleware**: Add  for standard security headers (X-Frame-Options: DENY, X-Content-Type-Options: nosniff, etc.)
- **CORS refactor**: Replace hardcoded origins with  function that parses  env var (comma-separated)
- **Frontend CSP**: Add Content-Security-Policy meta tag to  aligned with actual asset sources (Google Fonts, Supabase)
- **Documentation**: Add  to  with usage examples
- **Dependencies**: Add  to 

## Testing
- Backend syntax validation:  ✅
- ALLOWED_ORIGINS parsing tested for comma-separated values
- CSP aligned with: Google Fonts (fonts.googleapis.com, fonts.gstatic.com), Supabase (*.supabase.co), Vercel deployment

## Related Issues
Fixes #1406