### PR TITLE
Log failed ticket translations

### DIFF
--- a/backend/language_pipeline.py
+++ b/backend/language_pipeline.py
@@ -158,6 +158,7 @@ def detect_and_translate_ticket_text(text: str) -> dict:
             "source_language": "en",
             "source_language_name": "English",
             "was_translated": False,
+            "translation_attempted": False,
             "translation_failed": False,
             "original_text": "",
             "metadata": {},
@@ -174,6 +175,7 @@ def detect_and_translate_ticket_text(text: str) -> dict:
                 "English" if detected_lang in ("en", "eng") else source_name
             ),
             "was_translated": False,
+            "translation_attempted": False,
             "translation_failed": False,
             "original_text": original_text,
             "metadata": {},
@@ -182,10 +184,12 @@ def detect_and_translate_ticket_text(text: str) -> dict:
     lang = str(detected_lang).lower().split("-")[0][:2]
     model_name = f"Helsinki-NLP/opus-mt-{lang}-en"
     translated_text = original_text
+    failure_reason = "translation returned original text"
 
     try:
         translated_text = _run_translation(original_text, model_name)
     except Exception as e:
+        failure_reason = str(e)
         logger.error(
             "Translation failed: %s | detected language: %s",
             str(e),
@@ -193,11 +197,18 @@ def detect_and_translate_ticket_text(text: str) -> dict:
         )
 
     if not translated_text or not translated_text.strip() or translated_text.strip() == original_text:
+        logger.error(
+            "Translation attempted but failed for detected language %s using model %s: %s",
+            detected_lang,
+            model_name,
+            failure_reason if translated_text and translated_text.strip() else "empty translation result",
+        )
         return {
             "text_for_analysis": original_text,
             "source_language": detected_lang,
             "source_language_name": source_name,
             "was_translated": False,
+            "translation_attempted": True,
             "translation_failed": True,
             "original_text": original_text,
             "metadata": {},
@@ -208,6 +219,7 @@ def detect_and_translate_ticket_text(text: str) -> dict:
         "source_language": detected_lang,
         "source_language_name": source_name,
         "was_translated": True,
+        "translation_attempted": True,
         "translation_failed": False,
         "original_text": original_text,
         "metadata": {},

--- a/backend/tests/test_language_pipeline.py
+++ b/backend/tests/test_language_pipeline.py
@@ -273,5 +273,69 @@ class TestTranslateFromEnglish(unittest.TestCase):
             self.assertEqual(result, "Ticket resolved")
 
 
+# ---------------------------------------------------------------------------
+# detect_and_translate_ticket_text
+# ---------------------------------------------------------------------------
+
+class TestDetectAndTranslateTicketText(unittest.TestCase):
+
+    def test_english_text_skips_translation(self):
+        from backend.language_pipeline import detect_and_translate_ticket_text
+
+        with patch("backend.language_pipeline.detect_language", return_value="en"):
+            with patch("backend.language_pipeline._run_translation") as run_translation:
+                result = detect_and_translate_ticket_text("Printer is jammed")
+
+        self.assertEqual(result["text_for_analysis"], "Printer is jammed")
+        self.assertFalse(result["was_translated"])
+        self.assertFalse(result["translation_attempted"])
+        self.assertFalse(result["translation_failed"])
+        run_translation.assert_not_called()
+
+    def test_non_english_translation_success_sets_attempted_flag(self):
+        from backend.language_pipeline import detect_and_translate_ticket_text
+
+        with patch("backend.language_pipeline.detect_language", return_value="es"):
+            with patch("backend.language_pipeline._run_translation", return_value="Printer is broken"):
+                result = detect_and_translate_ticket_text("La impresora está rota")
+
+        self.assertEqual(result["text_for_analysis"], "Printer is broken")
+        self.assertTrue(result["was_translated"])
+        self.assertTrue(result["translation_attempted"])
+        self.assertFalse(result["translation_failed"])
+
+    def test_translation_returning_original_logs_failure(self):
+        from backend.language_pipeline import detect_and_translate_ticket_text
+
+        original = "La impresora está rota"
+        with patch("backend.language_pipeline.detect_language", return_value="es"):
+            with patch("backend.language_pipeline._run_translation", return_value=original):
+                with self.assertLogs("backend.language_pipeline", level="ERROR") as logs:
+                    result = detect_and_translate_ticket_text(original)
+
+        self.assertEqual(result["text_for_analysis"], original)
+        self.assertFalse(result["was_translated"])
+        self.assertTrue(result["translation_attempted"])
+        self.assertTrue(result["translation_failed"])
+        self.assertTrue(any("Translation attempted but failed" in msg for msg in logs.output))
+
+    def test_translation_exception_logs_failure_and_sets_flag(self):
+        from backend.language_pipeline import detect_and_translate_ticket_text
+
+        original = "La impresora está rota"
+        with patch("backend.language_pipeline.detect_language", return_value="es"):
+            with patch(
+                "backend.language_pipeline._run_translation",
+                side_effect=RuntimeError("model unavailable"),
+            ):
+                with self.assertLogs("backend.language_pipeline", level="ERROR") as logs:
+                    result = detect_and_translate_ticket_text(original)
+
+        self.assertEqual(result["text_for_analysis"], original)
+        self.assertTrue(result["translation_attempted"])
+        self.assertTrue(result["translation_failed"])
+        self.assertTrue(any("model unavailable" in msg for msg in logs.output))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:
- log when ticket translation is attempted but returns empty/original text
- add `translation_attempted` to translation context responses
- add regression coverage for successful, skipped, and failed ticket translations

Fixes #1381

Testing:
- python3 -m py_compile backend/language_pipeline.py backend/tests/test_language_pipeline.py
- PYTHONPATH=. python3 -m unittest backend.tests.test_language_pipeline -q

Note:
- Local pytest collection currently hits an existing optional-stub issue in conftest (`prometheus_fastapi_instrumentator.__spec__ is None`), so I validated this focused suite with unittest.