### PR TITLE
Fix #1708: docs: Add GSSoC translation cache eviction reference guide

### DIFF
--- a/docs/gssoc/guide_1708.md
+++ b/docs/gssoc/guide_1708.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC translation cache eviction reference guide
+
+## Overview
+This guide details the Redis cache eviction policies for translation payloads on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC translation cache eviction reference guide.

Closes #1708