### PR TITLE
fix: reset subcategory and re-derive priority when keyword override changes category

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -136,8 +136,12 @@ class ClassifierService:
                 if category == "General" or confidence < 0.9:
                     category = cat
                     assigned_team = TEAM_MAP.get(cat, "General Support")
+                    # Reset subcategory and re-derive priority to keep prediction consistent
+                    subcategory = "General"
+                    priority = PRIORITY_MAP.get(subcategory, "Medium")
+                    auto_resolve = subcategory in AUTO_RESOLVE_SUBS
                     # Boost confidence significantly for verified technical signals
-                    confidence = max(confidence, 0.92) 
+                    confidence = max(confidence, 0.92)
                     break
 
         return {


### PR DESCRIPTION
Fixes #1438

## Description
The regex keyword override block in `predict()` in `classifier_service.py` was updating `category` and `assigned_team` but leaving `subcategory`, `priority`, and `auto_resolve` unchanged from the original model prediction. This caused internally inconsistent outputs where e.g. `category: "Network"` was paired with `subcategory: "Password Reset"` — a subcategory that belongs to the Access category. Downstream auto-resolve and priority logic was silently operating on these mismatched values.

Fix resets `subcategory` to `"General"` and re-derives `priority` and `auto_resolve` from the new category context whenever the override fires.

## Related Issue
Closes #1438

## Type of Change
- [x] Bug fix

## Screenshots
N/A

## Testing
- [x] Ran `git diff --check`
- [x] Verified the changed behavior manually — submitted test tickets with network keywords where base model prediction was Access category and confirmed returned subcategory, priority, and auto_resolve are now consistent with the overridden category
- [x] Updated or added tests where appropriate — N/A, logic change is self-contained

## Checklist
- [x] My changes are focused on the linked issue
- [x] I have reviewed my own code
- [x] I have not introduced unrelated formatting or generated-file changes
- [x] Documentation is updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed technical keyword classification override to properly recalculate related fields, ensuring consistent priority assignment and auto-resolution behavior when keyword-based categorization is triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->