### PR TITLE
fix: add null-check for whisper model in voice health endpoint (#1115)

### DIFF
--- a/backend/routes/voice.py
+++ b/backend/routes/voice.py
@@ -137,26 +137,57 @@ async def create_ticket_from_voice(
 async def voice_health():
     """Check if the voice transcription service is available."""
     try:
-        from backend.services.voice_service import _whisper_model
-
+        # Import the voice_service module first to check if it exists
+        import backend.services.voice_service as voice_service
+        
+        # Use hasattr to safely check if _whisper_model attribute exists
+        if not hasattr(voice_service, '_whisper_model'):
+            logger.warning("voice_service module exists but _whisper_model attribute is missing")
+            return {
+                "status": "unavailable",
+                "model_loaded": False,
+                "message": "Voice service not properly initialized.",
+                "max_audio_size_mb": MAX_UPLOAD_SIZE // (1024 * 1024),
+                "supported_formats": ["webm", "wav", "mp3", "ogg", "m4a", "flac"],
+            }
+        
+        # Now safely access the model
+        _whisper_model = voice_service._whisper_model
         model_loaded = _whisper_model is not None
+        
         return {
-            "status": "ok",
+            "status": "ok" if model_loaded else "degraded",
             "model_loaded": model_loaded,
             "max_audio_size_mb": MAX_UPLOAD_SIZE // (1024 * 1024),
             "supported_formats": ["webm", "wav", "mp3", "ogg", "m4a", "flac"],
         }
-    except ImportError:
+        
+    except ImportError as e:
+        logger.error(f"Failed to import voice_service: {e}")
         return {
             "status": "unavailable",
             "model_loaded": False,
-            "message": "Whisper package not installed.",
+            "message": "Whisper package not installed. Voice features disabled.",
+            "max_audio_size_mb": MAX_UPLOAD_SIZE // (1024 * 1024),
+            "supported_formats": ["webm", "wav", "mp3", "ogg", "m4a", "flac"],
         }
-    except AttributeError:
+    except AttributeError as e:
+        logger.error(f"Attribute error in voice health check: {e}")
         return {
             "status": "unavailable",
             "model_loaded": False,
-            "message": "Whisper model not available.",
+            "message": "Whisper model not properly initialized.",
+            "max_audio_size_mb": MAX_UPLOAD_SIZE // (1024 * 1024),
+            "supported_formats": ["webm", "wav", "mp3", "ogg", "m4a", "flac"],
+        }
+    except Exception as e:
+        logger.error(f"Unexpected error in voice health check: {e}", exc_info=True)
+        return {
+            "status": "error",
+            "model_loaded": False,
+            "message": f"Health check failed: {str(e)}",
+            "max_audio_size_mb": MAX_UPLOAD_SIZE // (1024 * 1024),
+            "supported_formats": ["webm", "wav", "mp3", "ogg", "m4a", "flac"],
         }
 
 

--- a/backend/tests/test_voice_health_nullcheck.py
+++ b/backend/tests/test_voice_health_nullcheck.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for voice health endpoint null-check fix (Issue #1115)
+
+Tests that the /api/voice/health endpoint properly handles:
+- Missing whisper model (None)
+- Missing voice_service module
+- Missing _whisper_model attribute
+- Successful model loading
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app."""
+    from backend.main import app
+    return TestClient(app)
+
+
+class TestVoiceHealthEndpoint:
+    """Test suite for /api/voice/health endpoint."""
+
+    def test_health_when_model_loaded(self, client):
+        """Test health endpoint when whisper model is successfully loaded."""
+        with patch('backend.services.voice_service._whisper_model') as mock_model:
+            mock_model.is_some_value = True  # Simulate loaded model
+            
+            response = client.get("/api/voice/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "ok"
+            assert data["model_loaded"] is True
+            assert "max_audio_size_mb" in data
+            assert "supported_formats" in data
+            assert isinstance(data["supported_formats"], list)
+
+    def test_health_when_model_is_none(self, client):
+        """Test health endpoint when whisper model is None (not loaded)."""
+        with patch('backend.services.voice_service._whisper_model', None):
+            response = client.get("/api/voice/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "degraded"
+            assert data["model_loaded"] is False
+            assert "max_audio_size_mb" in data
+            assert "supported_formats" in data
+
+    def test_health_when_attribute_missing(self, client):
+        """Test health endpoint when _whisper_model attribute doesn't exist."""
+        with patch('backend.services.voice_service') as mock_service:
+            # Remove the _whisper_model attribute
+            del mock_service._whisper_model
+            
+            response = client.get("/api/voice/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "unavailable"
+            assert data["model_loaded"] is False
+            assert "message" in data
+            assert "Voice service not properly initialized" in data["message"]
+
+    def test_health_when_module_import_fails(self, client):
+        """Test health endpoint when voice_service module can't be imported."""
+        with patch.dict('sys.modules', {'backend.services.voice_service': None}):
+            response = client.get("/api/voice/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "unavailable"
+            assert data["model_loaded"] is False
+            assert "message" in data
+
+    def test_health_response_structure(self, client):
+        """Test that health endpoint always returns consistent structure."""
+        with patch('backend.services.voice_service._whisper_model', None):
+            response = client.get("/api/voice/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            
+            # Check required fields are always present
+            assert "status" in data
+            assert "model_loaded" in data
+            assert "max_audio_size_mb" in data
+            assert "supported_formats" in data
+            
+            # Check data types
+            assert isinstance(data["status"], str)
+            assert isinstance(data["model_loaded"], bool)
+            assert isinstance(data["max_audio_size_mb"], int)
+            assert isinstance(data["supported_formats"], list)
+            
+            # Check supported formats
+            expected_formats = ["webm", "wav", "mp3", "ogg", "m4a", "flac"]
+            for fmt in expected_formats:
+                assert fmt in data["supported_formats"]
+
+    def test_health_max_audio_size(self, client):
+        """Test that max_audio_size_mb is calculated correctly."""
+        with patch('backend.services.voice_service._whisper_model', None):
+            response = client.get("/api/voice/health")
+            
+            data = response.json()
+            # MAX_UPLOAD_SIZE is 25MB, so max_audio_size_mb should be 25
+            assert data["max_audio_size_mb"] == 25
+
+    def test_health_with_exception(self, client):
+        """Test health endpoint when an unexpected exception occurs."""
+        with patch('backend.services.voice_service') as mock_service:
+            # Make accessing _whisper_model raise an exception
+            type(mock_service)._whisper_model = property(
+                lambda self: (_ for _ in ()).throw(Exception("Test error"))
+            )
+            
+            response = client.get("/api/voice/health")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "error"
+            assert data["model_loaded"] is False
+            assert "message" in data
+            assert "Health check failed" in data["message"]
+
+
+class TestVoiceHealthEndpointIntegration:
+    """Integration tests for voice health endpoint."""
+
+    def test_health_endpoint_accessible(self, client):
+        """Test that health endpoint is accessible without authentication."""
+        with patch('backend.services.voice_service._whisper_model', None):
+            response = client.get("/api/voice/health")
+            
+            # Should not require authentication
+            assert response.status_code == 200
+
+    def test_health_endpoint_no_side_effects(self, client):
+        """Test that health endpoint doesn't have side effects."""
+        with patch('backend.services.voice_service._whisper_model', None):
+            # Call health endpoint multiple times
+            for _ in range(3):
+                response = client.get("/api/voice/health")
+                assert response.status_code == 200
+                data = response.json()
+                assert data["model_loaded"] is False


### PR DESCRIPTION
## Summary
Fixes #1115

The `/api/voice/health` endpoint was directly accessing `_whisper_model` without proper null-check handling, which could cause `AttributeError` when the voice service module is not properly initialized or when Whisper is not installed.

## Changes

### Backend (`backend/routes/voice.py`)
- Use `hasattr()` to safely check if `_whisper_model` attribute exists before accessing
- Handle `ImportError` gracefully when `voice_service` module is unavailable
- Add comprehensive error handling with proper logging
- Return consistent response structure across all scenarios
- Add `degraded` status when module exists but model is None
- Include detailed error messages for different failure scenarios

### Tests (`backend/tests/test_voice_health_nullcheck.py`)
- Comprehensive test suite covering:
  - Model successfully loaded
  - Model is None (not loaded)
  - Attribute missing from module
  - Module import fails
  - Unexpected exceptions
  - Response structure consistency
  - Integration tests

## Response Structure

All responses now include:
```json
{
  "status": "ok" | "degraded" | "unavailable" | "error",
  "model_loaded": true | false,
  "max_audio_size_mb": 25,
  "supported_formats": ["webm", "wav", "mp3", "ogg", "m4a", "flac"],
  "message": "..." // only for error/unavailable cases
}
```

## Testing

Run tests with:
```bash
cd backend
pytest tests/test_voice_health_nullcheck.py -v
```

## Impact
- Prevents 500 errors when voice service is not fully configured
- Provides clear health status for monitoring
- Improves reliability of voice API endpoints
- Better debugging with detailed error messages and logging