### PR TITLE
fix: normalize OCR base64 before validation

### DIFF
--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -65,6 +65,12 @@ class OCRService:
             return ""
 
         image_base64 = image_base64.strip()
+        if len(image_base64) > MAX_BASE64_LENGTH:
+            logger.warning(
+                "[OCRService] Rejected: base64 length %d exceeds limit %d",
+                len(image_base64), MAX_BASE64_LENGTH,
+            )
+            return ""
 
         # ── 1. Strip data-URI prefix ─────────────────────────────────────────
         content_type = None
@@ -77,16 +83,15 @@ class OCRService:
                     logger.warning("[OCRService] Rejected: unsupported content type %s", content_type)
                     return ""
 
-        # ── 2. Re-add padding ─────────────────────────────────────────────────
+        # ── 2. Normalise MIME-wrapped base64 ──────────────────────────────────
+        image_base64 = "".join(image_base64.split())
+        if not image_base64:
+            return ""
+
+        # ── 3. Re-add padding ─────────────────────────────────────────────────
         missing_padding = len(image_base64) % 4
         if missing_padding:
             image_base64 += "=" * (4 - missing_padding)
-
-        # ── 3. Validate base64 characters ─────────────────────────────────────
-        _b64_chars = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=")
-        if not all(c in _b64_chars for c in image_base64):
-            logger.warning("[OCRService] Rejected: invalid base64 characters detected.")
-            return ""
 
         # ── 4. Base64 length guard ────────────────────────────────────────────
         if len(image_base64) > MAX_BASE64_LENGTH:
@@ -98,7 +103,7 @@ class OCRService:
 
         try:
             # ── 5. Decode ─────────────────────────────────────────────────────
-            image_bytes = base64.b64decode(image_base64)
+            image_bytes = base64.b64decode(image_base64, validate=True)
 
             # ── 6. Decoded-bytes guard ────────────────────────────────────────
             if len(image_bytes) > MAX_DECODED_BYTES:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -528,6 +528,8 @@ def mock_ai_services(request):
         "test_notification_routing.py",
         "test_notification_routing_push.py",
         "test_notification_routing_admin_alert.py",
+        "test_ocr_service.py",
+        "test_ocr_dos_protection.py",
     }:
         yield
         return

--- a/backend/tests/test_ocr_service.py
+++ b/backend/tests/test_ocr_service.py
@@ -84,6 +84,26 @@ class TestOCRServiceInputValidation:
             assert result == "hello"
 
     @pytest.mark.asyncio
+    async def test_accepts_mime_wrapped_base64(self):
+        svc = OCRService()
+        tiny = _make_tiny_png_bytes()
+        wrapped = base64.encodebytes(tiny).decode()
+
+        with patch.object(svc, "_run_ocr", return_value=["wrapped"]):
+            result = await svc.extract_text(wrapped)
+            assert result == "wrapped"
+
+    @pytest.mark.asyncio
+    async def test_accepts_mime_wrapped_data_uri(self):
+        svc = OCRService()
+        tiny = _make_tiny_png_bytes()
+        wrapped = base64.encodebytes(tiny).decode()
+
+        with patch.object(svc, "_run_ocr", return_value=["uri wrapped"]):
+            result = await svc.extract_text(f"data:image/png;base64,{wrapped}")
+            assert result == "uri wrapped"
+
+    @pytest.mark.asyncio
     async def test_rejects_unsupported_content_type(self):
         svc = OCRService()
         tiny = _make_tiny_png_bytes()


### PR DESCRIPTION
Closes #793

## Summary
- normalize MIME-wrapped base64 by stripping internal whitespace after the optional data URI header is parsed
- replace the Python-level `all(...)` character scan with `base64.b64decode(..., validate=True)` so validation matches the decoder
- keep size guards before and after normalization to reject oversized payloads early
- let OCR-focused tests avoid the global app/AI-service fixture and add regressions for wrapped base64 payloads

## Validation
- `PYTHONPATH=backend:. /Users/henry/Documents/Codex/2026-06-04/new-chat/work/venvs/helpdesk-ocr-py312/bin/python -m pytest backend/tests/test_ocr_service.py -q` -> 17 passed, 1 existing coroutine warning
- `PYTHONPATH=backend:. /Users/henry/Documents/Codex/2026-06-04/new-chat/work/venvs/helpdesk-ocr-py312/bin/python -m pytest backend/tests/test_ocr_dos_protection.py::TestOCRServiceGuards -q` -> 6 passed, 1 existing asyncio deprecation warning
- `/Users/henry/Documents/Codex/2026-06-04/new-chat/work/venvs/helpdesk-ocr-py312/bin/python -m py_compile backend/services/ocr_service.py backend/tests/test_ocr_service.py backend/tests/conftest.py`
- `git diff --check`
