### PR TITLE
Fix #1724: docs: Add GSSoC system health logging reference guide

### DIFF
--- a/docs/gssoc/guide_1724.md
+++ b/docs/gssoc/guide_1724.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC system health logging reference guide
+
+## Overview
+Describes the structured JSON logs format and ingestion configuration on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1724