### PR TITLE
Fix #1728: docs: Add GSSoC API response payload schema reference guide

### DIFF
--- a/docs/gssoc/guide_1728.md
+++ b/docs/gssoc/guide_1728.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC API response payload schema reference guide
+
+## Overview
+Documents response payloads for core API endpoints on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1728