### PR TITLE
Fix #1720: docs: Add GSSoC duplicate ticket clustering reference guide

### DIFF
--- a/docs/gssoc/guide_1720.md
+++ b/docs/gssoc/guide_1720.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC duplicate ticket clustering reference guide
+
+## Overview
+Explains the duplicate ticket grouping and visual clustering metrics on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1720