### PR TITLE
[Security/Ops] Fix Hardcoded Environment URLs for Production Deployments

### DIFF
--- a/Frontend/src/config.js
+++ b/Frontend/src/config.js
@@ -6,12 +6,12 @@ const getBackendUrl = () => {
     const envUrl = import.meta.env.VITE_BACKEND_URL;
     if (envUrl) return envUrl.trim().replace(/\/$/, '');
 
-    // Dynamically deduce backend URL if running locally or on custom domain
-    if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-        return 'http://localhost:8000';
-    }
-    // Default to the live Hugging Face Space for stability in production deployment
-    return 'https://ritesh19180-ai-helpdesk-api.hf.space';
+    console.warn("VITE_BACKEND_URL is not set in the environment. Falling back to default URLs.");
+    
+    // Use production URL if in prod build, otherwise local dev server
+    return import.meta.env.PROD 
+        ? 'https://ritesh19180-ai-helpdesk-api.hf.space'
+        : 'http://localhost:8000';
 };
 
 export const API_CONFIG = {

--- a/backend/main.py
+++ b/backend/main.py
@@ -274,14 +274,20 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-# CORS — locked to production + local dev only
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
+# CORS — load from environment variable with fallback
+allowed_origins_env = os.environ.get("ALLOWED_ORIGINS")
+if allowed_origins_env:
+    origins = [origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()]
+else:
+    origins = [
         "https://helpdeskaiv1.vercel.app",
         "http://localhost:5173",
         "http://localhost:3000",
-    ],
+    ]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
This PR addresses the widespread use of hardcoded `localhost` URLs in both the frontend and backend, which caused brittle deployments and potential security risks when migrating across environments (Staging/Production).
### Changes Made:
- **Frontend (`Frontend/src/config.js`)**: 
  - Removed `window.location.hostname` hardcoded checks.
  - Now strictly reads from `import.meta.env.VITE_BACKEND_URL`.
  - Added a dynamic fallback using `import.meta.env.PROD` to gracefully handle local development and production edge cases when the `.env` variable isn't passed.
- **Backend (`backend/main.py`)**: 
  - Updated FastAPI CORS middleware to dynamically parse an `ALLOWED_ORIGINS` environment variable as a comma-separated list.
  - Retained the default `localhost` origins as a fallback to ensure local developer workflows remain unaffected.
### Testing/Verification:
- Confirmed that starting the backend without `.env` safely defaults to local development configurations.
- Verified that passing `ALLOWED_ORIGINS` overrides the default CORS allowed hosts.
- Verified that the frontend gracefully warns in the console and recovers if `VITE_BACKEND_URL` is omitted.
## Resolved Issue
Resolves #1624

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Backend CORS middleware configuration now supports dynamic origin allowlisting through environment variables, enabling flexible multi-environment deployments while maintaining backward compatibility with existing defaults.
  * Frontend configuration improved with enhanced environment detection for backend URL selection and added console warnings when required configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->