### PR TITLE
feat: keyboard shortcuts for rapid admin dashboard navigation (fixes #1409)

### DIFF
--- a/Frontend/src/admin/components/SLABadge.jsx
+++ b/Frontend/src/admin/components/SLABadge.jsx
@@ -37,7 +37,9 @@ export default function SLABadge({ priority, createdAt, status, compact = false 
 
         const priorityKey = priority.toLowerCase();
         const limit = SLA_LIMITS[priorityKey] || SLA_LIMITS.medium;
-        const createdMs = new Date(createdAt).getTime();
+        // Safari-safe date parsing: normalize space-separated timestamps to ISO 8601
+    const normalized = String(createdAt || '').trim().replace(' ', 'T');
+    const createdMs = new Date(normalized).getTime();
 
         const calculate = () => {
             const elapsed = Date.now() - createdMs;

--- a/Frontend/src/admin/components/ShortcutsHelp.jsx
+++ b/Frontend/src/admin/components/ShortcutsHelp.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { X, Command } from 'lucide-react';
+
+/**
+ * ShortcutsHelp — Modal overlay showing available keyboard shortcuts.
+ * Toggled by pressing '?' or Ctrl+/.
+ */
+const ShortcutsHelp = ({ isOpen, onClose, shortcuts }) => {
+    if (!isOpen) return null;
+
+    const isMac = typeof navigator !== 'undefined' && navigator.platform?.toUpperCase().indexOf('MAC') >= 0;
+    const modKey = isMac ? '⌘' : 'Ctrl';
+
+    const items = Object.entries(shortcuts);
+
+    return (
+        <div
+            className="fixed inset-0 z-[100] flex items-center justify-center"
+            onClick={onClose}
+        >
+            {/* Backdrop */}
+            <div className="absolute inset-0 bg-slate-900/70 backdrop-blur-sm" />
+
+            {/* Modal */}
+            <div
+                className="relative bg-white rounded-2xl shadow-2xl border border-gray-100 w-full max-w-md mx-4 overflow-hidden animate-in fade-in zoom-in-95 duration-200"
+                onClick={(e) => e.stopPropagation()}
+            >
+                {/* Header */}
+                <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-50">
+                    <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 rounded-xl bg-emerald-50 border border-emerald-100 flex items-center justify-center">
+                            <Command size={20} className="text-emerald-600" />
+                        </div>
+                        <div>
+                            <h2 className="text-base font-bold text-gray-900">Keyboard Shortcuts</h2>
+                            <p className="text-xs text-gray-400 font-medium mt-0.5">
+                                Rapid admin navigation
+                            </p>
+                        </div>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="w-8 h-8 rounded-lg hover:bg-gray-100 flex items-center justify-center transition-colors"
+                    >
+                        <X size={16} className="text-gray-400" />
+                    </button>
+                </div>
+
+                {/* Shortcuts list */}
+                <div className="px-6 py-4 space-y-1">
+                    {items.map(([key, label]) => (
+                        <div
+                            key={key}
+                            className="flex items-center justify-between py-3 px-3 rounded-lg hover:bg-gray-50 transition-colors"
+                        >
+                            <span className="text-sm font-medium text-gray-700">{label}</span>
+                            <kbd className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-gray-100 border border-gray-200 text-xs font-bold text-gray-500 font-mono">
+                                <span className="text-[10px] text-gray-400">{modKey}</span>
+                                <span>+</span>
+                                <span>{key}</span>
+                            </kbd>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Footer */}
+                <div className="px-6 py-4 border-t border-gray-50 bg-gray-50/50">
+                    <div className="flex items-center justify-between text-[11px] text-gray-400 font-medium">
+                        <span>Press <kbd className="px-1.5 py-0.5 rounded bg-gray-200 text-gray-500 font-mono text-[10px]">?</kbd> to toggle</span>
+                        <span>Press <kbd className="px-1.5 py-0.5 rounded bg-gray-200 text-gray-500 font-mono text-[10px]">Esc</kbd> to close</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ShortcutsHelp;

--- a/Frontend/src/admin/components/ShortcutsHelp.jsx
+++ b/Frontend/src/admin/components/ShortcutsHelp.jsx
@@ -2,34 +2,54 @@ import React from 'react';
 import { X, Command } from 'lucide-react';
 
 /**
+ * Detect macOS using the modern navigator.userAgentData API
+ * with a fallback to the deprecated navigator.platform.
+ */
+const isMacOS = () => {
+    if (typeof navigator === 'undefined') return false;
+    // Modern API (Chromium, Edge, Opera)
+    if (navigator.userAgentData?.platform) {
+        return navigator.userAgentData.platform.toUpperCase().includes('MAC');
+    }
+    // Legacy fallback (Safari, Firefox)
+    if (navigator.platform) {
+        return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+    }
+    return false;
+};
+
+/**
  * ShortcutsHelp — Modal overlay showing available keyboard shortcuts.
  * Toggled by pressing '?' or Ctrl+/.
  */
 const ShortcutsHelp = ({ isOpen, onClose, shortcuts }) => {
     if (!isOpen) return null;
 
-    const isMac = typeof navigator !== 'undefined' && navigator.platform?.toUpperCase().indexOf('MAC') >= 0;
-    const modKey = isMac ? '⌘' : 'Ctrl';
+    const modKey = isMacOS() ? '⌘' : 'Ctrl';
 
     const items = Object.entries(shortcuts);
 
     return (
         <div
             className="fixed inset-0 z-[100] flex items-center justify-center"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Keyboard shortcuts help"
             onClick={onClose}
         >
             {/* Backdrop */}
-            <div className="absolute inset-0 bg-slate-900/70 backdrop-blur-sm" />
+            <div className="absolute inset-0 bg-slate-900/70 backdrop-blur-sm" aria-hidden="true" />
 
             {/* Modal */}
             <div
                 className="relative bg-white rounded-2xl shadow-2xl border border-gray-100 w-full max-w-md mx-4 overflow-hidden animate-in fade-in zoom-in-95 duration-200"
                 onClick={(e) => e.stopPropagation()}
+                role="document"
             >
                 {/* Header */}
                 <div className="flex items-center justify-between px-6 pt-6 pb-4 border-b border-gray-50">
                     <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 rounded-xl bg-emerald-50 border border-emerald-100 flex items-center justify-center">
+                        <div className="w-10 h-10 rounded-xl bg-emerald-50 border border-emerald-100 flex items-center justify-center" aria-hidden="true">
                             <Command size={20} className="text-emerald-600" />
                         </div>
                         <div>
@@ -41,6 +61,7 @@ const ShortcutsHelp = ({ isOpen, onClose, shortcuts }) => {
                     </div>
                     <button
                         onClick={onClose}
+                        aria-label="Close shortcuts help"
                         className="w-8 h-8 rounded-lg hover:bg-gray-100 flex items-center justify-center transition-colors"
                     >
                         <X size={16} className="text-gray-400" />
@@ -48,10 +69,11 @@ const ShortcutsHelp = ({ isOpen, onClose, shortcuts }) => {
                 </div>
 
                 {/* Shortcuts list */}
-                <div className="px-6 py-4 space-y-1">
+                <div className="px-6 py-4 space-y-1" role="list">
                     {items.map(([key, label]) => (
                         <div
                             key={key}
+                            role="listitem"
                             className="flex items-center justify-between py-3 px-3 rounded-lg hover:bg-gray-50 transition-colors"
                         >
                             <span className="text-sm font-medium text-gray-700">{label}</span>
@@ -74,6 +96,6 @@ const ShortcutsHelp = ({ isOpen, onClose, shortcuts }) => {
             </div>
         </div>
     );
-};
+}
 
 export default ShortcutsHelp;

--- a/Frontend/src/admin/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/admin/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,81 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * useKeyboardShortcuts — Rapid Admin Dashboard Navigation
+ * 
+ * Shortcuts:
+ *   Ctrl+1 → Dashboard
+ *   Ctrl+2 → Tickets  
+ *   Ctrl+3 → Users
+ *   Ctrl+4 → Analytics
+ *   Ctrl+5 → Profile
+ *   Ctrl+6 → Settings
+ *   Ctrl+/ or ? → Toggle shortcuts help
+ * 
+ * Works cross-platform (Cmd for Mac, Ctrl for Windows/Linux).
+ */
+
+const ROUTES = {
+    '1': '/admin/dashboard',
+    '2': '/admin/tickets',
+    '3': '/admin/users',
+    '4': '/admin/analytics',
+    '5': '/admin/profile',
+    '6': '/admin/settings',
+};
+
+const SHORTCUT_LABELS = {
+    '1': 'Dashboard',
+    '2': 'Tickets',
+    '3': 'Users',
+    '4': 'Analytics',
+    '5': 'Profile',
+    '6': 'Settings',
+};
+
+const useKeyboardShortcuts = () => {
+    const navigate = useNavigate();
+    const [helpOpen, setHelpOpen] = useState(false);
+
+    const toggleHelp = useCallback(() => setHelpOpen(prev => !prev), []);
+    const closeHelp = useCallback(() => setHelpOpen(false), []);
+
+    useEffect(() => {
+        const handler = (e) => {
+            const mod = e.ctrlKey || e.metaKey;
+
+            // Navigation: Ctrl/Cmd + 1-6
+            if (mod && ROUTES[e.key]) {
+                e.preventDefault();
+                // Don't navigate if inside input/textarea
+                const tag = document.activeElement?.tagName?.toLowerCase();
+                if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+                navigate(ROUTES[e.key]);
+                return;
+            }
+
+            // Help: ? or Ctrl+/
+            if (
+                (!mod && e.key === '?') ||
+                (mod && e.key === '/')
+            ) {
+                e.preventDefault();
+                toggleHelp();
+                return;
+            }
+
+            // Close help on Escape
+            if (e.key === 'Escape' && helpOpen) {
+                closeHelp();
+            }
+        };
+
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [navigate, toggleHelp, closeHelp, helpOpen]);
+
+    return { helpOpen, closeHelp, toggleHelp, shortcuts: SHORTCUT_LABELS };
+};
+
+export default useKeyboardShortcuts;

--- a/Frontend/src/admin/hooks/useKeyboardShortcuts.js
+++ b/Frontend/src/admin/hooks/useKeyboardShortcuts.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 /**
@@ -34,9 +34,27 @@ const SHORTCUT_LABELS = {
     '6': 'Settings',
 };
 
+/**
+ * Check if the active element is an editable field where shortcuts should NOT fire.
+ * Covers: input, textarea, select, and contenteditable elements.
+ */
+const isEditableElement = (el) => {
+    if (!el) return false;
+    const tag = el.tagName?.toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+    if (el.isContentEditable || el.getAttribute?.('contenteditable') === 'true') return true;
+    return false;
+};
+
 const useKeyboardShortcuts = () => {
     const navigate = useNavigate();
     const [helpOpen, setHelpOpen] = useState(false);
+    const helpOpenRef = useRef(helpOpen);
+
+    // Keep ref in sync so the stable event handler always reads the latest value
+    useEffect(() => {
+        helpOpenRef.current = helpOpen;
+    }, [helpOpen]);
 
     const toggleHelp = useCallback(() => setHelpOpen(prev => !prev), []);
     const closeHelp = useCallback(() => setHelpOpen(false), []);
@@ -48,9 +66,8 @@ const useKeyboardShortcuts = () => {
             // Navigation: Ctrl/Cmd + 1-6
             if (mod && ROUTES[e.key]) {
                 e.preventDefault();
-                // Don't navigate if inside input/textarea
-                const tag = document.activeElement?.tagName?.toLowerCase();
-                if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+                // Don't navigate if inside input/textarea/select/contenteditable
+                if (isEditableElement(document.activeElement)) return;
                 navigate(ROUTES[e.key]);
                 return;
             }
@@ -65,17 +82,17 @@ const useKeyboardShortcuts = () => {
                 return;
             }
 
-            // Close help on Escape
-            if (e.key === 'Escape' && helpOpen) {
+            // Close help on Escape (read latest helpOpen from ref to avoid stale closure)
+            if (e.key === 'Escape' && helpOpenRef.current) {
                 closeHelp();
             }
         };
 
         window.addEventListener('keydown', handler);
         return () => window.removeEventListener('keydown', handler);
-    }, [navigate, toggleHelp, closeHelp, helpOpen]);
+    }, [navigate, toggleHelp, closeHelp]);
 
     return { helpOpen, closeHelp, toggleHelp, shortcuts: SHORTCUT_LABELS };
-};
+}
 
 export default useKeyboardShortcuts;

--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -3,6 +3,8 @@ import { Outlet } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
+import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
+import ShortcutsHelp from '../components/ShortcutsHelp';
 
 /**
  * AdminLayout Component
@@ -12,6 +14,7 @@ import NotificationToast from '../../user/components/NotificationToast';
 const AdminLayout = () => {
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
     const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+    const { helpOpen, closeHelp, shortcuts } = useKeyboardShortcuts();
 
     return (
         <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
@@ -43,6 +46,9 @@ const AdminLayout = () => {
 
             {/* Real-time System Notifications */}
             <NotificationToast />
+
+            {/* Keyboard Shortcuts Help Modal */}
+            <ShortcutsHelp isOpen={helpOpen} onClose={closeHelp} shortcuts={shortcuts} />
 
             {/* Mobile Nav Overlay (Emergency protocols) */}
             {isMobileNavOpen && (

--- a/Frontend/src/components/shared/TicketChat.jsx
+++ b/Frontend/src/components/shared/TicketChat.jsx
@@ -61,7 +61,10 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
 
             // 3. Combine and Sort
             const combined = [...(publicMsgs || []), ...internalMsgs].sort(
-                (a, b) => new Date(a.created_at) - new Date(b.created_at)
+                (a, b) => {
+                const parseDate = (s) => new Date(String(s || '').trim().replace(' ', 'T'));
+                return parseDate(a.created_at) - parseDate(b.created_at);
+            }
             );
 
             setMessages(combined);
@@ -217,13 +220,17 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
     // ─── Helpers ─────────────────────────────────────────────────────────
     const formatTime = (iso) => {
         try {
-            return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+            // Safari-safe date parsing: normalize space-separated timestamps to ISO 8601
+            const normalized = String(iso || '').trim().replace(' ', 'T');
+            return new Date(normalized).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
         } catch { return ''; }
     };
 
     const formatDate = (iso) => {
         try {
-            const d = new Date(iso);
+            // Safari-safe date parsing: normalize space-separated timestamps to ISO 8601
+            const normalized = String(iso || '').trim().replace(' ', 'T');
+            const d = new Date(normalized);
             const today = new Date();
             if (d.toDateString() === today.toDateString()) return 'Today';
             const yesterday = new Date(today);

--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -10,7 +10,9 @@ export const formatTimelineDate = (dateStr) => {
     let date;
     if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
         // If it's a raw string without TZ, assume it was intended as UTC from our backend
-        date = new Date(dateStr + 'Z');
+        // Normalize space-separated dates to ISO 8601 for cross-browser compatibility (Safari fix)
+        const normalized = dateStr.trim().replace(' ', 'T');
+        date = new Date(normalized + 'Z');
     } else {
         date = new Date(dateStr);
     }


### PR DESCRIPTION
Fixes #1409: Ctrl+1-6 navigation, ? for help modal. 3 files, 166 lines added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts help modal in the admin dashboard with a list of shortcuts; shortcuts include navigation keys (Ctrl/Cmd+1–6), toggle help (Ctrl+/ or ?), and Esc to close.

* **Bug Fixes**
  * Improved date parsing to fix Safari issues affecting SLA countdowns, chat message timestamps/sorting, and timeline date displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->