### PR TITLE
Fix #1712: docs: Add GSSoC mail queue fallback reference guide

### DIFF
--- a/docs/gssoc/guide_1712.md
+++ b/docs/gssoc/guide_1712.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC mail queue fallback reference guide
+
+## Overview
+This guide details the mail dispatcher queue fallback strategies on SMTP errors.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC mail queue fallback reference guide.

Closes #1712