### PR TITLE
fix: propagate API errors instead of silent mock fallback in predictTicket

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { MOCK_TICKETS } from './mockData';
 import { API_CONFIG } from '../config';
 
-const USE_MOCK = true;
+const USE_MOCK = false;
 const API_BASE_URL = API_CONFIG.BACKEND_URL;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -99,22 +99,9 @@ export const api = {
         }
       };
     } catch (error) {
-      console.error("AI Backend Error, falling back to mock:", error);
-      // Fallback to mock logic if backend fails
-      await delay(1000);
-      return {
-        data: {
-          ticket_id: "TCKT-MOCK-" + Math.floor(Math.random() * 10000),
-          category: "Hardware",
-          priority: "Medium",
-          assigned_team: "Hardware Support",
-          auto_resolve: false,
-          routing_confidence: 0.5,
-          duplicate_probability: 0.0,
-          summary: issueText.substring(0, 50) + "...",
-          entities: []
-        }
-      };
+      console.error("AI Backend Error:", error);
+      // Bubble up the error so calling components can handle failure state
+      throw error;
     }
   },
 


### PR DESCRIPTION
## Fixed the bug described in issue #1393

**What was wrong:**
The  function in  silently swallowed all API/network errors and returned fabricated mock data (with ticket_id prefixed ). This gave users a false sense of success while the actual classification outputs were broken — and hid real issues like network failures, server crashes, and authentication problems from developers.

**How I fixed it:**
1. Changed  from  to  so the real backend is always called by default.
2. Replaced the silent mock fallback with  — the exception now bubbles up to calling components so the UI can display an appropriate error screen, toast notification, or retry action.

**Testing:**
- Verified the diff is correct: only the mock fallback block was removed and USE_MOCK flipped.
- The error is still logged via  for developer visibility.

**Note:** The upstream issue specifies that PR branches must target the `gssoc` branch, not `main` — this PR targets `gssoc`.