### PR TITLE
feat: extend rate limiting to public API endpoints

### DIFF
--- a/backend/auth_cookie.py
+++ b/backend/auth_cookie.py
@@ -9,6 +9,8 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field, field_validator
 
+from backend.limiter import limiter
+
 ACCESS_COOKIE = "access_token"
 REFRESH_COOKIE = "refresh_token"
 ACCESS_MAX_AGE = 60 * 60
@@ -128,7 +130,8 @@ class SignupBody(BaseModel):
 
 
 @router.post("/login")
-async def auth_login(body: LoginBody, response: Response):
+@limiter.limit("5/minute")
+async def auth_login(request: Request, body: LoginBody, response: Response):
     try:
         client = _anon_supabase()
         result = client.auth.sign_in_with_password(
@@ -148,7 +151,8 @@ async def auth_login(body: LoginBody, response: Response):
 
 
 @router.post("/signup")
-async def auth_signup(body: SignupBody, response: Response):
+@limiter.limit("5/minute")
+async def auth_signup(request: Request, body: SignupBody, response: Response):
     metadata: dict[str, str] = {}
     if body.full_name:
         metadata["full_name"] = body.full_name
@@ -178,6 +182,7 @@ async def auth_signup(body: SignupBody, response: Response):
 
 
 @router.post("/logout")
+@limiter.limit("30/minute")
 async def auth_logout(request: Request, response: Response):
     # Invalidate the session server-side before clearing cookies
     token = extract_token(request)
@@ -192,7 +197,8 @@ async def auth_logout(request: Request, response: Response):
 
 
 @router.get("/me")
-async def auth_me(user: dict = Depends(get_current_user)):
+@limiter.limit("60/minute")
+async def auth_me(request: Request, user: dict = Depends(get_current_user)):
     return {"user": user}
 
 

--- a/backend/limiter.py
+++ b/backend/limiter.py
@@ -1,0 +1,14 @@
+"""
+Rate limiter configuration — shared global instance.
+Extracted to avoid circular imports between main.py and routers.
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+# Single global limiter instance (used by main.py and all routers)
+limiter = Limiter(key_func=get_remote_address)
+
+# Shared limit constants
+ML_HEAVY_LIMIT = "10/minute"   # NLP, OCR, Gemini — GPU/CPU intensive
+ML_LIGHT_LIMIT = "30/minute"   # Similar incident search — lighter

--- a/backend/main.py
+++ b/backend/main.py
@@ -132,6 +132,7 @@ from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sl
 from backend.services.redis_cache import redis_cache
 from backend.sla_predictor import get_sla_estimate
 from backend.sanitization import get_security_headers
+from backend.limiter import limiter, ML_HEAVY_LIMIT, ML_LIGHT_LIMIT
 from backend.auth_cookie import router as auth_cookie_router, get_current_user  # noqa: F401
 from backend.sanitization import sanitize_text
 
@@ -382,12 +383,6 @@ def classify_sla_status(sla_breach_at: str | None) -> str:
 # ── Rate limiter setup ────────────────────────────────────────────────────────
 # Uses client IP as the key. In production behind a proxy, set:
 #   get_remote_address to read X-Forwarded-For instead.
-limiter = Limiter(key_func=get_remote_address)
-
-# Limits (tune via env vars in production)
-ML_HEAVY_LIMIT  = "10/minute"   # NLP, OCR, Gemini — GPU/CPU intensive
-ML_LIGHT_LIMIT  = "30/minute"   # Similar incident search — lighter
-
 app = FastAPI(title="AI Helpdesk Ticket Analyzer")
 
 # ── Apply to FastAPI app ──────────────────────────────────────────────────────
@@ -1115,10 +1110,6 @@ body { background: var(--hd-bg); color: var(--hd-text); font-family: 'Inter', sy
 """
 
 # Rate limiter — 10 AI requests per minute per IP (free tier protection)
-limiter = Limiter(key_func=get_remote_address)
-app.state.limiter = limiter
-
-
 async def _custom_rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
     """Custom 429 handler that returns JSON with retry_after field."""
     limit_str = str(exc.detail) if hasattr(exc, 'detail') else RATE_LIMIT_AI
@@ -1134,8 +1125,6 @@ async def _custom_rate_limit_handler(request: Request, exc: RateLimitExceeded) -
         headers={"Retry-After": str(retry_after)},
     )
 
-
-app.add_exception_handler(RateLimitExceeded, _custom_rate_limit_handler)
 
 # ── Security Headers Middleware (Helmet.js equivalent) ────────────────────────
 from security_middleware import SecurityHeadersMiddleware, get_allowed_origins

--- a/backend/routes/estimator.py
+++ b/backend/routes/estimator.py
@@ -2,10 +2,11 @@
 Response Time Estimator API Routes — AI-Powered SLA Breach Prediction
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 from typing import Optional
 
+from backend.limiter import limiter
 from backend.services.response_time_estimator import (
     estimate_response_time,
     generate_estimation_summary,
@@ -23,15 +24,16 @@ class EstimateRequest(BaseModel):
 
 
 @router.post("/estimate")
-async def estimate(request: EstimateRequest):
+@limiter.limit("30/minute")
+async def estimate(request: Request, request_obj: EstimateRequest):
     """Estimate response time and predict SLA breach risk."""
     try:
         estimation = estimate_response_time(
-            priority=request.priority,
-            team_workload=request.team_workload,
-            team_size=request.team_size,
-            category=request.category,
-            historical_avg_hours=request.historical_avg_hours,
+            priority=request_obj.priority,
+            team_workload=request_obj.team_workload,
+            team_size=request_obj.team_size,
+            category=request_obj.category,
+            historical_avg_hours=request_obj.historical_avg_hours,
         )
         summary = generate_estimation_summary(estimation)
 

--- a/backend/routes/translation.py
+++ b/backend/routes/translation.py
@@ -6,10 +6,11 @@ import logging
 import re
 from functools import lru_cache
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator, model_validator
-from typing import Optional
+from typing import Any, Optional
 
+from backend.limiter import limiter
 from backend.services.translation_service import (
     detect_language,
     get_supported_languages,
@@ -122,21 +123,22 @@ def _cached_supported_languages() -> dict[str, str]:
 
 
 @router.post("/translate", response_model=TranslateResponse)
-async def translate(request: TranslateTextRequest):
+@limiter.limit("30/minute")
+async def translate(request: Request, request_obj: TranslateTextRequest):
     """Translate text to target language with auto-detection."""
     logger.info(
         "translate: text_len=%d, target=%s, source=%s",
-        len(request.text), request.target_lang, request.source_lang,
+        len(request_obj.text), request_obj.target_lang, request_obj.source_lang,
     )
     try:
         result = translate_text(
-            text=request.text,
-            target_lang=request.target_lang,
-            source_lang=request.source_lang,
+            text=request_obj.text,
+            target_lang=request_obj.target_lang,
+            source_lang=request_obj.source_lang,
         )
         return {"success": True, "data": result}
     except Exception:
-        logger.exception("Translation failed for text_len=%d", len(request.text))
+        logger.exception("Translation failed for text_len=%d", len(request_obj.text))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Translation service temporarily unavailable. Please try again later.",
@@ -144,25 +146,26 @@ async def translate(request: TranslateTextRequest):
 
 
 @router.post("/translate-ticket", response_model=TranslateResponse)
-async def translate_ticket_endpoint(request: TranslateTicketRequest):
+@limiter.limit("30/minute")
+async def translate_ticket_endpoint(request: Request, request_obj: TranslateTicketRequest):
     """Translate entire ticket content to target language."""
     logger.info(
         "translate_ticket: target=%s, has_subject=%s, has_desc=%s, msg_count=%d",
-        request.target_lang,
-        request.subject is not None,
-        request.description is not None,
-        len(request.messages) if request.messages else 0,
+        request_obj.target_lang,
+        request_obj.subject is not None,
+        request_obj.description is not None,
+        len(request_obj.messages) if request_obj.messages else 0,
     )
     try:
         ticket_data: dict[str, Any] = {}
-        if request.subject:
-            ticket_data["subject"] = request.subject
-        if request.description:
-            ticket_data["description"] = request.description
-        if request.messages:
-            ticket_data["messages"] = [m.model_dump() for m in request.messages]
+        if request_obj.subject:
+            ticket_data["subject"] = request_obj.subject
+        if request_obj.description:
+            ticket_data["description"] = request_obj.description
+        if request_obj.messages:
+            ticket_data["messages"] = [m.model_dump() for m in request_obj.messages]
 
-        result = translate_ticket(ticket_data, target_lang=request.target_lang)
+        result = translate_ticket(ticket_data, target_lang=request_obj.target_lang)
         return {"success": True, "data": result}
     except ValueError as exc:
         raise HTTPException(
@@ -178,10 +181,11 @@ async def translate_ticket_endpoint(request: TranslateTicketRequest):
 
 
 @router.post("/detect", response_model=DetectResponse)
-async def detect(request: DetectLanguageRequest):
+@limiter.limit("30/minute")
+async def detect(request: Request, request_obj: DetectLanguageRequest):
     """Detect the language of the given text."""
-    logger.info("detect: text_len=%d", len(request.text))
-    lang = detect_language(request.text)
+    logger.info("detect: text_len=%d", len(request_obj.text))
+    lang = detect_language(request_obj.text)
     if not lang:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -199,6 +203,7 @@ async def detect(request: DetectLanguageRequest):
 
 
 @router.get("/languages", response_model=LanguagesResponse)
-async def list_languages():
+@limiter.limit("60/minute")
+async def list_languages(request: Request):
     """List supported languages for translation."""
     return {"success": True, "data": _cached_supported_languages()}

--- a/backend/routes/voice.py
+++ b/backend/routes/voice.py
@@ -12,7 +12,9 @@ Issue #207: Voice-to-Ticket Feature
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+
+from backend.limiter import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +25,9 @@ MAX_UPLOAD_SIZE = 25 * 1024 * 1024
 
 
 @router.post("/transcribe")
+@limiter.limit("20/minute")
 async def transcribe_audio(
+    request: Request,
     audio: UploadFile = File(...),
     language: Optional[str] = Form(None),
 ):
@@ -68,7 +72,9 @@ async def transcribe_audio(
 
 
 @router.post("/create-ticket")
+@limiter.limit("20/minute")
 async def create_ticket_from_voice(
+    request: Request,
     audio: UploadFile = File(...),
     user_id: Optional[str] = Form(None),
     company: Optional[str] = Form(None),

--- a/backend/tag_router.py
+++ b/backend/tag_router.py
@@ -2,10 +2,12 @@
 tag_router.py — REST endpoints for ticket tagging
 Issue #404 — Smart Ticket Tagging System
 """
-from fastapi import APIRouter, HTTPException, Header, Query
+from fastapi import APIRouter, HTTPException, Header, Query, Request
 from pydantic import BaseModel, field_validator
 from typing import Optional
 from tag_service import suggest_tags, save_tags, get_tags, get_popular_tags
+
+from backend.limiter import limiter
 
 router = APIRouter(prefix="/api/tags", tags=["tags"])
 
@@ -44,7 +46,9 @@ class SaveTagsRequest(BaseModel):
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 @router.post("/suggest")
+@limiter.limit("20/minute")
 async def suggest_tags_endpoint(
+    request: Request,
     req: SuggestRequest,
     authorization: Optional[str] = Header(None),
 ):

--- a/backend/tests/test_public_rate_limits.py
+++ b/backend/tests/test_public_rate_limits.py
@@ -1,0 +1,139 @@
+import functools
+import importlib
+import unittest
+from unittest.mock import patch
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+import backend.main as main
+
+
+class TestPublicEndpointRateLimits(unittest.TestCase):
+    """Verify public endpoints are protected by the shared SlowAPI limiter."""
+
+    def _reload_module_with_limit(self, module_path: str, limit_wrapper):
+        original_limit = main.limiter.limit
+        main.limiter.limit = limit_wrapper
+        try:
+            module = importlib.reload(importlib.import_module(module_path))
+        finally:
+            main.limiter.limit = original_limit
+            importlib.reload(importlib.import_module(module_path))
+        return module
+
+    def test_translation_routes_are_limited(self):
+        captured = {}
+
+        def fake_limit(value):
+            def decorator(func):
+                captured[func.__name__] = value
+                return func
+
+            return decorator
+
+        translation = self._reload_module_with_limit("backend.routes.translation", fake_limit)
+
+        self.assertEqual(captured.get("translate"), "30/minute")
+        self.assertEqual(captured.get("translate_ticket_endpoint"), "30/minute")
+        self.assertEqual(captured.get("detect"), "30/minute")
+        self.assertEqual(captured.get("list_languages"), "60/minute")
+        self.assertIsNotNone(translation.router)
+
+    def test_auth_routes_are_limited(self):
+        captured = {}
+
+        def fake_limit(value):
+            def decorator(func):
+                captured[func.__name__] = value
+                return func
+
+            return decorator
+
+        auth = self._reload_module_with_limit("backend.auth_cookie", fake_limit)
+
+        self.assertEqual(captured.get("auth_login"), "5/minute")
+        self.assertEqual(captured.get("auth_signup"), "5/minute")
+        self.assertEqual(captured.get("auth_logout"), "30/minute")
+        self.assertEqual(captured.get("auth_me"), "60/minute")
+
+    def test_voice_routes_are_limited(self):
+        captured = {}
+
+        def fake_limit(value):
+            def decorator(func):
+                captured[func.__name__] = value
+                return func
+
+            return decorator
+
+        voice = self._reload_module_with_limit("backend.routes.voice", fake_limit)
+
+        self.assertEqual(captured.get("transcribe_audio"), "20/minute")
+        self.assertEqual(captured.get("create_ticket_from_voice"), "20/minute")
+
+    def test_estimator_route_is_limited(self):
+        captured = {}
+
+        def fake_limit(value):
+            def decorator(func):
+                captured[func.__name__] = value
+                return func
+
+            return decorator
+
+        estimator = self._reload_module_with_limit("backend.routes.estimator", fake_limit)
+
+        self.assertEqual(captured.get("estimate"), "30/minute")
+
+    def test_tag_suggest_route_is_limited(self):
+        captured = {}
+
+        def fake_limit(value):
+            def decorator(func):
+                captured[func.__name__] = value
+                return func
+
+            return decorator
+
+        tags = self._reload_module_with_limit("backend.tag_router", fake_limit)
+
+        self.assertEqual(captured.get("suggest_tags_endpoint"), "20/minute")
+
+    def test_translation_detect_endpoint_returns_429_after_limit(self):
+        def fake_limit(value):
+            def decorator(func):
+                @functools.wraps(func)
+                async def wrapper(*args, **kwargs):
+                    if wrapper.called:
+                        raise HTTPException(status_code=429, detail="Too Many Requests")
+                    wrapper.called = True
+                    return await func(*args, **kwargs)
+
+                wrapper.called = False
+                return wrapper
+
+            return decorator
+
+        original_limit = main.limiter.limit
+        main.limiter.limit = fake_limit
+        try:
+            translation = importlib.reload(importlib.import_module("backend.routes.translation"))
+            app = FastAPI()
+            app.include_router(translation.router)
+
+            with patch("backend.routes.translation.detect_language", return_value="es"), \
+                 patch("backend.routes.translation.get_supported_languages", return_value={"es": "Spanish"}):
+                client = TestClient(app)
+                first = client.post("/api/translation/detect", json={"text": "Hola mundo"})
+                self.assertEqual(first.status_code, 200)
+
+                second = client.post("/api/translation/detect", json={"text": "Hola mundo"})
+                self.assertEqual(second.status_code, 429)
+        finally:
+            main.limiter.limit = original_limit
+            importlib.reload(importlib.import_module("backend.routes.translation"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR extends the existing SlowAPI-based rate limiting system to additional public-facing endpoints that were previously unprotected.

### Changes Made

- Added a shared limiter module to avoid circular imports.
- Reused the existing SlowAPI configuration and exception handling.
- Added rate limiting to:
  - /auth/login
  - /auth/signup
  - /auth/logout
  - /auth/me
  - /api/voice/transcribe
  - /api/voice/create-ticket
  - /api/translation/translate
  - /api/translation/translate-ticket
  - /api/translation/detect
  - /api/translation/languages
  - /api/estimator/estimate
  - /api/tags/suggest
- Added tests covering public endpoint rate-limit configuration.

### Benefits

- Improves protection against abuse and brute-force requests.
- Extends coverage using the existing rate-limiting architecture.
- Avoids duplicate limiter instances and circular imports.
- Preserves existing endpoint behavior.

Closes #1385