### PR TITLE
Fix #1555: docs: Add GSSoC escalation templates reference manual

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,4 @@
+
+
+## Escalation reporting templates (Issue #1555)
+Access the templates at docs/escalation_templates.md for reporting violations privately.


### PR DESCRIPTION
This pull request resolves issue #1555.

Fixes #1555.