### PR TITLE
fix: accept MIME-wrapped base64 in OCR service

### DIFF
--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -78,17 +78,15 @@ class OCRService:
                     return ""
 
         # ── 2. Re-add padding ─────────────────────────────────────────────────
+        image_base64 = "".join(image_base64.split())
+        if not image_base64:
+            return ""
+
         missing_padding = len(image_base64) % 4
         if missing_padding:
             image_base64 += "=" * (4 - missing_padding)
 
-        # ── 3. Validate base64 characters ─────────────────────────────────────
-        _b64_chars = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=")
-        if not all(c in _b64_chars for c in image_base64):
-            logger.warning("[OCRService] Rejected: invalid base64 characters detected.")
-            return ""
-
-        # ── 4. Base64 length guard ────────────────────────────────────────────
+        # ── 3. Base64 length guard ────────────────────────────────────────────
         if len(image_base64) > MAX_BASE64_LENGTH:
             logger.warning(
                 "[OCRService] Rejected: base64 length %d exceeds limit %d",
@@ -98,7 +96,7 @@ class OCRService:
 
         try:
             # ── 5. Decode ─────────────────────────────────────────────────────
-            image_bytes = base64.b64decode(image_base64)
+            image_bytes = base64.b64decode(image_base64, validate=True)
 
             # ── 6. Decoded-bytes guard ────────────────────────────────────────
             if len(image_bytes) > MAX_DECODED_BYTES:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -524,6 +524,7 @@ def mock_ai_services(request):
         "test_knowledge_gap_service.py",
         "test_metrics_service.py",
         "test_audit_service.py",
+        "test_ocr_service.py",
         "test_correction_log_async.py",
         "test_notification_routing.py",
         "test_notification_routing_push.py",

--- a/backend/tests/test_ocr_service.py
+++ b/backend/tests/test_ocr_service.py
@@ -84,6 +84,17 @@ class TestOCRServiceInputValidation:
             assert result == "hello"
 
     @pytest.mark.asyncio
+    async def test_accepts_mime_wrapped_base64_with_newlines(self):
+        svc = OCRService()
+        tiny = _make_tiny_png_bytes()
+        b64 = _b64(tiny)
+        wrapped = "\r\n".join(b64[i:i + 16] for i in range(0, len(b64), 16))
+
+        with patch.object(svc, "_run_ocr", return_value=["wrapped"]):
+            result = await svc.extract_text(f"data:image/png;base64,{wrapped}")
+            assert result == "wrapped"
+
+    @pytest.mark.asyncio
     async def test_rejects_unsupported_content_type(self):
         svc = OCRService()
         tiny = _make_tiny_png_bytes()


### PR DESCRIPTION
Closes #793.

## Summary
- Normalize whitespace from MIME-wrapped base64 OCR payloads before padding and decoding.
- Replace the Python-level manual character scan with `base64.b64decode(..., validate=True)`.
- Add a regression test for data URI base64 payloads containing CRLF line wrapping.
- Exempt the isolated OCR unit test file from the global AI-service fixture so it can run without importing the full app.

## Verification
- `python -m pytest backend\tests\test_ocr_service.py -q` -> 16 passed, 1 existing coroutine warning in the timeout test.