### PR TITLE
Fix #1696: docs: Add GSSoC user authentication setup reference guide

### DIFF
--- a/docs/gssoc/guide_1696.md
+++ b/docs/gssoc/guide_1696.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC user authentication setup reference guide
+
+## Overview
+This guide details the setup and configuration of user authentication using Supabase on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC user authentication setup reference guide.

Closes #1696