### PR TITLE
Fix #1726: docs: Add GSSoC Redis sentinel clustering reference guide

### DIFF
--- a/docs/gssoc/guide_1726.md
+++ b/docs/gssoc/guide_1726.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC Redis sentinel clustering reference guide
+
+## Overview
+Details how to configure Redis sentinel failover for caches on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1726