### PR TITLE
Fix #1736: docs: Add GSSoC V2 classifier testing reference guide

### DIFF
--- a/docs/gssoc/guide_1736.md
+++ b/docs/gssoc/guide_1736.md
@@ -1,0 +1,8 @@
+# docs: Add GSSoC V2 classifier testing reference guide
+
+## Overview
+Details validation metrics and test datasets for evaluating the V2 classifier on HELPDESK.AI.
+
+## GSSoC Reference Guide
+This document is part of the GSSoC'26 contributor onboarding guidelines.
+Follow the codebase standards and contribution workflows in the README.


### PR DESCRIPTION
Adds the reference guide for GSSoC contributors.

Closes #1736