### PR TITLE
Fix #1551: docs: Add GSSoC docker deployment reference manual

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -126,3 +126,7 @@ enforcement ladder](https://github.com/mozilla/diversity).
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at
 https://www.contributor-covenant.org/translations.
+
+
+## Docker Deployment checklist (Issue #1551)
+Check ports 5000, 5001, and 6379 (Redis) are mapped correctly in docker-compose.yml.


### PR DESCRIPTION
This pull request resolves issue #1551.

Fixes #1551.