### PR TITLE
Fix #1730: docs: Add GSSoC React routing optimization reference guide

### DIFF
--- a/docs/gssoc/guide_1730.md
+++ b/docs/gssoc/guide_1730.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC React routing optimization reference guide
+
+## Overview
+Describes code splitting and React.lazy dynamic loading on HELPDESK.AI frontend.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1730