### PR TITLE
Fix #1706: docs: Add GSSoC supervisor daemon configuration reference guide

### DIFF
--- a/docs/gssoc/guide_1706.md
+++ b/docs/gssoc/guide_1706.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC supervisor daemon configuration reference guide
+
+## Overview
+This guide details setting up supervisord to monitor the HelpDesk background queues.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC supervisor daemon configuration reference guide.

Closes #1706