### PR TITLE
fix: warn on unknown SLA priorities

### DIFF
--- a/backend/services/sla_engine.py
+++ b/backend/services/sla_engine.py
@@ -143,7 +143,14 @@ class SLAEngine:
           - needs_notification: bool
           - policy: the applied SLA policy
         """
-        priority_key = (ticket.get("priority") or "medium").lower().strip()
+        original_priority = ticket.get("priority")
+        priority_key = (original_priority or "medium").lower().strip()
+        if priority_key not in SLA_POLICIES:
+            logger.warning(
+                "[SLA] Unknown priority %r for ticket %s; falling back to medium policy.",
+                original_priority,
+                ticket.get("id") or ticket.get("ticket_id") or "<unknown>",
+            )
         policy = SLA_POLICIES.get(priority_key, SLA_POLICIES["medium"])
 
         # Resolve the start time: use sla_started_at if set, else created_at

--- a/backend/tests/test_sla_engine.py
+++ b/backend/tests/test_sla_engine.py
@@ -360,7 +360,7 @@ class TestSLAEngineEvaluateTicket:
 
     def test_priority_case_insensitive(self):
         now = datetime.datetime.now(datetime.timezone.utc)
-        past = now - datetime.timedelta(hours=6)
+        past = now - datetime.timedelta(hours=2)
         ticket = {"priority": "HIGH", "created_at": past.isoformat(), "status": "open"}
         result = self.engine.evaluate_ticket(ticket)
         assert result["sla_status"] in ("warning", "active")
@@ -371,6 +371,22 @@ class TestSLAEngineEvaluateTicket:
         ticket = {"created_at": past.isoformat(), "status": "open"}
         result = self.engine.evaluate_ticket(ticket)
         assert "policy" in result
+
+    def test_unknown_priority_logs_warning_and_uses_medium_policy(self, caplog):
+        now = datetime.datetime.now(datetime.timezone.utc)
+        past = now - datetime.timedelta(minutes=30)
+        ticket = {
+            "id": "ticket-urgent-1",
+            "priority": "URGENT",
+            "created_at": past.isoformat(),
+            "status": "open",
+        }
+
+        result = self.engine.evaluate_ticket(ticket)
+
+        assert result["policy"] == SLA_POLICIES["medium"]
+        assert "Unknown priority 'URGENT'" in caplog.text
+        assert "ticket-urgent-1" in caplog.text
 
     def test_returns_elapsed_pct(self):
         now = datetime.datetime.now(datetime.timezone.utc)


### PR DESCRIPTION
## Summary
- Logs a warning when `evaluate_ticket` receives an unknown priority before falling back to the existing medium SLA policy.
- Includes the original priority value and ticket id in the warning so misclassified tickets are visible in logs.
- Keeps valid-priority behavior unchanged and updates the case-insensitive priority test fixture to use a non-breached high-priority age.

## Verification
- `PYTHONPATH=backend python -m pytest backend\tests\test_sla_engine.py::TestSLAEngineEvaluateTicket -q` -> 16 passed
- `PYTHONPATH=backend python -m pytest backend\tests\test_sla_engine.py -q` -> 67 passed, 2 pre-existing webhook mock failures where tests patch `services.sla_engine.aiohttp.ClientSession` but the module does not expose `aiohttp`.

Closes #1490