### PR TITLE
fix: add authentication and authorization to PATCH /tickets/{ticket_id}

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -677,17 +677,24 @@ async def create_ticket(ticket: TicketRecord):
 
 
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict):
+async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
+    # Protect sensitive fields from being overwritten
+    updates.pop("ticket_id", None)
+    updates.pop("owner_id", None)
+
+    user_id = user.get("id") or user.get("sub")
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):
+            if str(ticket.owner_id) != str(user_id):
+                raise HTTPException(status_code=403, detail="Not authorized to modify this ticket")
             # Convert to dict, update, then back to model
             ticket_dict = ticket.dict()
             ticket_dict.update(updates)
             updated_ticket = TicketRecord(**ticket_dict)
             TICKETS_DB[i] = updated_ticket
             return updated_ticket
-    
+
     raise HTTPException(status_code=404, detail="Ticket not found")
 
 


### PR DESCRIPTION
## Summary

Fixes #1386

The  endpoint had no authentication or authorization checks, allowing anyone to modify any ticket without a valid session.

## Changes
- Added  to require a valid Supabase auth token
- Added owner check: only the ticket owner can modify their ticket
- Added protection against overwriting  and  fields

## Testing
- Unauthenticated requests now return 401
- Authenticated users can only modify their own tickets (403 on others)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket updates now require user authentication and ownership verification
  * Users can only modify their own tickets; access requests from other users are rejected with an authorization error
  * Critical ticket metadata is now protected from being overwritten during updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->