### PR TITLE
fix: add minimal permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: [main]
 
+permissions:
+    contents: read
+
 jobs:
     # --- JOB 1: Frontend Build Verification ---
     frontend-build:


### PR DESCRIPTION
## Summary
Adds a minimal `permissions: contents: read` block to the CI workflow, resolving CodeQL security recommendations.

## Changes
- Add `permissions` block with `contents: read` to `.github/workflows/ci.yml`

## Testing
- CI workflow syntax validated (no functional changes to jobs)
- Permissions are read-only — follows principle of least privilege

## Related Issues
Addresses CodeQL workflow permission warnings on PRs #1580, #1581, #1582