### PR TITLE
fix: normalize date parsing for Safari browser compatibility

### DIFF
--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -1,18 +1,37 @@
 /**
  * Unified Date Utility for HELPDESK.AI
  * Fixes timezone shift issues by explicitly forcing local display.
+ * Safari-safe: normalizes ISO-8601 strings before parsing.
  */
+
+/**
+ * Normalize a date string so Safari (and all browsers) can parse it.
+ * Safari rejects "YYYY-MM-DD HH:MM:SS" but accepts "YYYY-MM-DDTHH:MM:SSZ".
+ */
+function normalizeDateString(dateStr) {
+    if (typeof dateStr !== 'string') return dateStr;
+    // Replace a space between date and time with 'T' (Safari fix)
+    let normalized = dateStr.replace(/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2})/, '$1T$2');
+    // If no timezone info, assume UTC
+    if (!normalized.endsWith('Z') && !/[+-]\d{2}:?\d{2}$/.test(normalized) && normalized.includes('T')) {
+        normalized += 'Z';
+    }
+    return normalized;
+}
 
 export const formatTimelineDate = (dateStr) => {
     if (!dateStr) return null;
     
-    // Ensure the date string is interpreted as UTC if it's an ISO string from DB
     let date;
-    if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
-        // If it's a raw string without TZ, assume it was intended as UTC from our backend
-        date = new Date(dateStr + 'Z');
-    } else {
-        date = new Date(dateStr);
+    try {
+        if (typeof dateStr === 'string') {
+            const normalized = normalizeDateString(dateStr);
+            date = new Date(normalized);
+        } else {
+            date = new Date(dateStr);
+        }
+    } catch (_e) {
+        return 'Invalid Date';
     }
 
     if (isNaN(date.getTime())) return 'Invalid Date';

--- a/Frontend/src/utils/dateUtils.test.js
+++ b/Frontend/src/utils/dateUtils.test.js
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for dateUtils — Safari-safe date parsing.
+ * Run with: node --test Frontend/src/utils/dateUtils.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatTimelineDate, formatFullTimestamp } from './dateUtils.js';
+
+describe('formatTimelineDate', () => {
+  it('returns null for null/undefined/empty input', () => {
+    assert.equal(formatTimelineDate(null), null);
+    assert.equal(formatTimelineDate(undefined), null);
+    assert.equal(formatTimelineDate(''), null);
+  });
+
+  it('parses ISO-8601 with Z suffix', () => {
+    const result = formatTimelineDate('2024-06-15T10:30:00Z');
+    assert.ok(result);
+    assert.notEqual(result, 'Invalid Date');
+  });
+
+  it('parses ISO-8601 without Z (assumes UTC)', () => {
+    const result = formatTimelineDate('2024-06-15T10:30:00');
+    assert.ok(result);
+    assert.notEqual(result, 'Invalid Date');
+  });
+
+  it('parses space-separated datetime (Safari fix)', () => {
+    const result = formatTimelineDate('2024-06-15 10:30:00');
+    assert.ok(result);
+    assert.notEqual(result, 'Invalid Date');
+  });
+
+  it('parses date-only strings', () => {
+    const result = formatTimelineDate('2024-06-15');
+    assert.ok(result);
+    assert.notEqual(result, 'Invalid Date');
+  });
+
+  it('parses ISO with timezone offset', () => {
+    const result = formatTimelineDate('2024-06-15T10:30:00+05:30');
+    assert.ok(result);
+    assert.notEqual(result, 'Invalid Date');
+  });
+
+  it('returns Invalid Date for garbage strings', () => {
+    assert.equal(formatTimelineDate('not-a-date'), 'Invalid Date');
+  });
+
+  it('returns Invalid Date for garbage non-string', () => {
+    assert.equal(formatTimelineDate('abc123'), 'Invalid Date');
+  });
+});
+
+describe('formatFullTimestamp', () => {
+  it('returns Processing... for null', () => {
+    assert.equal(formatFullTimestamp(null), 'Processing...');
+  });
+
+  it('appends timezone abbreviation', () => {
+    const result = formatFullTimestamp('2024-06-15T10:30:00Z');
+    assert.ok(result.includes('('));
+    assert.ok(result.includes(')'));
+    assert.notEqual(result, 'Processing...');
+  });
+});


### PR DESCRIPTION
Fixes #1411

## Changes
- Add  helper that converts space-separated datetimes to ISO-8601 with T separator (Safari fix)
- Auto-append 'Z' suffix for timezone-naive strings so Safari parses them correctly
- Add try/catch for robust error handling — invalid dates return 'Invalid Date' instead of throwing
- Add unit tests for various date formats (ISO with Z, without Z, space-separated, date-only, with timezone offset, garbage strings)

## Safari Issue
Safari's  constructor rejects  format (space between date and time) but accepts . This fix normalizes the format before parsing.