### PR TITLE
fix : raised ValueError on empty text in classifier_service.predict

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -136,6 +136,8 @@ class ClassifierService:
         Results are cached in Redis by input text so repeated identical tickets
         skip the full transformer forward-pass entirely.
         """
+        if not text or not text.strip():
+            raise ValueError("text must be a non-empty string")
         start_time = time.perf_counter()
         try:
             self.load()


### PR DESCRIPTION
Refs #1496.

Summary of What Has Been Done:
Added a guard at the top of ClassifierService.predict() in
backend/services/classifier_service.py that raises ValueError when
the input text is None, empty, or whitespace-only. No other
behaviour was changed.

Changes Made:
- backend/services/classifier_service.py: added the early-return
  check in predict().

Verification:
- text="" raises ValueError.
- text="   " raises ValueError.

Impact it Made:
- Surfaces a programming error at the boundary instead of returning
  a low-confidence prediction.
- Mirrors the validation done in classifier_v3.