### PR TITLE
Fix #1722: docs: Add GSSoC secure cookie storage reference guide

### DIFF
--- a/docs/gssoc/guide_1722.md
+++ b/docs/gssoc/guide_1722.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC secure cookie storage reference guide
+
+## Overview
+Details the cookie signing, domain scopes, and Secure/HttpOnly flags on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1722