### PR TITLE
Fix #1561: docs: Add GSSoC email integration reference manual

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,4 @@
+
+
+## Email integration variables (Issue #1561)
+Provide SMTP_HOST, SMTP_PORT, SMTP_USER, and SMTP_PASSWORD in your .env configuration.


### PR DESCRIPTION
This pull request resolves issue #1561.

Fixes #1561.