### PR TITLE
test: cover encryption utility redaction behavior

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -528,6 +528,7 @@ def mock_ai_services(request):
         "test_notification_routing.py",
         "test_notification_routing_push.py",
         "test_notification_routing_admin_alert.py",
+        "test_encryption_new.py",
     }:
         yield
         return

--- a/backend/tests/test_encryption_new.py
+++ b/backend/tests/test_encryption_new.py
@@ -1,409 +1,180 @@
-"""Unit tests for backend/utils/encryption.py - AES-256-GCM encryption utilities.
+"""Unit tests for backend.utils.encryption.
 
-Issue: #1101 - test: add unit tests for encryption utility
+Issue #1101 asks for coverage around the encryption utility. These tests keep
+the cryptography package real while patching key derivation where the exact
+PBKDF2 output is not under test, making the suite fast and deterministic.
 """
 
-import unittest
 import base64
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.utils import encryption
 
 
-# ---------------------------------------------------------------------------
-# Import the real module after mocking heavy crypto imports
-# ---------------------------------------------------------------------------
-
-# We patch the heavy crypto imports so tests run fast without real crypto
-# but we still exercise the actual logic by patching at the function level.
-
-import sys
-sys.modules['cryptography'] = MagicMock()
-sys.modules['cryptography.hazmat'] = MagicMock()
-sys.modules['cryptography.hazmat.primitives'] = MagicMock()
-sys.modules['cryptography.hazmat.primitives.ciphers'] = MagicMock()
-sys.modules['cryptography.hazmat.primitives.ciphers.aead'] = MagicMock()
-sys.modules['cryptography.hazmat.primitives.hashes'] = MagicMock()
-sys.modules['cryptography.hazmat.primitives.kdf'] = MagicMock()
-sys.modules['cryptography.hazmat.primitives.kdf.pbkdf2'] = MagicMock()
-
-# Now import our module
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+FAST_TEST_KEY = b"0" * 32
 
 
-class TestEncryptionUtilities(unittest.TestCase):
-    """Test the encryption.py utility functions with mocked crypto."""
+class TestGetEncryptionKey:
+    def test_uses_default_password_and_salt(self, monkeypatch):
+        monkeypatch.delenv("ENCRYPTION_PASSWORD", raising=False)
+        monkeypatch.delenv("ENCRYPTION_SALT", raising=False)
 
-    def setUp(self):
-        """Reset mocks before each test."""
-        self._mock_aesgcm = MagicMock()
-        self._mock_kdf = MagicMock()
-        self._mock_derive = MagicMock(return_value=b'0' * 32)
+        mock_kdf = MagicMock()
+        mock_kdf.derive.return_value = FAST_TEST_KEY
+        kdf_cls = MagicMock(return_value=mock_kdf)
+        monkeypatch.setattr(encryption, "PBKDF2HMAC", kdf_cls)
 
-        AESGCM.reset_mock()
-        PBKDF2HMAC.reset_mock()
-        self._mock_kdf.derive = self._mock_derive
-        PBKDF2HMAC.return_value = self._mock_kdf
+        assert encryption.get_encryption_key() == FAST_TEST_KEY
+        kdf_cls.assert_called_once()
+        mock_kdf.derive.assert_called_once_with(b"helpdesk-default-key")
 
-    # ---- get_encryption_key ----
+    def test_uses_environment_password_and_salt(self, monkeypatch):
+        monkeypatch.setenv("ENCRYPTION_PASSWORD", "env-password")
+        monkeypatch.setenv("ENCRYPTION_SALT", "env-salt")
 
-    def test_get_key_default_password_and_salt(self):
-        """Key derived from default password and salt when env vars unset."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import get_encryption_key
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-            result = get_encryption_key()
-            self.assertEqual(result, b'0' * 32)
-            self._mock_derive.assert_called_once()
+        mock_kdf = MagicMock()
+        mock_kdf.derive.return_value = FAST_TEST_KEY
+        kdf_cls = MagicMock(return_value=mock_kdf)
+        monkeypatch.setattr(encryption, "PBKDF2HMAC", kdf_cls)
 
-    def test_get_key_custom_password(self):
-        """Key derived from provided password."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import get_encryption_key
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-            result = get_encryption_key(password="my-secret-pw")
-            self.assertEqual(result, b'0' * 32)
-            # Password should be used in derive call
-            call_args = self._mock_derive.call_args[0]
-            self.assertIn("my-secret-pw", call_args[0].decode())
+        assert encryption.get_encryption_key() == FAST_TEST_KEY
+        kwargs = kdf_cls.call_args.kwargs
+        assert kwargs["salt"] == b"env-salt"
+        mock_kdf.derive.assert_called_once_with(b"env-password")
 
-    def test_get_key_custom_salt_bytes(self):
-        """Key derived with custom salt as bytes."""
-        from backend.utils.encryption import get_encryption_key
-        PBKDF2HMAC.reset_mock()
-        self._mock_kdf.derive = self._mock_derive
-        PBKDF2HMAC.return_value = self._mock_kdf
-        result = get_encryption_key(salt=b'custom-salt-bytes-16char')
-        self.assertEqual(result, b'0' * 32)
+    def test_accepts_string_and_bytes_salt(self, monkeypatch):
+        seen_salts = []
 
-    def test_get_key_custom_salt_string(self):
-        """Key derived with custom salt as string (should be encoded)."""
-        from backend.utils.encryption import get_encryption_key
-        PBKDF2HMAC.reset_mock()
-        self._mock_kdf.derive = self._mock_derive
-        PBKDF2HMAC.return_value = self._mock_kdf
-        result = get_encryption_key(salt="string-salt")
-        self.assertEqual(result, b'0' * 32)
+        def fake_kdf_factory(**kwargs):
+            seen_salts.append(kwargs["salt"])
+            mock_kdf = MagicMock()
+            mock_kdf.derive.return_value = FAST_TEST_KEY
+            return mock_kdf
 
-    def test_get_key_from_env(self):
-        """Key derived from ENCRYPTION_PASSWORD env var."""
-        with patch.dict('os.environ', {'ENCRYPTION_PASSWORD': 'env-password'}):
-            from backend.utils.encryption import get_encryption_key
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-            result = get_encryption_key()
-            self.assertEqual(result, b'0' * 32)
+        monkeypatch.setattr(encryption, "PBKDF2HMAC", fake_kdf_factory)
 
-    def test_get_key_with_salt_from_env(self):
-        """Key derived with ENCRYPTION_SALT env var."""
-        with patch.dict('os.environ', {'ENCRYPTION_SALT': 'env-salt'}):
-            from backend.utils.encryption import get_encryption_key
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-            result = get_encryption_key()
-            self.assertEqual(result, b'0' * 32)
-
-    # ---- encrypt_aes256_gcm ----
-
-    def test_encrypt_empty_string_returns_empty(self):
-        """Empty string should return empty string."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            result = encrypt_aes256_gcm("")
-            self.assertEqual(result, "")
-
-    def test_encrypt_normal_text(self):
-        """Normal text should be encrypted and return base64 string."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            # Mock AESGCM encrypt to return known bytes
-            mock_aes = MagicMock()
-            mock_aes.encrypt.return_value = b'encrypted_data_here!'
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', return_value=b'\x01' * 12):
-                result = encrypt_aes256_gcm("Hello World")
-                self.assertIsInstance(result, str)
-                decoded = base64.b64decode(result)
-                # First 12 bytes should be nonce
-                self.assertEqual(decoded[:12], b'\x01' * 12)
-
-    def test_encrypt_with_special_characters(self):
-        """Text with special/unicode characters should encrypt correctly."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            mock_aes = MagicMock()
-            mock_aes.encrypt.return_value = b'special_encrypted'
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', return_value=b'\x02' * 12):
-                result = encrypt_aes256_gcm("p@ssw0rd!$%^&*()_+-={}[]|:;<>,.?/~`")
-                self.assertIsInstance(result, str)
-                self.assertTrue(len(result) > 0)
-
-    def test_encrypt_unicode_text(self):
-        """Unicode text (Chinese, emoji) should encrypt correctly."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            mock_aes = MagicMock()
-            mock_aes.encrypt.return_value = b'unicode_encrypted'
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', return_value=b'\x03' * 12):
-                result = encrypt_aes256_gcm("你好世界 🌍✨")
-                self.assertIsInstance(result, str)
-
-    def test_encrypt_different_nonces_produce_different_outputs(self):
-        """Same plaintext with different nonces produces different ciphertexts."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            mock_aes = MagicMock()
-            mock_aes.encrypt.side_effect = [
-                b'cipher1', b'cipher2'
-            ]
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', side_effect=[b'\xaa' * 12, b'\xbb' * 12]):
-                r1 = encrypt_aes256_gcm("same text")
-                r2 = encrypt_aes256_gcm("same text")
-                self.assertNotEqual(r1, r2)
-
-    # ---- decrypt_aes256_gcm ----
-
-    def test_decrypt_empty_string_returns_empty(self):
-        """Empty encrypted string should return empty string."""
-        from backend.utils.encryption import decrypt_aes256_gcm
-        result = decrypt_aes256_gcm("")
-        self.assertEqual(result, "")
-
-    def test_decrypt_roundtrip(self):
-        """Decrypt should recover original plaintext."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import decrypt_aes256_gcm
-
-            original = "Secret message 42!"
-            nonce = b'\xde' * 12
-            ciphertext = nonce + b'enc_payload'
-
-            mock_aes = MagicMock()
-            mock_aes.decrypt.return_value = original.encode()
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            encrypted_b64 = base64.b64encode(ciphertext).decode()
-            result = decrypt_aes256_gcm(encrypted_b64)
-            self.assertEqual(result, original)
-
-    def test_decrypt_with_custom_password(self):
-        """Decrypt with custom password uses that password for key derivation."""
-        from backend.utils.encryption import decrypt_aes256_gcm
-        mock_aes = MagicMock()
-        mock_aes.decrypt.return_value = b'recovered_data'
-        AESGCM.return_value = mock_aes
-        PBKDF2HMAC.reset_mock()
-        self._mock_kdf.derive = self._mock_derive
-        PBKDF2HMAC.return_value = self._mock_kdf
-
-        ciphertext = b'\x11' * 12 + b'payload'
-        encrypted_b64 = base64.b64encode(ciphertext).decode()
-        result = decrypt_aes256_gcm(encrypted_b64, password="custom-pw")
-        self.assertEqual(result, "recovered_data")
-
-    def test_decrypt_long_text(self):
-        """Decrypt handles long encrypted payloads."""
-        from backend.utils.encryption import decrypt_aes256_gcm
-        long_text = "A" * 10000
-        mock_aes = MagicMock()
-        mock_aes.decrypt.return_value = long_text.encode()
-        AESGCM.return_value = mock_aes
-        PBKDF2HMAC.reset_mock()
-        self._mock_kdf.derive = self._mock_derive
-        PBKDF2HMAC.return_value = self._mock_kdf
-
-        ciphertext = b'\x44' * 12 + b'long_payload'
-        encrypted_b64 = base64.b64encode(ciphertext).decode()
-        result = decrypt_aes256_gcm(encrypted_b64)
-        self.assertEqual(result, long_text)
-
-    # ---- redact_pii (from encryption.py) ----
-
-    def test_redact_pii_empty_text(self):
-        """Empty text returns empty."""
-        from backend.utils.encryption import redact_pii
-        result = redact_pii("")
-        self.assertEqual(result, "")
-
-    def test_redact_pii_none_text(self):
-        """None returns None (falsy check)."""
-        from backend.utils.encryption import redact_pii
-        result = redact_pii(None)
-        self.assertIsNone(result)
-
-    def test_redact_pii_email(self):
-        """Email addresses are redacted."""
-        from backend.utils.encryption import redact_pii
-        result = redact_pii("Contact user@example.com for help")
-        self.assertNotIn("user@example.com", result)
-        self.assertIn("[REDACTED_EMAIL]", result)
-
-    def test_redact_pii_multiple_emails(self):
-        """Multiple email addresses are all redacted."""
-        from backend.utils.encryption import redact_pii
-        text = "Email a@b.com and c@d.org"
-        result = redact_pii(text)
-        self.assertNotIn("a@b.com", result)
-        self.assertNotIn("c@d.org", result)
-
-    def test_redact_pii_phone(self):
-        """Phone numbers are redacted."""
-        from backend.utils.encryption import redact_pii
-        result = redact_pii("Call 800-555-0199 for support")
-        self.assertNotIn("800-555-0199", result)
-        self.assertIn("[REDACTED_PHONE]", result)
-
-    def test_redact_pii_ssn(self):
-        """SSN formatted numbers are redacted."""
-        from backend.utils.encryption import redact_pii
-        result = redact_pii("SSN: 123-45-6789")
-        self.assertNotIn("123-45-6789", result)
-        self.assertIn("[REDACTED_SSN]", result)
-
-    def test_redact_pii_credit_card(self):
-        """Credit card numbers are redacted."""
-        from backend.utils.encryption import redact_pii
-        result = redact_pii("Card: 4111-1111-1111-1111")
-        self.assertNotIn("4111-1111-1111-1111", result)
-        self.assertIn("[REDACTED_CREDIT_CARD]", result)
-
-    def test_redact_pii_combined(self):
-        """All PII types redacted simultaneously."""
-        from backend.utils.encryption import redact_pii
-        text = "Email: me@test.com, Phone: 123-456-7890, SSN: 987-65-4321, Card: 5555 5555 5555 4444"
-        result = redact_pii(text)
-        for pii_type in ["EMAIL", "PHONE", "SSN", "CREDIT_CARD"]:
-            self.assertIn(f"[REDACTED_{pii_type}]", result)
-
-    def test_redact_pii_no_pii_unchanged(self):
-        """Text without PII is returned unchanged."""
-        from backend.utils.encryption import redact_pii
-        text = "Just a normal sentence with no PII."
-        result = redact_pii(text)
-        self.assertEqual(result, text)
-
-    # ---- redact_and_encrypt ----
-
-    def test_redact_and_encrypt_normal_text(self):
-        """Redact then encrypt should produce base64 output."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import redact_and_encrypt
-            mock_aes = MagicMock()
-            mock_aes.encrypt.return_value = b'combined_encrypted'
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', return_value=b'\xcc' * 12):
-                result = redact_and_encrypt("Email: a@b.com, normal text")
-                self.assertIsInstance(result, str)
-                # Should not contain the raw email
-                self.assertNotIn("a@b.com", result)
-
-    def test_redact_and_encrypt_empty(self):
-        """Empty text redacted and encrypted returns empty."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import redact_and_encrypt
-            result = redact_and_encrypt("")
-            self.assertEqual(result, "")
-
-    # ---- decrypt_and_reveal ----
-
-    def test_decrypt_and_reveal_roundtrip(self):
-        """Decrypt reveals the redacted+encrypted text."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import decrypt_and_reveal
-            redacted_text = "Message: [REDACTED_EMAIL] normal"
-            mock_aes = MagicMock()
-            mock_aes.decrypt.return_value = redacted_text.encode()
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            ciphertext = b'\xee' * 12 + b'payload'
-            encrypted_b64 = base64.b64encode(ciphertext).decode()
-            result = decrypt_and_reveal(encrypted_b64)
-            self.assertEqual(result, redacted_text)
-
-    # ---- Edge cases ----
-
-    def test_encrypt_very_long_text(self):
-        """Very long text (100KB+) encrypts without error."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            long_text = "X" * 100000
-            mock_aes = MagicMock()
-            mock_aes.encrypt.return_value = b'x' * 100016
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', return_value=b'\xff' * 12):
-                result = encrypt_aes256_gcm(long_text)
-                self.assertIsInstance(result, str)
-                self.assertTrue(len(result) > 0)
-
-    def test_encrypt_single_char(self):
-        """Single character text encrypts correctly."""
-        with patch.dict('os.environ', {}, clear=True):
-            from backend.utils.encryption import encrypt_aes256_gcm
-            mock_aes = MagicMock()
-            mock_aes.encrypt.return_value = b'x'
-            AESGCM.return_value = mock_aes
-            PBKDF2HMAC.reset_mock()
-            self._mock_kdf.derive = self._mock_derive
-            PBKDF2HMAC.return_value = self._mock_kdf
-
-            with patch('os.urandom', return_value=b'\x99' * 12):
-                result = encrypt_aes256_gcm("X")
-                self.assertIsInstance(result, str)
-
-    def test_decrypt_tampered_ciphertext(self):
-        """Decrypt with wrong password or tampered data raises error."""
-        from backend.utils.encryption import decrypt_aes256_gcm
-        mock_aes = MagicMock()
-        mock_aes.decrypt.side_effect = Exception("InvalidTag")
-        AESGCM.return_value = mock_aes
-        PBKDF2HMAC.reset_mock()
-        self._mock_kdf.derive = self._mock_derive
-        PBKDF2HMAC.return_value = self._mock_kdf
-
-        ciphertext = b'\x00' * 12 + b'tampered'
-        encrypted_b64 = base64.b64encode(ciphertext).decode()
-        with self.assertRaises(Exception):
-            decrypt_aes256_gcm(encrypted_b64)
+        assert encryption.get_encryption_key("pw", salt="string-salt") == FAST_TEST_KEY
+        assert encryption.get_encryption_key("pw", salt=b"bytes-salt") == FAST_TEST_KEY
+        assert seen_salts == [b"string-salt", b"bytes-salt"]
 
 
-if __name__ == '__main__':
-    unittest.main()
+class TestAesGcmEncryption:
+    @pytest.fixture(autouse=True)
+    def fast_key(self, monkeypatch):
+        monkeypatch.setattr(encryption, "get_encryption_key", lambda password=None: FAST_TEST_KEY)
+
+    @pytest.mark.parametrize(
+        "plaintext",
+        [
+            "normal password",
+            "p@ssw0rd! $%^&*()",
+            "unicode text: hola, こんにちは, 🔐",
+            "x" * 10_000,
+        ],
+    )
+    def test_encrypt_decrypt_roundtrip_for_various_inputs(self, plaintext):
+        encrypted = encryption.encrypt_aes256_gcm(plaintext, password="secret")
+
+        assert encrypted != plaintext
+        assert isinstance(encrypted, str)
+        assert encryption.decrypt_aes256_gcm(encrypted, password="secret") == plaintext
+
+    def test_empty_values_are_preserved(self):
+        assert encryption.encrypt_aes256_gcm("") == ""
+        assert encryption.decrypt_aes256_gcm("") == ""
+
+    def test_nonce_is_prepended_to_ciphertext(self, monkeypatch):
+        monkeypatch.setattr(encryption.os, "urandom", lambda size: b"\x01" * size)
+
+        encrypted = encryption.encrypt_aes256_gcm("hello")
+        decoded = base64.b64decode(encrypted)
+
+        assert decoded[:12] == b"\x01" * 12
+        assert len(decoded) > 12
+
+    def test_same_plaintext_uses_random_nonce(self):
+        first = encryption.encrypt_aes256_gcm("same text")
+        second = encryption.encrypt_aes256_gcm("same text")
+
+        assert first != second
+        assert encryption.decrypt_aes256_gcm(first) == "same text"
+        assert encryption.decrypt_aes256_gcm(second) == "same text"
+
+    def test_tampered_ciphertext_raises(self):
+        encrypted = encryption.encrypt_aes256_gcm("sensitive")
+        raw = bytearray(base64.b64decode(encrypted))
+        raw[-1] ^= 1
+        tampered = base64.b64encode(raw).decode("utf-8")
+
+        with pytest.raises(Exception):
+            encryption.decrypt_aes256_gcm(tampered)
+
+    def test_invalid_base64_raises(self):
+        with pytest.raises(Exception):
+            encryption.decrypt_aes256_gcm("not valid base64")
+
+
+class TestPiiRedaction:
+    @pytest.mark.parametrize(
+        ("text", "token", "secret"),
+        [
+            ("Email user@example.com", "[REDACTED_EMAIL]", "user@example.com"),
+            ("Call +1 800-555-0199", "[REDACTED_PHONE]", "800-555-0199"),
+            ("SSN 123-45-6789", "[REDACTED_SSN]", "123-45-6789"),
+            ("Card 4111-1111-1111-1111", "[REDACTED_CREDIT_CARD]", "4111-1111-1111-1111"),
+        ],
+    )
+    def test_redacts_supported_pii_types(self, text, token, secret):
+        redacted = encryption.redact_pii(text)
+
+        assert token in redacted
+        assert secret not in redacted
+
+    def test_redacts_multiple_pii_types_together(self):
+        text = (
+            "Email me@test.com, phone 123-456-7890, "
+            "SSN 987-65-4321, card 5555 5555 5555 4444"
+        )
+
+        redacted = encryption.redact_pii(text)
+
+        for token in (
+            "[REDACTED_EMAIL]",
+            "[REDACTED_PHONE]",
+            "[REDACTED_SSN]",
+            "[REDACTED_CREDIT_CARD]",
+        ):
+            assert token in redacted
+        assert "me@test.com" not in redacted
+        assert "987-65-4321" not in redacted
+
+    def test_falsy_text_is_returned_unchanged(self):
+        assert encryption.redact_pii("") == ""
+        assert encryption.redact_pii(None) is None
+
+    def test_text_without_pii_is_unchanged(self):
+        text = "A normal support ticket without sensitive data."
+        assert encryption.redact_pii(text) == text
+
+
+class TestCombinedHelpers:
+    @pytest.fixture(autouse=True)
+    def fast_key(self, monkeypatch):
+        monkeypatch.setattr(encryption, "get_encryption_key", lambda password=None: FAST_TEST_KEY)
+
+    def test_redact_and_encrypt_hides_pii_before_encryption(self):
+        encrypted = encryption.redact_and_encrypt("Contact user@example.com", password="secret")
+
+        assert "user@example.com" not in encrypted
+        decrypted = encryption.decrypt_and_reveal(encrypted, password="secret")
+        assert decrypted == "Contact [REDACTED_EMAIL]"
+
+    def test_empty_redact_and_encrypt_returns_empty(self):
+        assert encryption.redact_and_encrypt("") == ""
+
+    def test_decrypt_and_reveal_delegates_to_decrypt(self):
+        encrypted = encryption.encrypt_aes256_gcm("Message [REDACTED_EMAIL]")
+
+        assert encryption.decrypt_and_reveal(encrypted) == "Message [REDACTED_EMAIL]"

--- a/backend/utils/encryption.py
+++ b/backend/utils/encryption.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 # PII patterns for redaction
 PII_PATTERNS = {
     "email": re.compile(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'),
-    "phone": re.compile(r'\+?[\d\s\-()]{7,15}'),
     "ssn": re.compile(r'\b\d{3}-\d{2}-\d{4}\b'),
     "credit_card": re.compile(r'\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b'),
+    "phone": re.compile(r'\+?[\d\s\-()]{7,15}'),
 }
 
 


### PR DESCRIPTION
## Summary
- Replaces brittle global cryptography mocks in `test_encryption_new.py` with focused pytest coverage for `backend.utils.encryption`.
- Covers key derivation inputs, AES-GCM round trips, nonce behavior, tamper handling, PII redaction, and combined redact/encrypt helpers.
- Fixes PII redaction ordering so SSNs and credit-card numbers are not partially consumed by the broader phone-number regex first.

## Verification
- `python -m pytest backend\tests\test_encryption_new.py -q` -> 22 passed
- Direct smoke check confirmed SSN, credit-card, and phone redaction tokens are preserved correctly.

Closes #1101