### PR TITLE
feat: Add privacy controls & GDPR compliance suite- closes 

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -39,6 +39,7 @@ import CreateTicket from "./user/pages/CreateTicket";
 import MyTickets from "./user/pages/MyTickets";
 import TicketResult from "./user/pages/TicketResult";
 import Profile from "./user/pages/Profile";
+import PrivacySettings from "./user/pages/PrivacySettings";
 import TicketDetail from "./user/pages/TicketDetail";
 import TicketProcessing from "./user/pages/AIProcessing"; // Renamed generic import just in case, but keeping AIProcessing
 import AIProcessing from "./user/pages/AIProcessing";
@@ -118,6 +119,7 @@ function TitleUpdater() {
     else if (path === '/create-ticket') title = 'Create Ticket';
     else if (path === '/my-tickets') title = 'My Tickets';
     else if (path === '/profile') title = 'User Profile';
+    else if (path === '/privacy') title = 'Privacy & Data Controls';
     else if (path === '/notifications') title = 'Notifications';
     else if (path === '/docs') title = 'Documentation';
     else if (path === '/api-reference') title = 'API Reference';
@@ -191,6 +193,7 @@ function AppLayout() {
           <Route path="/ticket-tracking" element={<TicketTracking />} />
           <Route path="/ticket-result" element={<TicketResult />} />
           <Route path="/profile" element={<Profile />} />
+          <Route path="/privacy" element={<PrivacySettings />} />
           <Route path="/help" element={<Help />} />
           <Route path="/notifications" element={<Notifications />} />
         </Route>

--- a/Frontend/src/services/privacyService.js
+++ b/Frontend/src/services/privacyService.js
@@ -1,0 +1,87 @@
+import { API_CONFIG } from '../config';
+
+export const privacyService = {
+  async getConsent(userId) {
+    try {
+      const response = await fetch(`${API_CONFIG.BACKEND_URL}/privacy/consent?user_id=${encodeURIComponent(userId)}`);
+      if (!response.ok) throw new Error('Failed to fetch consent');
+      return await response.json();
+    } catch (err) {
+      console.error('getConsent error:', err);
+      // Default consent
+      return {
+        consent: {
+          marketing_emails: false,
+          product_updates: true,
+          usage_analytics: true,
+          experimental_features: false,
+        },
+        updated_at: null,
+        user_id: userId,
+      };
+    }
+  },
+
+  async updateConsent(userId, consent, actor = 'user') {
+    try {
+      const response = await fetch(`${API_CONFIG.BACKEND_URL}/privacy/consent`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, consent, actor }),
+      });
+      if (!response.ok) throw new Error('Failed to update consent');
+      return await response.json();
+    } catch (err) {
+      console.error('updateConsent error:', err);
+      throw err;
+    }
+  },
+
+  async exportData(userId, format = 'json') {
+    try {
+      const response = await fetch(
+        `${API_CONFIG.BACKEND_URL}/privacy/export?user_id=${encodeURIComponent(userId)}&format=${encodeURIComponent(format)}`
+      );
+      if (!response.ok) throw new Error('Failed to export data');
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `user_data_${userId}.${format}`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+      return { success: true };
+    } catch (err) {
+      console.error('exportData error:', err);
+      throw err;
+    }
+  },
+
+  async requestDeletion(userId, reason = '') {
+    try {
+      const response = await fetch(`${API_CONFIG.BACKEND_URL}/privacy/request_deletion`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ user_id: userId, reason }),
+      });
+      if (!response.ok) throw new Error('Failed to request deletion');
+      return await response.json();
+    } catch (err) {
+      console.error('requestDeletion error:', err);
+      throw err;
+    }
+  },
+
+  async getPrivacyRequests(userId) {
+    try {
+      const response = await fetch(`${API_CONFIG.BACKEND_URL}/privacy/requests?user_id=${encodeURIComponent(userId)}`);
+      if (!response.ok) throw new Error('Failed to fetch privacy requests');
+      return await response.json();
+    } catch (err) {
+      console.error('getPrivacyRequests error:', err);
+      return { requests: [] };
+    }
+  },
+};

--- a/Frontend/src/user/pages/PrivacySettings.jsx
+++ b/Frontend/src/user/pages/PrivacySettings.jsx
@@ -1,0 +1,362 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ShieldCheck, Download, Trash2, CheckCircle2, AlertCircle, ChevronLeft, Loader2 } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
+import { Button } from '../../components/ui/button';
+import useAuthStore from '../../store/authStore';
+import useToastStore from '../../store/toastStore';
+import { privacyService } from '../../services/privacyService';
+
+const PrivacySettings = () => {
+  const navigate = useNavigate();
+  const { user } = useAuthStore();
+  const { showToast } = useToastStore();
+  const [loading, setLoading] = useState(true);
+  const [consent, setConsent] = useState({
+    marketing_emails: false,
+    product_updates: true,
+    usage_analytics: true,
+    experimental_features: false,
+  });
+  const [updatingConsent, setUpdatingConsent] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [privacyRequests, setPrivacyRequests] = useState([]);
+  const [requestsLoading, setRequestsLoading] = useState(false);
+  const [deletionReason, setDeletionReason] = useState('');
+  const [showDeletionConfirm, setShowDeletionConfirm] = useState(false);
+
+  useEffect(() => {
+    if (async () => {
+      if (!user?.id) return;
+      try {
+        const consentData = await privacyService.getConsent(user.id);
+        setConsent(consentData.consent);
+        const reqData = await privacyService.getPrivacyRequests(user.id);
+        setPrivacyRequests(reqData.requests || []);
+      } catch (err) {
+        console.error('Failed to load privacy data', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [user]);
+
+  const handleConsentChange = async (key, value) => {
+    if (!user?.id) return;
+    setConsent(prev => ({ ...prev, [key]: value }));
+    setUpdatingConsent(true);
+    try {
+      await privacyService.updateConsent(user.id, { ...consent, [key]: value });
+      showToast('Privacy preferences updated successfully', 'success');
+    } catch (err) {
+      showToast('Failed to update preferences', 'error');
+      // Revert
+      const original = await privacyService.getConsent(user.id);
+      setConsent(original.consent);
+    } finally {
+      setUpdatingConsent(false);
+    }
+  };
+
+  const handleExport = async (format) => {
+    if (!user?.id) return;
+    setExporting(true);
+    try {
+      await privacyService.exportData(user.id, format);
+      showToast(`Data exported successfully as ${format.toUpperCase()}`, 'success');
+    } catch (err) {
+      showToast('Failed to export data', 'error');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleDeletionRequest = async () => {
+    setShowDeletionConfirm(true);
+  };
+
+  const confirmDeletionRequest = async () => {
+    if (!user?.id) return;
+    setRequestsLoading(true);
+    try {
+      const req = await privacyService.requestDeletion(user.id, deletionReason);
+      setPrivacyRequests([req, ...privacyRequests]);
+      showToast('Deletion request submitted', 'success');
+      setShowDeletionConfirm(false);
+      setDeletionReason('');
+    } catch (err) {
+      showToast('Failed to submit deletion request', 'error');
+    } finally {
+      setRequestsLoading(false);
+    }
+  };
+
+  if (loading || !user) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center bg-white">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f6f8f7] pb-20">
+      <main className="pt-32 px-6 flex justify-center">
+        <div className="w-full max-w-[1100px] flex flex-col gap-8">
+          {/* Back button */}
+          <button
+            onClick={() => navigate('/profile')}
+            className="flex items-center gap-2 text-slate-600 hover:text-emerald-600 transition-colors font-semibold"
+          >
+            <ChevronLeft className="w-5 h-5" />
+            Back to Profile
+          </button>
+
+          {/* Privacy Header */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="relative bg-white p-8 rounded-[2.5rem] shadow-xl shadow-slate-200/50 border border-white overflow-hidden"
+          >
+            <div className="flex items-center gap-4">
+              <div className="w-16 h-16 bg-emerald-100 rounded-3xl flex items-center justify-center text-emerald-600">
+                <ShieldCheck className="w-8 h-8" />
+              </div>
+              <div>
+                <h1 className="text-3xl font-black text-slate-900 italic">Privacy & Data Controls</h1>
+                <p className="text-slate-500">Manage your personal data and consent preferences</p>
+              </div>
+            </div>
+          </motion.div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {/* Consent Settings */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.1 }}
+            >
+              <Card className="border-none shadow-xl shadow-slate-200/40 rounded-[2.5rem] bg-white h-full">
+                <CardHeader className="p-8 pb-4 bg-slate-50/50">
+                  <CardTitle className="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em] flex items-center gap-2 italic">
+                    Consent Preferences
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-8 space-y-6">
+                  {[
+                    {
+                      key: 'marketing_emails',
+                      label: 'Marketing Emails',
+                      desc: 'Receive promotional emails and offers',
+                    },
+                    {
+                      key: 'product_updates',
+                      label: 'Product Updates',
+                      desc: 'Get notified about new features and improvements',
+                    },
+                    {
+                      key: 'usage_analytics',
+                      label: 'Usage Analytics',
+                      desc: 'Allow anonymous usage data to improve the product',
+                    },
+                    {
+                      key: 'experimental_features',
+                      label: 'Experimental Features',
+                      desc: 'Participate in early access tests',
+                    },
+                  ].map((item) => (
+                    <div
+                      key={item.key}
+                      className="flex items-center justify-between p-4 bg-slate-50 rounded-2xl border border-slate-100/50"
+                    >
+                      <div className="flex-1">
+                        <p className="text-sm font-semibold text-slate-900">{item.label}</p>
+                        <p className="text-xs text-slate-500">{item.desc}</p>
+                      </div>
+                      <button
+                        onClick={() => handleConsentChange(item.key, !consent[item.key])}
+                        disabled={updatingConsent}
+                        className={`w-14 h-7 rounded-full transition-colors relative ${
+                          consent[item.key] ? 'bg-emerald-500' : 'bg-slate-300'
+                        }`}
+                      >
+                        <div
+                          className={`absolute top-1 left-1 w-5 h-5 bg-white rounded-full transition-transform ${
+                            consent[item.key] ? 'translate-x-7' : ''
+                          }`}
+                        />
+                      </button>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            </motion.div>
+
+            {/* Data Actions */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.2 }}
+            >
+              <Card className="border-none shadow-xl shadow-slate-200/40 rounded-[2.5rem] bg-white h-full">
+                <CardHeader className="p-8 pb-4 bg-slate-50/50">
+                  <CardTitle className="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em] flex items-center gap-2 italic">
+                    Data Management
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-8 space-y-6">
+                  {/* Export Data */}
+                  <div className="p-4 bg-slate-50 rounded-2xl border border-slate-100/50">
+                    <p className="text-sm font-semibold text-slate-900 mb-2">Download Your Data</p>
+                    <p className="text-xs text-slate-500 mb-4">
+                      Export all your personal data and ticket history
+                    </p>
+                    <div className="flex gap-3">
+                      <Button
+                        onClick={() => handleExport('json')}
+                        disabled={exporting}
+                        className="rounded-2xl bg-slate-900 hover:bg-slate-800 text-white font-semibold"
+                      >
+                        {exporting ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Download className="w-4 h-4 mr-2" />}
+                        {exporting ? 'Exporting...' : 'JSON'}
+                      </Button>
+                      <Button
+                        onClick={() => handleExport('csv')}
+                        disabled={exporting}
+                        className="rounded-2xl bg-slate-100 hover:bg-slate-200 text-slate-900 font-semibold"
+                      >
+                        {exporting ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}
+                        CSV
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Request Deletion */}
+                  <div className="p-4 bg-red-50 rounded-2xl border border-red-100">
+                    <p className="text-sm font-semibold text-red-700 mb-2 flex items-center gap-2">
+                      <AlertCircle className="w-4 h-4" />
+                      Delete Account
+                    </p>
+                    <p className="text-xs text-red-600 mb-4">
+                      Request permanent deletion of your account and personal data
+                    </p>
+                    <Button
+                      onClick={handleDeletionRequest}
+                      className="rounded-2xl bg-red-600 hover:bg-red-700 text-white font-semibold"
+                    >
+                      <Trash2 className="w-4 h-4 mr-2" />
+                      Request Deletion
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </motion.div>
+
+            {/* Privacy Requests History */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.3 }}
+              className="md:col-span-2"
+            >
+              <Card className="border-none shadow-xl shadow-slate-200/40 rounded-[2.5rem] bg-white">
+                <CardHeader className="p-8 pb-4 bg-slate-50/50">
+                  <CardTitle className="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em] flex items-center gap-2 italic">
+                    Privacy Request History
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="p-8">
+                  {privacyRequests.length === 0 ? (
+                    <div className="text-center py-10 text-slate-500">
+                      <CheckCircle2 className="w-12 h-12 mx-auto mb-4 text-emerald-500 opacity-50" />
+                      No privacy requests yet
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      {privacyRequests.map((req, idx) => (
+                        <div
+                          key={idx}
+                          className="p-4 bg-slate-50 rounded-2xl border border-slate-100/50"
+                        >
+                          <div className="flex justify-between items-center">
+                            <div>
+                              <p className="text-sm font-semibold text-slate-900 capitalize">
+                                {req.type} Request
+                              </p>
+                              <p className="text-xs text-slate-500">
+                                {new Date(req.requested_at || req.created_at).toLocaleDateString()}
+                              </p>
+                            </div>
+                            <span
+                              className={`text-xs font-black px-3 py-1 rounded-full uppercase tracking-wider ${
+                                req.status === 'pending'
+                                  ? 'bg-amber-100 text-amber-700'
+                                  : req.status === 'completed'
+                                  ? 'bg-emerald-100 text-emerald-700'
+                                  : 'bg-slate-100 text-slate-700'
+                              }`}
+                            >
+                              {req.status}
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            </motion.div>
+          </div>
+        </div>
+      </main>
+
+      {/* Deletion Confirmation Modal */}
+      {showDeletionConfirm && (
+        <div className="fixed inset-0 bg-slate-900/60 backdrop-blur-sm z-[100] flex items-center justify-center p-6">
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="w-full max-w-md bg-white rounded-[2.5rem] shadow-2xl overflow-hidden"
+          >
+            <div className="px-8 py-6 bg-red-600 text-white flex items-center justify-between">
+              <h3 className="font-black italic uppercase text-sm tracking-widest">
+                Confirm Deletion Request
+              </h3>
+            </div>
+            <div className="p-8 space-y-4">
+              <p className="text-sm text-slate-600">
+                Are you sure you want to request account deletion? This will erase your
+                data will be scheduled for deletion.
+              </p>
+              <textarea
+                value={deletionReason}
+                onChange={(e) => setDeletionReason(e.target.value)}
+                placeholder="Optional: Reason for leaving"
+                className="w-full bg-slate-50 border-2 border-transparent focus:border-red-500 px-4 py-3 rounded-2xl text-sm font-bold outline-none transition-all"
+              />
+              <div className="flex gap-3 pt-2">
+                <Button
+                  onClick={() => setShowDeletionConfirm(false)}
+                  className="flex-1 rounded-2xl bg-slate-100 hover:bg-slate-200 text-slate-900 font-semibold"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={confirmDeletionRequest}
+                  disabled={requestsLoading}
+                  className="flex-1 rounded-2xl bg-red-600 hover:bg-red-700 text-white font-semibold"
+                >
+                  {requestsLoading ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}
+                  Confirm Request
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PrivacySettings;

--- a/Frontend/src/user/pages/Profile.jsx
+++ b/Frontend/src/user/pages/Profile.jsx
@@ -485,6 +485,22 @@ const Profile = () => {
                                             <ChevronRight size={18} className="text-slate-300 group-hover:text-indigo-600 transition-all" />
                                         </button>
 
+                                        <button
+                                            onClick={() => navigate('/privacy')}
+                                            className="w-full p-8 flex items-center justify-between hover:bg-emerald-50 transition-all group border-t border-slate-50"
+                                        >
+                                            <div className="flex items-center gap-6">
+                                                <div className="w-12 h-12 bg-slate-50 rounded-2xl flex items-center justify-center text-slate-400 group-hover:bg-emerald-600 group-hover:text-white transition-all shadow-sm">
+                                                    <ShieldCheck size={20} />
+                                                </div>
+                                                <div className="text-left">
+                                                    <p className="text-sm font-black text-emerald-700 uppercase italic tracking-tight">Privacy & Data</p>
+                                                    <p className="text-[10px] font-bold text-emerald-600 uppercase tracking-widest">Manage consent, export, or delete your data</p>
+                                                </div>
+                                            </div>
+                                            <ChevronRight size={18} className="text-emerald-200 group-hover:text-emerald-600 transition-all" />
+                                        </button>
+
                                         {/* Bug Report Custom Trigger */}
                                         <BugReportWidget
                                             advanced={true}

--- a/backend/main.py
+++ b/backend/main.py
@@ -59,6 +59,7 @@ from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
+from backend.services.gdpr_service import GDPRService
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +199,7 @@ classifier_service = ClassifierService()
 ner_service = NERService()
 duplicate_service = DuplicateService()
 rag_service = RagService()
+gdpr_service = GDPRService(supabase)
 
 try:
     from backend.services.gemini_service import GeminiService
@@ -689,6 +691,53 @@ async def update_ticket(ticket_id: str, updates: dict):
             return updated_ticket
     
     raise HTTPException(status_code=404, detail="Ticket not found")
+
+
+# ---------------------------------------------------------------------------
+# Privacy Controls & GDPR Compliance Endpoints
+# ---------------------------------------------------------------------------
+class ConsentUpdateRequest(BaseModel):
+    user_id: str
+    consent: dict
+    actor: str = "user"
+
+
+class DeletionRequestRequest(BaseModel):
+    user_id: str
+    reason: str = ""
+
+
+@app.get("/privacy/consent")
+async def get_consent(user_id: str):
+    """Fetch current user consent preferences."""
+    return gdpr_service.get_consent(user_id)
+
+
+@app.put("/privacy/consent")
+async def update_consent(request: ConsentUpdateRequest):
+    """Update user consent preferences with audit logging."""
+    return gdpr_service.update_consent(request.user_id, request.consent, request.actor)
+
+
+@app.get("/privacy/export")
+async def export_data(user_id: str, format: str = "json"):
+    """Export user's personal data in JSON or CSV format."""
+    data = gdpr_service.export_data(user_id, format)
+    if format == "csv":
+        return Response(content=data, media_type="text/csv", headers={"Content-Disposition": f"attachment; filename=user_data_{user_id}.csv"})
+    return Response(content=data, media_type="application/json", headers={"Content-Disposition": f"attachment; filename=user_data_{user_id}.json"})
+
+
+@app.post("/privacy/request_deletion")
+async def request_deletion(request: DeletionRequestRequest):
+    """Submit a data deletion request."""
+    return gdpr_service.request_deletion(request.user_id, request.reason)
+
+
+@app.get("/privacy/requests")
+async def get_privacy_requests(user_id: str):
+    """Get all privacy requests for a user."""
+    return {"requests": gdpr_service.get_privacy_requests(user_id)}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/gdpr_service.py
+++ b/backend/services/gdpr_service.py
@@ -1,0 +1,160 @@
+import json
+import uuid
+import csv
+from datetime import datetime, timezone
+from pathlib import Path
+from io import StringIO
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+DEFAULT_CONSENT = {
+    "marketing_emails": False,
+    "product_updates": True,
+    "usage_analytics": True,
+    "experimental_features": False
+}
+
+
+class GDPRService:
+    def __init__(self, supabase_client=None):
+        self.supabase = supabase_client
+        self.state_path = Path(__file__).resolve().parent.parent / "data" / "privacy_state.json"
+
+    def _read_state(self):
+        if not self.state_path.exists():
+            return {}
+        try:
+            return json.loads(self.state_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+
+    def _write_state(self, state):
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+    def get_consent(self, user_id: str):
+        if self.supabase:
+            try:
+                res = self.supabase.table("consent_log").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+                if res.data and len(res.data) > 0:
+                    latest = res.data[0]
+                    return {
+                        "consent": json.loads(latest.get("consent_json", "{}")),
+                        "updated_at": latest.get("created_at"),
+                        "user_id": latest.get("user_id")
+                    }
+            except Exception as e:
+                print(f"[GDPR] Supabase consent fetch failed: {e}")
+        state = self._read_state()
+        user_consent = state.get(f"consent_{user_id}", {})
+        return {
+            "consent": user_consent.get("consent", DEFAULT_CONSENT),
+            "updated_at": user_consent.get("updated_at"),
+            "user_id": user_id
+        }
+
+    def update_consent(self, user_id: str, consent: dict, actor: str = "user"):
+        normalized_consent = {**DEFAULT_CONSENT, **consent}
+        timestamp = utc_now_iso()
+        log_entry = {
+            "id": str(uuid.uuid4()),
+            "user_id": user_id,
+            "consent_json": json.dumps(normalized_consent),
+            "actor": actor,
+            "created_at": timestamp
+        }
+        if self.supabase:
+            try:
+                self.supabase.table("consent_log").insert(log_entry).execute()
+            except Exception as e:
+                print(f"[GDPR] Supabase consent log failed: {e}")
+        state = self._read_state()
+        state[f"consent_{user_id}"] = {
+            "consent": normalized_consent,
+            "updated_at": timestamp,
+            "user_id": user_id
+        }
+        self._write_state(state)
+        return {"success": True, "consent": normalized_consent, "updated_at": timestamp}
+
+    def export_data(self, user_id: str, format: str = "json"):
+        user_data = {
+            "profile": {},
+            "tickets": [],
+            "consent_history": [],
+            "privacy_requests": []
+        }
+        if self.supabase:
+            try:
+                profile_res = self.supabase.table("profiles").select("*").eq("id", user_id).single().execute()
+                if profile_res.data:
+                    user_data["profile"] = profile_res.data
+                tickets_res = self.supabase.table("tickets").select("*").eq("user_id", user_id).execute()
+                if tickets_res.data:
+                    user_data["tickets"] = tickets_res.data
+                consent_res = self.supabase.table("consent_log").select("*").eq("user_id", user_id).execute()
+                if consent_res.data:
+                    user_data["consent_history"] = consent_res.data
+            except Exception as e:
+                print(f"[GDPR] Supabase export fetch failed: {e}")
+        state = self._read_state()
+        if not user_data["profile"] and state.get(f"profile_{user_id}"):
+            user_data["profile"] = state[f"profile_{user_id}"]
+        if not user_data["tickets"] and state.get(f"tickets_{user_id}"):
+            user_data["tickets"] = state[f"tickets_{user_id}"]
+        if format == "json":
+            return json.dumps(user_data, indent=2)
+        elif format == "csv":
+            output = StringIO()
+            writer = csv.writer(output)
+            writer.writerow(["Section", "Key", "Value"])
+            for key, value in user_data["profile"].items():
+                writer.writerow(["Profile", key, str(value)])
+            for ticket in user_data["tickets"]:
+                for k, v in ticket.items():
+                    writer.writerow([f"Ticket {ticket.get('id', 'N/A')}", k, str(v)])
+            return output.getvalue()
+        else:
+            return json.dumps(user_data, indent=2)
+
+    def request_deletion(self, user_id: str, reason: str = ""):
+        timestamp = utc_now_iso()
+        request_id = str(uuid.uuid4())
+        request = {
+            "id": request_id,
+            "user_id": user_id,
+            "type": "deletion",
+            "reason": reason,
+            "status": "pending",
+            "requested_at": timestamp,
+            "scheduled_at": None
+        }
+        if self.supabase:
+            try:
+                self.supabase.table("privacy_requests").insert(request).execute()
+            except Exception as e:
+                print(f"[GDPR] Supabase deletion request failed: {e}")
+        state = self._read_state()
+        if f"requests_{user_id}" not in state:
+            state[f"requests_{user_id}"] = []
+        state[f"requests_{user_id}"].append(request)
+        self._write_state(state)
+        return request
+
+    def get_privacy_requests(self, user_id: str):
+        requests = []
+        if self.supabase:
+            try:
+                res = self.supabase.table("privacy_requests").select("*").eq("user_id", user_id).order("created_at", desc=True).execute()
+                if res.data:
+                    requests = res.data
+            except Exception as e:
+                print(f"[GDPR] Supabase requests fetch failed: {e}")
+        if not requests:
+            state = self._read_state()
+            requests = state.get(f"requests_{user_id}", [])
+        return requests
+

--- a/supabase/migrations/20260603000001_privacy_controls.sql
+++ b/supabase/migrations/20260603000001_privacy_controls.sql
@@ -1,0 +1,28 @@
+-- Privacy Controls & GDPR Compliance Tables
+CREATE TABLE IF NOT EXISTS consent_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    consent_json JSONB NOT NULL,
+    actor TEXT NOT NULL DEFAULT 'user',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_consent_log_user_id ON consent_log(user_id);
+CREATE INDEX IF NOT EXISTS idx_consent_log_created_at ON consent_log(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS privacy_requests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    type TEXT NOT NULL CHECK (type IN ('deletion', 'export', 'portability')),
+    reason TEXT,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'cancelled')),
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    scheduled_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    notes TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_privacy_requests_user_id ON privacy_requests(user_id);
+CREATE INDEX IF NOT EXISTS idx_privacy_requests_status ON privacy_requests(status);
+CREATE INDEX IF NOT EXISTS idx_privacy_requests_type ON privacy_requests(type);
+


### PR DESCRIPTION
Backend Changes

- Created backend/services/gdpr_service.py : Handles consent management, data export (JSON/CSV), deletion requests, and privacy request history; supports both Supabase and local file storage as fallback.
- Added 5 new API endpoints in backend/main.py for privacy operations.
- Created supabase/migrations/20260603000001_privacy_controls.sql : Adds consent_log and privacy_requests tables to your database.
Frontend Changes

- Created Frontend/src/services/privacyService.js : Communicates with the new backend privacy APIs.
- Added Frontend/src/user/pages/PrivacySettings.jsx : A complete UI with:
  - Consent toggles for marketing emails, product updates, usage analytics, and experimental features
  - Data export buttons for JSON and CSV
  - Deletion request flow with confirmation modal
  - Privacy request history section
- Updated Frontend/src/user/pages/Profile.jsx : Added a "Privacy & Data" button to navigate to the new privacy page
- Updated Frontend/src/App.jsx : Added import, title updater, and route for /privacy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Privacy & Data Controls page for managing consent preferences
  * Ability to export personal data in JSON or CSV formats
  * Submit account or data deletion requests with optional reason
  * View history of privacy requests and current status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1614