### PR TITLE
feat:translation-routes-type-safety-bcp47-request-id [ GSSOC'26 ]

### DIFF
--- a/backend/routes/translation.py
+++ b/backend/routes/translation.py
@@ -4,11 +4,12 @@ Translation API Routes — Multi-Language Ticket Support
 
 import logging
 import re
+import uuid
 from functools import lru_cache
+from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator, model_validator
-from typing import Optional
 
 from backend.services.translation_service import (
     detect_language,
@@ -21,9 +22,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/translation", tags=["translation"])
 
-# BCP-47 language tag regex (covers "en", "en-US", "zh-Hant", "pt-BR", etc.)
-_LANG_TAG_RE = re.compile(r"^[a-zA-Z]{2,3}(?:-[a-zA-Z]{2,8})*$")
+# BCP-47: 2-3 letter primary tag, optional subtags that are alpha OR numeric
+# (covers "en", "en-US", "zh-Hant", "zh-419" — UN M.49 numeric region codes).
+# Previous regex used [a-zA-Z]{2,8} for subtags, rejecting valid codes like zh-419.
+_LANG_TAG_RE = re.compile(r"^[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*$")
 
+
+# ─── Shared lang-tag validator (DRY) ─────────────────────────────────────────
+# Previously duplicated as validate_lang_tag in both request model classes.
+
+def _validate_lang_tag(v: Optional[str]) -> Optional[str]:
+    if v is None:
+        return v
+    if not _LANG_TAG_RE.match(v):
+        raise ValueError(
+            f"Invalid BCP-47 language tag: '{v}'. "
+            "Expected format like 'en', 'en-US', 'zh-Hant', or 'zh-419'."
+        )
+    return v
+
+
+# ─── Request schemas ──────────────────────────────────────────────────────────
 
 class TranslateTextRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=5000)
@@ -33,14 +52,7 @@ class TranslateTextRequest(BaseModel):
     @field_validator("target_lang", "source_lang", mode="before")
     @classmethod
     def validate_lang_tag(cls, v: Optional[str]) -> Optional[str]:
-        if v is None:
-            return v
-        if not _LANG_TAG_RE.match(v):
-            raise ValueError(
-                f"Invalid BCP-47 language tag: '{v}'. "
-                "Expected format like 'en', 'en-US', or 'zh-Hant'."
-            )
-        return v
+        return _validate_lang_tag(v)
 
 
 class MessageSchema(BaseModel):
@@ -51,28 +63,32 @@ class MessageSchema(BaseModel):
 
 
 class TranslateTicketRequest(BaseModel):
-    subject: Optional[str] = None
-    description: Optional[str] = None
+    # FIX 6: subject and description now have max_length to prevent unbounded
+    # strings reaching the translation service.
+    subject: Optional[str] = Field(default=None, max_length=500)
+    description: Optional[str] = Field(default=None, max_length=20000)
     messages: Optional[list[MessageSchema]] = None
     target_lang: str = Field(default="en", max_length=10)
 
     @field_validator("target_lang", mode="before")
     @classmethod
     def validate_lang_tag(cls, v: str) -> str:
-        if not _LANG_TAG_RE.match(v):
-            raise ValueError(
-                f"Invalid BCP-47 language tag: '{v}'. "
-                "Expected format like 'en', 'en-US', or 'zh-Hant'."
-            )
-        return v
+        return _validate_lang_tag(v)  # type: ignore[return-value]
 
     @model_validator(mode="after")
-    def require_translatable_content(self):
-        """Reject requests where all translatable fields are None/empty."""
-        has_subject = self.subject is not None and self.subject.strip()
-        has_description = self.description is not None and self.description.strip()
-        has_messages = self.messages is not None and len(self.messages) > 0
-        if not (has_subject or has_description or has_messages):
+    def require_translatable_content(self) -> "TranslateTicketRequest":
+        """
+        Reject all-empty bodies. Also strips stored values so a
+        whitespace-only subject does not silently reach the service.
+        FIX 9: previously .strip() was checked for truthiness but the
+        original un-stripped value was kept on the model.
+        """
+        if self.subject is not None:
+            self.subject = self.subject.strip() or None
+        if self.description is not None:
+            self.description = self.description.strip() or None
+
+        if not any([self.subject, self.description, self.messages]):
             raise ValueError(
                 "At least one of 'subject', 'description', or 'messages' must be provided."
             )
@@ -83,7 +99,7 @@ class DetectLanguageRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=5000)
 
 
-# --- Response Models ---
+# ─── Response schemas ─────────────────────────────────────────────────────────
 
 class TranslationData(BaseModel):
     translated: str
@@ -97,8 +113,26 @@ class TranslateResponse(BaseModel):
     data: TranslationData
 
 
+class TicketTranslationData(BaseModel):
+    """
+    FIX 2: Dedicated response model for /translate-ticket.
+    Previously TranslateResponse (shape: translated/source_lang/target_lang/cached)
+    was reused here, but translate_ticket() returns subject/description/messages —
+    a completely different shape that always failed response_model validation.
+    """
+    subject: Optional[str] = None
+    description: Optional[str] = None
+    messages: Optional[list[dict[str, Any]]] = None
+    target_lang: str
+
+
+class TranslateTicketResponse(BaseModel):
+    success: bool
+    data: TicketTranslationData
+
+
 class DetectData(BaseModel):
-    language: Optional[str]
+    language: Optional[str] = None
     language_name: str
     supported: bool
 
@@ -113,20 +147,42 @@ class LanguagesResponse(BaseModel):
     data: dict[str, str]
 
 
-# --- Cached wrapper for supported languages ---
+# ─── Language cache ───────────────────────────────────────────────────────────
 
 @lru_cache(maxsize=1)
 def _cached_supported_languages() -> dict[str, str]:
-    """Cache supported languages to avoid repeated calls."""
+    """
+    Cache supported languages for the process lifetime.
+    FIX 4: Paired with invalidate_languages_cache() so callers (tests,
+    admin endpoints) can clear the cache without restarting the process.
+    """
     return get_supported_languages()
 
 
+def invalidate_languages_cache() -> None:
+    """Invalidate the supported-languages cache (e.g. after an admin update)."""
+    _cached_supported_languages.cache_clear()
+
+
+# ─── Request-ID helper ────────────────────────────────────────────────────────
+
+def _request_id(request: Request) -> str:
+    """
+    FIX 10: Return X-Request-ID header if present, else generate a UUID.
+    Propagated into every log line so requests can be traced across services.
+    """
+    return request.headers.get("x-request-id") or str(uuid.uuid4())
+
+
+# ─── Routes ───────────────────────────────────────────────────────────────────
+
 @router.post("/translate", response_model=TranslateResponse)
-async def translate(request: TranslateTextRequest):
+async def translate(request: TranslateTextRequest, req: Request) -> TranslateResponse:
     """Translate text to target language with auto-detection."""
+    rid = _request_id(req)
     logger.info(
-        "translate: text_len=%d, target=%s, source=%s",
-        len(request.text), request.target_lang, request.source_lang,
+        "translate: request_id=%s text_len=%d target=%s source=%s",
+        rid, len(request.text), request.target_lang, request.source_lang,
     )
     try:
         result = translate_text(
@@ -134,20 +190,25 @@ async def translate(request: TranslateTextRequest):
             target_lang=request.target_lang,
             source_lang=request.source_lang,
         )
-        return {"success": True, "data": result}
+        return TranslateResponse(success=True, data=result)
     except Exception:
-        logger.exception("Translation failed for text_len=%d", len(request.text))
+        logger.exception("translate: request_id=%s failed", rid)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Translation service temporarily unavailable. Please try again later.",
         )
 
 
-@router.post("/translate-ticket", response_model=TranslateResponse)
-async def translate_ticket_endpoint(request: TranslateTicketRequest):
+@router.post("/translate-ticket", response_model=TranslateTicketResponse)
+async def translate_ticket_endpoint(
+    request: TranslateTicketRequest, req: Request
+) -> TranslateTicketResponse:
     """Translate entire ticket content to target language."""
+    rid = _request_id(req)
+    # FIX 8: Restore full log line (msg_count, has_subject, has_desc regressed in prior version).
     logger.info(
-        "translate_ticket: target=%s, has_subject=%s, has_desc=%s, msg_count=%d",
+        "translate-ticket: request_id=%s target=%s has_subject=%s has_desc=%s msg_count=%d",
+        rid,
         request.target_lang,
         request.subject is not None,
         request.description is not None,
@@ -160,17 +221,21 @@ async def translate_ticket_endpoint(request: TranslateTicketRequest):
         if request.description:
             ticket_data["description"] = request.description
         if request.messages:
-            ticket_data["messages"] = [m.model_dump() for m in request.messages]
+            # FIX 3: exclude_none=True prevents id=None / author=None being
+            # forwarded to the translation service.
+            ticket_data["messages"] = [
+                m.model_dump(exclude_none=True) for m in request.messages
+            ]
 
         result = translate_ticket(ticket_data, target_lang=request.target_lang)
-        return {"success": True, "data": result}
+        return TranslateTicketResponse(success=True, data=result)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
         )
     except Exception:
-        logger.exception("Ticket translation failed")
+        logger.exception("translate-ticket: request_id=%s failed", rid)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Ticket translation service temporarily unavailable. Please try again later.",
@@ -178,9 +243,10 @@ async def translate_ticket_endpoint(request: TranslateTicketRequest):
 
 
 @router.post("/detect", response_model=DetectResponse)
-async def detect(request: DetectLanguageRequest):
+async def detect(request: DetectLanguageRequest, req: Request) -> DetectResponse:
     """Detect the language of the given text."""
-    logger.info("detect: text_len=%d", len(request.text))
+    rid = _request_id(req)
+    logger.info("detect: request_id=%s text_len=%d", rid, len(request.text))
     lang = detect_language(request.text)
     if not lang:
         raise HTTPException(
@@ -188,17 +254,17 @@ async def detect(request: DetectLanguageRequest):
             detail="Could not detect language from the provided text.",
         )
     languages = _cached_supported_languages()
-    return {
-        "success": True,
-        "data": {
-            "language": lang,
-            "language_name": languages.get(lang, "Unknown"),
-            "supported": lang in languages,
-        },
-    }
+    return DetectResponse(
+        success=True,
+        data=DetectData(
+            language=lang,
+            language_name=languages.get(lang, "Unknown"),
+            supported=lang in languages,
+        ),
+    )
 
 
 @router.get("/languages", response_model=LanguagesResponse)
-async def list_languages():
-    """List supported languages for translation."""
-    return {"success": True, "data": _cached_supported_languages()}
+async def list_languages() -> LanguagesResponse:
+    """List all supported languages for translation."""
+    return LanguagesResponse(success=True, data=_cached_supported_languages())git 


### PR DESCRIPTION
Closes #1444 

────────────────────────────────────────────────────────────

## Summary
Fixes 9 bugs introduced or left over in the previous translation-routes PR.
Most critically: /translate-ticket was returning 500 on every success due to
a wrong response_model, and Any was causing a NameError at startup. No
service-layer or database changes.

────────────────────────────────────────────────────────────

## Changes

FIX 1 — Any imported
  typing import block: added Any

FIX 2 — Correct response schema for /translate-ticket
  Added TicketTranslationData(subject, description, messages, target_lang)
  Added TranslateTicketResponse(success, data: TicketTranslationData)
  Changed response_model=TranslateResponse → response_model=TranslateTicketResponse

FIX 3 — exclude_none on MessageSchema serialisation
  m.model_dump() → m.model_dump(exclude_none=True)
  Prevents null id/author being forwarded to translation service

FIX 4 — BCP-47 numeric region subtags
  _LANG_TAG_RE subtag class: [a-zA-Z]{2,8} → [a-zA-Z0-9]{2,8}
  zh-419 and other UN M.49 codes now accepted

FIX 5 — max_length on subject and description
  subject: Optional[str] = Field(default=None, max_length=500)
  description: Optional[str] = Field(default=None, max_length=20000)

FIX 6 — DRY lang-tag validator
  Module-level _validate_lang_tag(v) extracted
  Both field validators delegate to it; single point of change

FIX 7 — invalidate_languages_cache() helper
  Paired with _cached_supported_languages for test and admin use
  Calls _cached_supported_languages.cache_clear()

FIX 8 — Restored full translate-ticket log line
  has_subject=%s has_desc=%s msg_count=%d re-added

FIX 9 — Whitespace-only fields stripped and stored
  require_translatable_content now writes back:
    self.subject = self.subject.strip() or None
    self.description = self.description.strip() or None
  Subject="   " now correctly rejected and not forwarded

FIX 10 — X-Request-ID tracing
  _request_id(req: Request) reads header or generates UUID
  req: Request injected into all four route signatures
  request_id=%s included in every logger.info / logger.exception call

────────────────────────────────────────────────────────────

## Testing Done
- [x] POST /translate-ticket with valid subject returns 200 (not 500)
- [x] POST /translate-ticket response body matches TicketTranslationData shape
- [x] POST /translate-ticket with subject="   " returns 422
- [x] POST /translate with Any in type hint causes no NameError
- [x] MessageSchema with no id/author serialises without null fields
- [x] POST /translate with target_lang="zh-419" returns 200
- [x] POST /translate with target_lang="xy99" returns 422
- [x] POST /translate-ticket subject > 500 chars returns 422
- [x] POST /translate-ticket description > 20000 chars returns 422
- [x] X-Request-ID header echoed in log lines when provided
- [x] UUID generated in log lines when X-Request-ID absent
- [x] invalidate_languages_cache() clears cache; next call re-fetches
- [x] translate-ticket log line includes has_subject, has_desc, msg_count