### PR TITLE
fix: add missing alt attribute to image tag in Submit.jsx

### DIFF
--- a/Frontend/src/legacy_ui/Submit.jsx
+++ b/Frontend/src/legacy_ui/Submit.jsx
@@ -158,7 +158,7 @@ function Submit() {
                       <label className="text-[var(--stitch-text-main,#111814)] text-sm font-bold">Attachments</label>
                       <div className="flex items-center gap-3 p-3 rounded-lg border border-[var(--stitch-border-light,#e2e8e5)] bg-[var(--stitch-background-light,#f6f8f7)]">
                         <div className="size-10 rounded bg-slate-200 flex items-center justify-center text-slate-500 overflow-hidden">
-                          {imagePreview ? <img src={imagePreview} className="w-full h-full object-cover" /> : <ImageIcon />}
+                          {imagePreview ? <img src={imagePreview} alt="Selected ticket image" className="w-full h-full object-cover" /> : <ImageIcon />}
                         </div>
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-[var(--stitch-text-main,#111814)] truncate">{file.name}</p>


### PR DESCRIPTION
## What
Added a descriptive `alt` attribute (`"Selected ticket image"`) to the image preview `<img>` tag in `Frontend/src/legacy_ui/Submit.jsx` that was missing an alt text. This was the only `<img>` tag across the entire frontend codebase without an alt attribute.

## Why
Screen readers rely on `alt` attributes to describe images to visually impaired users. Missing alt text reduces accessibility and fails WCAG compliance. The linked issue (#1390) identified this specific tag in `Submit.jsx`.

## Testing
- Verified the fix by inspecting the component — the `alt` attribute is now present
- Confirmed all other `<img>` tags across the Frontend codebase already have appropriate alt text (no other missing attributes found)