### PR TITLE
Fix #1704: docs: Add GSSoC frontend state management reference guide

### DIFF
--- a/docs/gssoc/guide_1704.md
+++ b/docs/gssoc/guide_1704.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC frontend state management reference guide
+
+## Overview
+This guide covers the state store patterns and side-effects management on HELPDESK.AI frontend.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC frontend state management reference guide.

Closes #1704