### PR TITLE
Fix #1710: docs: Add GSSoC OCR engine preprocessing reference guide

### DIFF
--- a/docs/gssoc/guide_1710.md
+++ b/docs/gssoc/guide_1710.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC OCR engine preprocessing reference guide
+
+## Overview
+This guide describes image binarization and rotation correction before running OCR on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC OCR engine preprocessing reference guide.

Closes #1710