### PR TITLE
Fix #1718: docs: Add GSSoC SLA breach escalation routing reference guide

### DIFF
--- a/docs/gssoc/guide_1718.md
+++ b/docs/gssoc/guide_1718.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC SLA breach escalation routing reference guide
+
+## Overview
+Details the SLA breach check intervals and email escalation rules on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1718