### PR TITLE
fix: add warning log when translation returns empty/unchanged text

### DIFF
--- a/backend/language_pipeline.py
+++ b/backend/language_pipeline.py
@@ -193,6 +193,12 @@ def detect_and_translate_ticket_text(text: str) -> dict:
         )
 
     if not translated_text or not translated_text.strip() or translated_text.strip() == original_text:
+        logger.warning(
+            "detect_and_translate_ticket_text: translation returned empty/unchanged text "
+            "(lang=%s, original_len=%d). Setting translation_failed=True.",
+            detected_lang,
+            len(original_text),
+        )
         return {
             "text_for_analysis": original_text,
             "source_language": detected_lang,


### PR DESCRIPTION
## Summary
Adds a `logger.warning` in `detect_and_translate_ticket_text` when translation fails silently (returns same text or empty string), making translation failures observable in production logs.

## Changes
- `backend/language_pipeline.py`: Added `logger.warning` with detected language and original text length when translation returns empty/unchanged text and `translation_failed=True` is set.

## Testing
- Existing translation tests continue to pass
- New log message is emitted when translation returns unchanged text

## Related Issues
Fixes #1381