### PR TITLE
feat : added request ID middleware that propagates X-Request-ID

### DIFF
--- a/backend/middleware/request_id.py
+++ b/backend/middleware/request_id.py
@@ -1,0 +1,60 @@
+"""
+Request ID Middleware — generates or propagates a unique request ID
+for every incoming request and echoes it in the X-Request-ID
+response header. The ID is also stored on request.state for use in
+logging and error handlers.
+
+Usage in main.py:
+    from backend.middleware.request_id import add_request_id_middleware
+    add_request_id_middleware(app)
+"""
+
+import logging
+import uuid
+
+from fastapi import FastAPI, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+
+def _new_request_id() -> str:
+    """Return a fresh UUID4 hex string (32 chars, no dashes)."""
+    return uuid.uuid4().hex
+
+
+def get_request_id(request: Request) -> str:
+    """Return the request ID stored on request.state, or a new one."""
+    rid = getattr(request.state, "request_id", None)
+    if not rid:
+        rid = _new_request_id()
+        request.state.request_id = rid
+    return rid
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Assign a request ID to every request and echo it in the response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        # Honour an inbound X-Request-ID header if the upstream (e.g. a
+        # load balancer or the front-end) already set one.
+        inbound = request.headers.get(REQUEST_ID_HEADER, "").strip()
+        request_id = inbound or _new_request_id()
+        request.state.request_id = request_id
+
+        response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response
+
+
+def add_request_id_middleware(app: FastAPI) -> None:
+    """
+    Attach the RequestIDMiddleware to the FastAPI app.
+
+    Call this BEFORE adding routes so the middleware wraps every
+    request, but AFTER any CORS / security middleware that should
+    run first.
+    """
+    app.add_middleware(RequestIDMiddleware)

--- a/backend/tests/test_request_id_middleware.py
+++ b/backend/tests/test_request_id_middleware.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for backend/middleware/request_id.py.
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")),
+)
+
+from backend.middleware.request_id import (
+    RequestIDMiddleware,
+    add_request_id_middleware,
+    get_request_id,
+    _new_request_id,
+    REQUEST_ID_HEADER,
+)
+
+
+def _make_request(inbound_id=None):
+    request = mock.MagicMock()
+    request.headers = {}
+    if inbound_id is not None:
+        request.headers[REQUEST_ID_HEADER] = inbound_id
+    # Use a real attribute for request.state
+    class _State:
+        pass
+    request.state = _State()
+    return request
+
+
+def _make_response():
+    response = mock.MagicMock()
+    response.headers = {}
+    return response
+
+
+class TestNewRequestId(unittest.TestCase):
+    def test_returns_string(self):
+        self.assertIsInstance(_new_request_id(), str)
+
+    def test_unique(self):
+        ids = {_new_request_id() for _ in range(100)}
+        self.assertEqual(len(ids), 100)
+
+    def test_is_hex(self):
+        rid = _new_request_id()
+        # 32 char hex
+        self.assertEqual(len(rid), 32)
+        int(rid, 16)  # parses as hex
+
+
+class TestGetRequestId(unittest.TestCase):
+    def test_returns_existing(self):
+        request = _make_request()
+        request.state.request_id = "preset"
+        self.assertEqual(get_request_id(request), "preset")
+
+    def test_generates_if_missing(self):
+        request = _make_request()
+        rid = get_request_id(request)
+        self.assertEqual(len(rid), 32)
+        # Side effect: stored on state
+        self.assertEqual(request.state.request_id, rid)
+
+
+class TestAddMiddleware(unittest.TestCase):
+    def test_adds_middleware(self):
+        app = mock.MagicMock()
+        add_request_id_middleware(app)
+        self.assertEqual(app.add_middleware.call_count, 1)
+        call = app.add_middleware.call_args
+        self.assertEqual(call.args[0].__name__, "RequestIDMiddleware")
+
+
+class TestMiddlewareDispatch(unittest.TestCase):
+    def _run_dispatch(self, mw, request):
+        async def call_next(_):
+            return _make_response()
+
+        return asyncio.run(mw.dispatch(request, call_next))
+
+    def test_generates_id_when_no_inbound(self):
+        mw = RequestIDMiddleware(mock.MagicMock())
+        request = _make_request()
+        response = self._run_dispatch(mw, request)
+        # request.state.request_id was set
+        self.assertEqual(len(request.state.request_id, ), 32)
+        # response echoes the same id
+        self.assertEqual(response.headers[REQUEST_ID_HEADER], request.state.request_id)
+
+    def test_propagates_inbound_id(self):
+        mw = RequestIDMiddleware(mock.MagicMock())
+        request = _make_request(inbound_id="upstream-id-123")
+        response = self._run_dispatch(mw, request)
+        self.assertEqual(request.state.request_id, "upstream-id-123")
+        self.assertEqual(response.headers[REQUEST_ID_HEADER], "upstream-id-123")
+
+    def test_inbound_whitespace_stripped(self):
+        # The middleware uses .strip() — verify behaviour via the request
+        # headers that were set
+        mw = RequestIDMiddleware(mock.MagicMock())
+        request = _make_request(inbound_id="   ")
+        response = self._run_dispatch(mw, request)
+        # Whitespace is treated as missing; a new id is generated
+        self.assertNotEqual(request.state.request_id.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #1488.

Summary of What Has Been Done:
Added a new request-ID propagation middleware that assigns (or
honours an inbound) X-Request-ID per request, stores the id on
request.state for downstream handlers, and echoes it in the
response. A new test module covers the helper, the dispatch
behaviour, and the add_middleware setup.

Changes Made:
- backend/middleware/request_id.py (new file)
  - _new_request_id() returning a fresh UUID4 hex string
  - get_request_id(request) helper
  - RequestIDMiddleware: dispatch honours inbound X-Request-ID
    header, stores the id on request.state, echoes it in the
    response
  - add_request_id_middleware(app) setup helper
- backend/tests/test_request_id_middleware.py (new file, 9 tests)
  - _new_request_id: string, unique, hex
  - get_request_id: returns existing, generates if missing
  - add_middleware: registers the middleware
  - dispatch: generates when missing, propagates inbound,
    whitespace treated as missing

Impact it Made:
- Lets the front-end / API clients log the X-Request-ID returned in
  every response so failed requests can be correlated with server
  logs.
- Provides a stable, well-known header to set on request.state for
  future logging and error-handling improvements.
- No existing endpoint behaviour is changed because the middleware
  only sets a header.