### PR TITLE
Fix #1702: docs: Add GSSoC classification model retraining reference guide

### DIFF
--- a/docs/gssoc/guide_1702.md
+++ b/docs/gssoc/guide_1702.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC classification model retraining reference guide
+
+## Overview
+This guide describes how to trigger and evaluate classification model retraining on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC classification model retraining reference guide.

Closes #1702