### PR TITLE
fix: use primitive values instead of full user/profile objects as useEffect dependencies in useRealtimeNotifications

### DIFF
--- a/Frontend/src/hooks/useRealtimeNotifications.js
+++ b/Frontend/src/hooks/useRealtimeNotifications.js
@@ -6,12 +6,15 @@ import useTicketStore from '../store/ticketStore';
 const useTicketsRealtime = () => {
     const { user, profile } = useAuthStore();
     const { addTicket, updateTicket, removeTicket } = useTicketStore();
+    const userId = user?.id;
+    const userRole = profile?.role;
+    const companyId = profile?.company_id;
 
     useEffect(() => {
-        if (!user || !profile) return;
+        if (!userId || !userRole || !companyId) return;
 
         // Only admins see the live ticket queue
-        const isAdmin = profile.role === 'admin' || profile.role === 'master_admin';
+        const isAdmin = userRole === 'admin' || userRole === 'master_admin';
         if (!isAdmin) return;
 
         const channel = supabase
@@ -22,7 +25,7 @@ const useTicketsRealtime = () => {
                     event: '*',
                     schema: 'public',
                     table: 'tickets',
-                    filter: `company_id=eq.${profile.company_id}`,
+                    filter: `company_id=eq.${companyId}`,
                 },
                 (payload) => {
                     const { eventType, new: newRecord, old: oldRecord } = payload;
@@ -45,7 +48,7 @@ const useTicketsRealtime = () => {
         return () => {
             supabase.removeChannel(channel);
         };
-    }, [user, profile, addTicket, updateTicket, removeTicket]);
+    }, [userId, userRole, companyId, addTicket, updateTicket, removeTicket]);
 };
 
 export default useTicketsRealtime;


### PR DESCRIPTION
Fixes #1525

## Description
The `useEffect` in `useRealtimeNotifications.js` was listing `user` and `profile` as dependencies. Since these are full objects from Zustand, every Supabase auth state change (tab focus, token refresh, session sync) creates new object references even when the actual user identity hasn't changed — causing the effect to re-run, tearing down the existing admin real-time subscription and creating a new one unnecessarily, with missed events during the gap.

Fix extracts `userId`, `userRole`, and `companyId` as primitive values before the effect and uses those as dependencies instead, so the subscription only re-creates when the actual identity or company changes.

## Related Issue
Closes #1525

## Type of Change
- [x] Bug fix

## Screenshots
N/A

## Testing
- [x] Ran `git diff --check`
- [x] Verified the changed behavior manually — triggered a Supabase session refresh via tab switching and confirmed the admin subscription is no longer torn down and re-created unnecessarily
- [x] Updated or added tests where appropriate — N/A

## Checklist
- [x] My changes are focused on the linked issue
- [x] I have reviewed my own code
- [x] I have not introduced unrelated formatting or generated-file changes
- [x] Documentation is updated if needed