### PR TITLE
fix : added threshold range validation in duplicate_service.check_duplicate

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -312,6 +312,14 @@ class DuplicateService:
         """
         self.load()
 
+        # Validate the threshold up front so a bad override is reported
+        # even when the model is unavailable (degraded mode).
+        active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD
+        if active_threshold is not None and not (0.0 <= active_threshold <= 1.0):
+            raise ValueError(
+                f"threshold must be between 0.0 and 1.0, got {active_threshold!r}"
+            )
+
         # If model is not available, return no duplicate found
         if not self.is_available():
             print(
@@ -323,8 +331,6 @@ class DuplicateService:
                 "similarity": 0.0,
             }
 
-        # Use provided threshold or default to global constant
-        active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD
         use_default_threshold = threshold is None
 
         # Try the result cache only when using the default threshold so we


### PR DESCRIPTION
Refs #1492.

Summary of What Has Been Done:
Added a range validation in backend/services/duplicate_service.py
check_duplicate that raises ValueError when the threshold is outside
[0.0, 1.0]. The check runs before the model-availability early
return so a bad override is reported even in degraded mode.

Changes Made:
- backend/services/duplicate_service.py: added the threshold range
  check at the top of check_duplicate.

Verification:
- threshold=1.5 raises ValueError.
- threshold=-0.5 raises ValueError.
- threshold=0.0, 0.5, 1.0 return normally.

Impact it Made:
- Catches programming errors at the boundary instead of producing
  silently-wrong duplicate-check results.
- Validates the threshold even in degraded mode so a misconfigured
  caller is reported immediately.