### PR TITLE
Feature: Add Docker multi-stage containerization support for HELPDESK.AI deployment (Refreshed) (#1384)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,76 @@
-# --- Stage 1: Build & Dependencies ---
-FROM python:3.11-slim as builder
+# =============================================================================
+# Multi-stage Dockerfile for HELPDESK.AI — Production Backend Image
+# Stage 1 (builder): Install all Python dependencies including torch/transformers
+# Stage 2 (production): Minimal runtime image with non-root user & health check
+# Base: python:3.11-slim-bookworm
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder — install all Python dependencies
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /build
 
-# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install python dependencies into a virtual environment
-RUN python -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
-# --- Stage 2: Runtime ---
-FROM python:3.11-slim
-
-WORKDIR /app
-
-# Copy virtual environment from builder
-COPY --from=builder /opt/venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    libgl1 \
+    libglib2.0-0 \
     libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy application code
-COPY . .
+COPY requirements.txt .
+RUN python -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
-# Environment variables
-ENV PYTHONUNBUFFERED=1
-ENV ALLOW_DEGRADED_STARTUP=1
-ENV PORT=7860
+COPY backend /build/backend
+RUN /opt/venv/bin/python -m compileall -q /build/backend || true
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: production — minimal runtime image
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS production
+
+LABEL maintainer="HELPDESK.AI Team" \
+      version="2.0.0" \
+      description="AI Helpdesk — production backend image"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    libglib2.0-0 \
+    libgomp1 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid 1001 --no-create-home --shell /bin/false appuser
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /app
+
+COPY --from=builder /build/backend /app/backend
+
+ENV PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    ALLOW_DEGRADED_STARTUP=1 \
+    PORT=7860
+
+USER appuser
 
 EXPOSE 7860
 
-# Run the application
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD ["python", "/app/backend/healthcheck.py"]
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860", "--workers", "1"]

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,64 +1,82 @@
-# Multi-stage Dockerfile for HelpDesk.ai Backend
-# Stage 1: Build stage - install dependencies
-FROM python:3.10-slim as builder
+# =============================================================================
+# Multi-stage Dockerfile for HELPDESK.AI — Production Backend Image
+#
+# NOTE: This file is provided for compatibility. The canonical Dockerfile is
+#       the root `Dockerfile`, which already uses multi-stage builds.
+#       Both files produce equivalent images.
+#
+# Stage 1 (builder): Install all Python dependencies including torch/transformers
+# Stage 2 (production): Minimal runtime image with non-root user & health check
+# Base: python:3.11-slim-bookworm
+# Usage: docker build -f Dockerfile.multi-stage -t helpdesk-ai:latest .
+# =============================================================================
 
-WORKDIR /app
+# ---------------------------------------------------------------------------
+# Stage 1: builder — install all Python dependencies
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS builder
 
-# Install system dependencies required for building Python packages
-RUN apt-get update && apt-get install -y \
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy requirements file
-COPY backend/requirements.txt .
-
-# Create virtual environment and install dependencies
-RUN python -m venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
-
-# Install Python dependencies
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
-
-# Stage 2: Production stage - minimal runtime image
-FROM python:3.10-slim as production
-
-LABEL version="2.0.0" rebuild_trigger="2026-05-31" maintainer="HelpDesk.ai"
-
-# Install only runtime system dependencies
-RUN apt-get update && apt-get install -y \
+    git \
     libgl1 \
     libglib2.0-0 \
+    libgomp1 \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security
-RUN groupadd -r helpdesk && useradd -r -g helpdesk -d /app -s /sbin/nologin helpdesk
+COPY requirements.txt .
+RUN python -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
-WORKDIR /app
+COPY backend /build/backend
+RUN /opt/venv/bin/python -m compileall -q /build/backend || true
 
-# Copy virtual environment from builder stage
+
+# ---------------------------------------------------------------------------
+# Stage 2: production — minimal runtime image
+# ---------------------------------------------------------------------------
+FROM python:3.11-slim-bookworm AS production
+
+LABEL maintainer="HELPDESK.AI Team" \
+      version="2.0.0" \
+      description="AI Helpdesk — production backend image"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    libglib2.0-0 \
+    libgomp1 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid 1001 --no-create-home --shell /bin/false appuser
+
 COPY --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy application code
-COPY backend /app/backend
+WORKDIR /app
 
-# Set Python path
-ENV PYTHONPATH=/app
+COPY --from=builder /build/backend /app/backend
 
-# Create directory for logs and temporary files
-RUN mkdir -p /app/logs /app/tmp && \
-    chown -R helpdesk:helpdesk /app
+ENV PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    ALLOW_DEGRADED_STARTUP=1 \
+    PORT=7860
 
-# Switch to non-root user
-USER helpdesk
+USER appuser
 
-# Expose port 7860 (Hugging Face Spaces default)
 EXPOSE 7860
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=5s --start-period=120s --retries=3 \
-    CMD ["python", "backend/healthcheck.py"]
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD ["python", "/app/backend/healthcheck.py"]
 
-# Run the FastAPI server via Uvicorn
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860", "--workers", "1"]

--- a/Frontend/.dockerignore
+++ b/Frontend/.dockerignore
@@ -1,0 +1,17 @@
+node_modules/
+.npm-cache/
+dist/
+build/
+.git/
+.gitignore
+.github/
+*.md
+.env
+.env.local
+.env.*.local
+.DS_Store
+Thumbs.db
+desktop.ini
+**/__pycache__/
+**/*.pyc
+**/*.pyo

--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,0 +1,38 @@
+# =============================================================================
+# Multi-stage Dockerfile for HELPDESK.AI Frontend (Vite + nginx)
+# Stage 1 (builder): Build the Vite/React application
+# Stage 2 (production): Serve via nginx:alpine
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder — install deps and compile Vite production bundle
+# ---------------------------------------------------------------------------
+FROM node:20-alpine AS builder
+
+WORKDIR /build
+
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: production — serve static files via nginx
+# ---------------------------------------------------------------------------
+FROM nginx:stable-alpine AS production
+
+LABEL maintainer="HELPDESK.AI Team" \
+      version="2.0.0" \
+      description="AI Helpdesk — frontend production image"
+
+COPY --from=builder /build/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["wget", "--spider", "-q", "http://localhost:80/"]
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Frontend/nginx.conf
+++ b/Frontend/nginx.conf
@@ -1,0 +1,54 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Security headers
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options DENY;
+    add_header X-XSS-Protection "1; mode=block";
+    add_header Referrer-Policy strict-origin-when-cross-origin;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_min_length 1000;
+    gzip_vary on;
+
+    # Static assets with content hash — long cache
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # API proxy to backend
+    location /api/ {
+        proxy_pass http://backend:7860/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket proxy
+    location /ws {
+        proxy_pass http://backend:7860;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 86400;
+    }
+
+    # Health endpoint proxy
+    location /health {
+        proxy_pass http://backend:7860/health;
+        proxy_set_header Host $host;
+    }
+
+    # SPA fallback — all other routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
 version: "3.9"
 
-# Local development stack for HELPDESK.AI
+# Full-stack deployment stack for HELPDESK.AI
 # Usage: docker compose up --build
+#
+# Multi-stage builds used for both backend (Python) and frontend (Vite + nginx)
+# to ensure minimal production images with only runtime dependencies.
 
 services:
+  # ── Backend: FastAPI (Python) ──────────────────────────────────────────────
   backend:
     build:
       context: ./backend
@@ -41,6 +45,23 @@ services:
     networks:
       - helpdesk_net
 
+  # ── Frontend: Vite + nginx (multi-stage build) ─────────────────────────────
+  frontend:
+    build:
+      context: ./Frontend
+      dockerfile: Dockerfile
+    image: helpdesk-ai-frontend:local
+    container_name: helpdesk_frontend
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - helpdesk_net
+
+  # ── Redis Cache ────────────────────────────────────────────────────────────
   redis:
     image: redis:7-alpine
     container_name: helpdesk_redis


### PR DESCRIPTION
## Summary

Refreshes Docker multi-stage containerization across HELPDESK.AI following the established approach from \ackend/Dockerfile\. All images now use proper builder → production stages for minimal runtime footprint.

## Changes

### Backend (\Dockerfile\, \Dockerfile.multi-stage\)
- Base: \python:3.11-slim-bookworm\ (consistent with \ackend/Dockerfile\)
- Builder: venv isolation, compileall bytecode pre-compilation, layer caching
- Production: non-root appuser (uid 1001), HEALTHCHECK via healthcheck.py, runtime-only deps
- Env: \ALLOW_DEGRADED_STARTUP=1\, \PYTHONUNBUFFERED=1\

### Frontend (new: \Frontend/Dockerfile\, \Frontend/nginx.conf\, \Frontend/.dockerignore\)
- Builder: \
ode:20-alpine\, npm ci, vite build
- Production: \
ginx:stable-alpine\, static serving
- nginx: SPA fallback, /api/ + /ws proxy to backend, security headers, gzip, immutable cache

### Compose
- Added \rontend\ service (port 3000, multi-stage build, depends on backend healthy)

Closes #1384