### PR TITLE
fix: add missing alt attribute to attachment preview image in Submit.jsx

### DIFF
--- a/Frontend/src/legacy_ui/Submit.jsx
+++ b/Frontend/src/legacy_ui/Submit.jsx
@@ -158,7 +158,7 @@ function Submit() {
                       <label className="text-[var(--stitch-text-main,#111814)] text-sm font-bold">Attachments</label>
                       <div className="flex items-center gap-3 p-3 rounded-lg border border-[var(--stitch-border-light,#e2e8e5)] bg-[var(--stitch-background-light,#f6f8f7)]">
                         <div className="size-10 rounded bg-slate-200 flex items-center justify-center text-slate-500 overflow-hidden">
-                          {imagePreview ? <img src={imagePreview} className="w-full h-full object-cover" /> : <ImageIcon />}
+                          {imagePreview ? <img src={imagePreview} alt="Attachment preview" className="w-full h-full object-cover" /> : <ImageIcon />}
                         </div>
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-[var(--stitch-text-main,#111814)] truncate">{file.name}</p>


### PR DESCRIPTION
## Summary

Fixes #1390

The attachment preview image in Submit.jsx was missing an alt attribute, reducing accessibility for screen readers and impacting SEO.

## Changes
- Added alt text to the attachment preview image in Frontend/src/legacy_ui/Submit.jsx
- Decorative images already had alt="" or descriptive alt text

## Testing
- Verified the image tag now has an alt attribute
- Screen readers can now properly identify the element

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied minor formatting adjustments to the attachment preview UI component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->