### PR TITLE
fix: add AbortController timeout to translateText to prevent indefinite hang

### DIFF
--- a/Frontend/src/services/translationService.js
+++ b/Frontend/src/services/translationService.js
@@ -34,7 +34,10 @@ export async function translateText(text, fromLang = 'en', toLang = 'en') {
     try {
         const langPair = `${fromLang}|${toLang}`;
         const url = `https://api.mymemory.translated.net/get?q=${encodeURIComponent(text)}&langpair=${langPair}`;
-        const response = await fetch(url);
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 8000);
+        const response = await fetch(url, { signal: controller.signal });
+        clearTimeout(timeoutId);
         if (!response.ok) throw new Error(`Translation API error: ${response.status}`);
 
         const data = await response.json();


### PR DESCRIPTION
Fixes #1439

## Description
`translateText()` in `Frontend/src/services/translationService.js` was calling `fetch()` with no timeout or abort mechanism. If the MyMemory API was slow or unresponsive, the Promise would never reject, leaving `isTranslating` as `true` indefinitely in `CreateTicket.jsx` — disabling the submit button with no way to recover without a page refresh.

Fix adds an `AbortController` with an 8-second timeout. If the fetch does not complete within 8 seconds, the request is aborted and the existing `catch` block handles it gracefully by returning the original untranslated text, allowing ticket submission to continue normally.

## Related Issue
Closes #1439

## Type of Change
- [x] Bug fix

## Screenshots
N/A

## Testing
- [x] Ran `git diff --check`
- [x] Verified the changed behavior manually — throttled the MyMemory API in DevTools and confirmed the fetch aborts after 8 seconds and falls back to original text instead of hanging
- [x] Updated or added tests where appropriate — N/A

## Checklist
- [x] My changes are focused on the linked issue
- [x] I have reviewed my own code
- [x] I have not introduced unrelated formatting or generated-file changes
- [x] Documentation is updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Translation requests now enforce an automatic 8-second timeout mechanism. Any request exceeding this duration will automatically cancel, preventing indefinite loading states and application hangs. This enhancement ensures the application remains responsive and provides users with a better experience during translation operations, especially when services experience delays or connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->