### PR TITLE
Fix #1714: docs: Add GSSoC admin dashboard customization reference guide

### DIFF
--- a/docs/gssoc/guide_1714.md
+++ b/docs/gssoc/guide_1714.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC admin dashboard customization reference guide
+
+## Overview
+This guide explains how to customize and extend admin dashboard cards on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC contributor onboarding guidelines.
+Please follow the codebase standards and contribution workflows outlined in the README.


### PR DESCRIPTION
This Pull Request adds the reference manual for GSSoC contributors detailing the workflow for the title: docs: Add GSSoC admin dashboard customization reference guide.

Closes #1714