### PR TITLE
fix: add deduplication check in addTicket to prevent duplicate entries in admin queue

### DIFF
--- a/Frontend/src/store/ticketStore.js
+++ b/Frontend/src/store/ticketStore.js
@@ -26,6 +26,7 @@ const useTicketStore = create(
                 ]
             })),
             addTicket: (ticket) => set((state) => {
+                if (state.tickets.some(t => t.id === ticket.id)) return state;
                 return {
                     tickets: [...state.tickets, ticket]
                 };


### PR DESCRIPTION
Fixes #1526

## Description
`addTicket` in `ticketStore.js` was blindly appending tickets without checking if a ticket with the same ID already existed in the store. Combined with the `storage` event listener at the bottom of the file that calls `useTicketStore.persist.rehydrate()` on every localStorage change, a real-time INSERT event and a simultaneous rehydration could add the same ticket twice to the admin queue.

Fix adds an ID existence check before appending — if a ticket with the same `id` already exists in the store, the insert is skipped and the state is returned unchanged.

## Related Issue
Closes #1526

## Type of Change
- [x] Bug fix

## Screenshots
N/A

## Testing
- [x] Ran `git diff --check`
- [x] Verified the changed behavior manually — opened admin dashboard in two tabs, submitted a new ticket, confirmed it appears only once in the queue
- [x] Updated or added tests where appropriate — N/A

## Checklist
- [x] My changes are focused on the linked issue
- [x] I have reviewed my own code
- [x] I have not introduced unrelated formatting or generated-file changes
- [x] Documentation is updated if needed