### PR TITLE
Fix #1734: docs: Add GSSoC dev environment onboarding checklist reference guide

### DIFF
--- a/docs/gssoc/guide_1734.md
+++ b/docs/gssoc/guide_1734.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC dev environment onboarding checklist reference guide
+
+## Overview
+Provides an onboarding checklist and local database seeding steps for HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1734