### PR TITLE
test: cover translation service fallback paths

### DIFF
--- a/backend/routes/translation.py
+++ b/backend/routes/translation.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/translation", tags=["translation"])
 
 # BCP-47 language tag regex (covers "en", "en-US", "zh-Hant", "pt-BR", etc.)
-_LANG_TAG_RE = re.compile(r"^[a-zA-Z]{2,3}(?:-[a-zA-Z]{2,8})*$")
+_LANG_TAG_RE = re.compile(r"^[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*$")
 
 
 class TranslateTextRequest(BaseModel):

--- a/backend/services/translation_service.py
+++ b/backend/services/translation_service.py
@@ -5,6 +5,7 @@ Translation helpers for locale detection, MyMemory API fallback, and ticket tran
 from __future__ import annotations
 
 import logging
+import re
 from typing import Optional
 from functools import lru_cache
 
@@ -21,7 +22,7 @@ MAX_CACHE_SIZE = 1000
 MAX_TEXT_LENGTH = 5000
 
 # BCP-47 language tag regex
-_LANG_TAG_RE = re.compile(r"^[a-zA-Z]{2,3}(?:-[a-zA-Z]{2,8})*$")
+_LANG_TAG_RE = re.compile(r"^[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*$")
 
 # Supported languages for translation
 SUPPORTED_LANGUAGES = {
@@ -190,7 +191,7 @@ def translate_text(
 
         # Non-200 API status
         details = data.get("responseDetails", "Unknown error")
-        logger.warning("[TranslationService] API returned status %s: %s", status, details)
+        logger.warning("[TranslationService] API returned status %s: %s", data.get("responseStatus"), details)
         return {"translated": text, "source_lang": source_lang, "target_lang": target_lang, "cached": False}
 
     except _requests_lib.exceptions.Timeout:
@@ -247,7 +248,7 @@ def translate_ticket(ticket_data: dict, target_lang: str = "en") -> dict:
         desc_result = translate_text(ticket_data["description"], target_lang=target_lang)
         result["translations"]["description"] = desc_result
         if not result["original_language"]:
-            result["original_language"] = description_result["source_lang"]
+            result["original_language"] = desc_result["source_lang"]
 
     if "messages" in ticket_data:
         translated_messages = []

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -5,7 +5,7 @@ Covers: BCP-47 validation, duplicate model removal, all-None body rejection,
 """
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock
 from fastapi.testclient import TestClient
 
 from backend.routes.translation import (
@@ -219,3 +219,22 @@ class TestTranslationService:
             result = translate_ticket({"subject": "hello"}, target_lang="es")
             assert "subject" in result["translations"]
             mock.assert_called_once_with("hello", target_lang="es")
+
+    def test_translate_ticket_description_sets_original_language(self):
+        with patch("backend.services.translation_service.translate_text") as mock:
+            mock.return_value = {"translated": "hola", "source_lang": "es", "target_lang": "en", "cached": False}
+            result = translate_ticket({"description": "hola"}, target_lang="en")
+            assert result["original_language"] == "es"
+            assert result["translations"]["description"]["translated"] == "hola"
+
+    def test_translate_text_non_200_response_falls_back(self):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"responseStatus": 403, "responseDetails": "quota exceeded"}
+
+        with patch("backend.services.translation_service._requests_lib.get", return_value=mock_response):
+            result = translate_text("hello", target_lang="es", source_lang="en")
+
+        assert result["translated"] == "hello"
+        assert result["source_lang"] == "en"
+        assert result["target_lang"] == "es"


### PR DESCRIPTION
## 🚀 Work Completed
- Adds focused regression coverage for the translation service fallback paths requested in #1370.
- Fixes import/runtime issues found while exercising `backend.services.translation_service` directly.
- Keeps the PR scoped to translation validation and service behavior.

## 🔍 Requirement Match
- Locale detection: existing locale tests continue to cover ASCII/default detection.
- Fallback workflow: adds coverage for non-200 MyMemory responses returning the original text safely.
- Ticket translation: adds coverage for description-only tickets preserving `original_language`.
- BCP-47 validation: supports numeric region subtags such as `es-419`.

## 💻 Changes Included
- Import `re` in `backend/services/translation_service.py` so `_LANG_TAG_RE` initializes correctly.
- Replace undefined fallback variables (`status`, `description_result`) with the actual response/description values.
- Align route/service language-tag regex with numeric region subtags.
- Add pytest cases for description-only ticket translation and non-200 API fallback.

## 🧪 Verification
- `python -m pytest tests/test_translation.py -q`
- Result: `41 passed in 1.37s`

References: Fixes #1370
