### PR TITLE
docs : added docstring to healthcheck run_check with usage example

### DIFF
--- a/backend/healthcheck.py
+++ b/backend/healthcheck.py
@@ -323,6 +323,30 @@ def _single_attempt(cfg: Config, attempt: int) -> CheckResult:
 # ─── Retry Loop ───────────────────────────────────────────────────────────────
 
 def run_check(cfg: Config) -> CheckResult:
+    """
+    Run a single health-check Config, with retries and exponential backoff.
+
+    Returns the final CheckResult (either the first success or the last
+    failure after exhausting retries). The caller can inspect
+    ``result.success`` and ``result.failure_reason`` to decide what to
+    do next.
+
+    Usage example (programmatic):
+
+        from backend.healthcheck import Config, run_check, main
+
+        cfg = Config(
+            url="https://helpdeskaiv1.vercel.app/ready",
+            timeout=3.0,
+            retries=2,
+            expected_status=(200, 299),
+            expected_json_key="status",
+            expected_json_value="ok",
+        )
+        result = run_check(cfg)
+        if not result.success:
+            raise SystemExit(f"health check failed: {result.failure_reason}")
+    """
     delay = cfg.retry_delay
     last: Optional[CheckResult] = None
 


### PR DESCRIPTION
Refs #1483.

Summary of What Has Been Done:
Expanded the docstring of run_check in backend/healthcheck.py to
describe the function's behaviour (retries with exponential backoff,
returns the final CheckResult), document the .success /
.failure_reason contract, and include a usage example showing how
a programmatic caller would construct a Config, run the check, and
react to a failure. No runtime behaviour was changed.

Changes Made:
- backend/healthcheck.py: added a docstring to run_check().

Verification:
- `python -c "from backend.healthcheck import run_check; help(run_check)"`
  renders the new docstring.

Impact it Made:
- Makes the public entry point of the healthcheck utility self-
  documenting for future contributors.
- Documents the .success / .failure_reason contract that callers
  rely on.