### PR TITLE
fix: sanitize auto resolve markdown

### DIFF
--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -20,6 +20,7 @@ import TicketAuditTimeline from "../components/TicketAuditTimeline";
 import TicketTagManager from '../../components/TicketTagManager';
 import TagChip from '../../components/TagChip';
 import { TicketDetailSkeleton } from "../../components/Skeletons";
+import { safeDisplayText } from "../../utils/sanitizeText";
 
 const AdminTicketDetailSkeleton = () => (
     <div
@@ -73,11 +74,6 @@ const AdminTicketDetailSkeleton = () => (
         </div>
     </div>
 );
-
-const safeDisplayText = (text, fallback = 'None') => {
-  if (text === null || text === undefined || text === '') return fallback;
-  return text;
-};
 
 const AdminTicketDetail = () => {
   const { ticket_id } = useParams();

--- a/Frontend/src/user/pages/AutoResolveChat.jsx
+++ b/Frontend/src/user/pages/AutoResolveChat.jsx
@@ -414,6 +414,7 @@ const AutoResolveChat = () => {
                         {msg.role === 'bot' ? (
                           <ReactMarkdown
                             remarkPlugins={[remarkGfm]}
+                            rehypePlugins={[rehypeSanitize]}
                             components={{
                               ul: ({ ...props }) => (
                                 <ul className='list-disc ml-4 space-y-2 mb-3' {...props} />


### PR DESCRIPTION
Closes #858.

## Summary
- Wire `rehype-sanitize` into the AI-generated `ReactMarkdown` output in `AutoResolveChat`.
- Replace the local raw `safeDisplayText` helper in `AdminTicketDetail` with the shared sanitizer utility.

## Verification
- Static check: confirmed `rehypePlugins={[rehypeSanitize]}` is wired and `AdminTicketDetail` imports the shared `safeDisplayText`.
- Full frontend build was not run because `Frontend/package.json` is currently invalid JSON on `gssoc` (missing comma before duplicate `cypress` devDependency entry).