### PR TITLE
fix(mobile): resolve hardcoded Supabase anon key and document env vars (Fixes #1401)

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -17,3 +17,12 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 
 # Set to 'false' to disable mock data and use real API
 VITE_USE_MOCK=false
+
+# Support email address
+VITE_SUPPORT_EMAIL=support@example.com
+
+# YouTube API Key for media integrations
+VITE_YOUTUBE_API_KEY=your-youtube-api-key
+
+# Stripe subscription link
+VITE_STRIPE_GROWTH_LINK=https://billing.stripe.com/p/mock-link

--- a/MobileApp/src/lib/supabase.js
+++ b/MobileApp/src/lib/supabase.js
@@ -1,7 +1,6 @@
 import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config';
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
@@ -12,20 +11,13 @@ if (!supabaseUrl || !supabaseKey) {
   );
 }
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  console.error(
-    '[Supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY. ' +
-    'Create a .env file in MobileApp/ with these values. See .env.example.'
-  );
-} else {
-  supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-    auth: {
-      storage: AsyncStorage,
-      autoRefreshToken: true,
-      persistSession: true,
-      detectSessionInUrl: false,
-    },
-  });
-}
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    storage: AsyncStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});
 
 export { supabase };


### PR DESCRIPTION
This PR updates the MobileApp Supabase client configuration to correctly read credentials from environment variables using Expo's runtime prefix (EXPO_PUBLIC_). It removes hardcoded project credentials and completes the environment documentation in Frontend/.env.example.

Fixes #1401