### PR TITLE
chore: add .editorconfig for consistent coding style across IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-# EditorConfig helps maintain consistent coding styles across editors
-# https://editorconfig.org
-
 root = true
 
 [*]
@@ -11,11 +8,11 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
-trim_trailing_whitespace = false
-
 [*.{py,pyi}]
 indent_size = 4
 
 [Makefile]
 indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Closes #212

Adds  to enforce consistent:
- Indentation (spaces, 2 for most files, 4 for Python)
- Line endings (LF)
- Character encoding (UTF-8)
- Trailing whitespace trimming