### PR TITLE
fix: stabilize Supabase real-time subscription in MyTickets by using user?.id as dependency

### DIFF
--- a/Frontend/src/user/pages/MyTickets.jsx
+++ b/Frontend/src/user/pages/MyTickets.jsx
@@ -53,7 +53,7 @@ function MyTickets() {
             setTickets(data || []);
         }
         setLoading(false);
-    }, [user]);
+    }, [user?.id]);
 
     useEffect(() => {
          
@@ -88,7 +88,7 @@ function MyTickets() {
         return () => {
             supabase.removeChannel(channel);
         };
-    }, [user, fetchTickets]); // Re-subscribe when user changes
+    }, [user?.id, fetchTickets]); // Re-subscribe only when user ID changes
 
     // Filtering logic
     const filteredTickets = useMemo(() => {


### PR DESCRIPTION
Fixes #1440

## Description
`fetchTickets` in `MyTickets.jsx` had `user` as its `useCallback` dependency, and the `useEffect` that sets up the Supabase real-time subscription depended on both `user` and `fetchTickets`. Every time Supabase created a new `user` object reference (on tab focus, token refresh, or session sync), `fetchTickets` was recreated, causing the `useEffect` to re-run — tearing down the existing subscription and creating a new one even when the actual user identity hadn't changed.

Fix changes both dependencies from `user` to `user?.id` so the callback and effect only re-run when the actual user ID changes, not on every object reference change.

## Related Issue
Closes #1440

## Type of Change
- [x] Bug fix

## Screenshots
N/A

## Testing
- [x] Ran `git diff --check`
- [x] Verified the changed behavior manually — triggered a Supabase session refresh via tab switching and confirmed the subscription is no longer torn down and re-created unnecessarily
- [x] Updated or added tests where appropriate — N/A

## Checklist
- [x] My changes are focused on the linked issue
- [x] I have reviewed my own code
- [x] I have not introduced unrelated formatting or generated-file changes
- [x] Documentation is updated if needed