### PR TITLE
fix: normalize date parsing for older Safari browsers

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -8,9 +8,16 @@ export const formatTimelineDate = (dateStr) => {
     
     // Ensure the date string is interpreted as UTC if it's an ISO string from DB
     let date;
-    if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
-        // If it's a raw string without TZ, assume it was intended as UTC from our backend
-        date = new Date(dateStr + 'Z');
+    if (typeof dateStr === 'string') {
+        // Safari compatibility: replace hyphens with slashes for YYYY-MM-DD format
+        const normalized = /^\d{4}-\d{2}-\d{2}$/.test(dateStr) ? dateStr.replace(/-/g, '/') : dateStr;
+        
+        if (!normalized.includes('Z') && !normalized.includes('+')) {
+            // Assume UTC if no timezone is provided
+            date = new Date(normalized + (normalized.includes('/') ? ' UTC' : 'Z'));
+        } else {
+            date = new Date(normalized);
+        }
     } else {
         date = new Date(dateStr);
     }


### PR DESCRIPTION
Fixed a bug where ISO-8601 date strings (YYYY-MM-DD) were parsed as 'Invalid Date' in older Safari versions. Implemented a normalization step to replace hyphens with slashes for simple date strings while preserving UTC interpretation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timezone consistency when displaying dates across different platforms
  * Fixed date formatting compatibility issues with Safari browsers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->