### PR TITLE
fix: guard notification click handler and ticket badge against missing ticketId

### DIFF
--- a/Frontend/src/user/pages/Notifications.jsx
+++ b/Frontend/src/user/pages/Notifications.jsx
@@ -39,8 +39,8 @@ const NotificationsPage = () => {
                     notifications.map((notif) => (
                         <Card
                             key={notif.id}
-                            onClick={() => navigate(`/ticket/${notif.ticketId}`)}
-                            className={`p-6 rounded-2xl border transition-all cursor-pointer group flex gap-5 items-start ${!notif.read ? 'border-emerald-200 bg-emerald-50/20 shadow-sm' : 'border-gray-100 hover:border-gray-200'}`}
+                            onClick={() => notif.ticketId && navigate(`/ticket/${notif.ticketId}`)}
+                            className={`p-6 rounded-2xl border transition-all ${notif.ticketId ? 'cursor-pointer' : 'cursor-default'} group flex gap-5 items-start ${!notif.read ? 'border-emerald-200 bg-emerald-50/20 shadow-sm' : 'border-gray-100 hover:border-gray-200'}`}
                         >
                             <div className={`p-3 rounded-xl shrink-0 ${!notif.read ? 'bg-emerald-100/50' : 'bg-gray-100 group-hover:bg-gray-200'}`}>
                                 {getIcon(notif.type)}
@@ -58,9 +58,11 @@ const NotificationsPage = () => {
                                     {notif.message}
                                 </p>
                                 <div className="flex items-center gap-3 mt-4">
-                                    <span className="text-[10px] font-black text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-md uppercase tracking-wider border border-emerald-100">
-                                        Ticket #{formatTicketId(notif.ticketId)}
-                                    </span>
+                                    {notif.ticketId && (
+                                        <span className="text-[10px] font-black text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-md uppercase tracking-wider border border-emerald-100">
+                                            Ticket #{formatTicketId(notif.ticketId)}
+                                        </span>
+                                    )}
                                     {!notif.read && (
                                         <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
                                     )}


### PR DESCRIPTION
Fixes #1528

## Description
In `Notifications.jsx`, the notification card click handler used `navigate('/ticket/${notif.ticketId}')` with no null guard. If `notif.ticketId` was `undefined` or `null` — which can happen for system-level notifications not linked to a specific ticket — the user was navigated to `/ticket/undefined`. The ticket badge also rendered `Ticket #` with no ID in this case.

Fix adds two guards:
1. Click handler only navigates if `notif.ticketId` is present, and the card cursor changes to `cursor-default` when there is no linked ticket
2. The ticket badge is conditionally rendered only when `notif.ticketId` exists

## Related Issue
Closes #1528

## Type of Change
- [x] Bug fix

## Screenshots
N/A

## Testing
- [x] Ran `git diff --check`
- [x] Verified the changed behavior manually — notifications without a ticketId no longer navigate on click and do not render the ticket badge
- [x] Updated or added tests where appropriate — N/A

## Checklist
- [x] My changes are focused on the linked issue
- [x] I have reviewed my own code
- [x] I have not introduced unrelated formatting or generated-file changes
- [x] Documentation is updated if needed