### PR TITLE
fix : added warning log when SLA engine receives an unknown priority

### DIFF
--- a/backend/services/sla_engine.py
+++ b/backend/services/sla_engine.py
@@ -134,7 +134,7 @@ class SLAEngine:
     def evaluate_ticket(self, ticket: dict) -> dict:
         """
         Evaluate a single ticket's SLA status.
-        
+
         Returns dict with:
           - sla_status: SLAStatus value
           - remaining_seconds: seconds until breach (negative if breached)
@@ -144,6 +144,12 @@ class SLAEngine:
           - policy: the applied SLA policy
         """
         priority_key = (ticket.get("priority") or "medium").lower().strip()
+        if priority_key not in SLA_POLICIES:
+            logger.warning(
+                "[SLAEngine] Unknown priority %r for ticket %s; falling back to 'medium'.",
+                ticket.get("priority"),
+                ticket.get("id"),
+            )
         policy = SLA_POLICIES.get(priority_key, SLA_POLICIES["medium"])
 
         # Resolve the start time: use sla_started_at if set, else created_at


### PR DESCRIPTION
Refs #1490.

Summary of What Has Been Done:
Added a logger.warning in backend/services/sla_engine.py
evaluate_ticket when the ticket's priority is not in SLA_POLICIES.
The existing fallback to the "medium" policy is preserved; the
warning makes misclassifications discoverable in the logs.

Changes Made:
- backend/services/sla_engine.py: added a single logger.warning
  inside evaluate_ticket for the unknown-priority path.

Impact it Made:
- Makes misclassified-priority tickets visible in the logs without
  requiring extra debugging.
- No behaviour change for valid priorities.