### PR TITLE
fix: add authentication to GET /tickets and GET /tickets/{id} (#1669)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -536,7 +536,7 @@ async def log_correction(raw_request: Request):
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
+async def get_tickets(user: dict = Depends(get_current_user), company_id: str | None = None):
     """Fetch persistent tickets from Supabase."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
@@ -652,7 +652,7 @@ async def save_ticket(request_body: TicketSaveRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/tickets/{ticket_id}")
-async def get_ticket_by_id(ticket_id: str):
+async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user)):
     """Fetch single persistent ticket."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")


### PR DESCRIPTION
﻿### Description

**Issue:** Closes #1669

The `GET /tickets` and `GET /tickets/{ticket_id}` endpoints had no authentication. Any unauthenticated user could read all tickets across all tenants.

### Fix

Added `Depends(get_current_user)` to both endpoints, which validates the Supabase JWT session before returning ticket data.

### Changes

- `backend/main.py`: added `user: dict = Depends(get_current_user)` to `GET /tickets` and `GET /tickets/{ticket_id}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Accessing ticket information now requires user authentication to retrieve ticket listings and view individual ticket details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->