### PR TITLE
fix: reject empty classifier input

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -136,6 +136,9 @@ class ClassifierService:
         Results are cached in Redis by input text so repeated identical tickets
         skip the full transformer forward-pass entirely.
         """
+        if text is None or not text.strip():
+            raise ValueError("Classifier input text must not be empty")
+
         start_time = time.perf_counter()
         try:
             self.load()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -528,6 +528,7 @@ def mock_ai_services(request):
         "test_notification_routing.py",
         "test_notification_routing_push.py",
         "test_notification_routing_admin_alert.py",
+        "test_classifier_predict_validation.py",
     }:
         yield
         return

--- a/backend/tests/test_classifier_predict_validation.py
+++ b/backend/tests/test_classifier_predict_validation.py
@@ -1,0 +1,34 @@
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+for mod_name in ["torch", "torch.nn.functional", "transformers"]:
+    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
+
+sys.modules["transformers"].DistilBertTokenizerFast = MagicMock()
+sys.modules["transformers"].DistilBertForSequenceClassification = MagicMock()
+sys.modules.setdefault("backend.services.cache_service", MagicMock())
+sys.modules.setdefault("backend.services.metrics_service", MagicMock())
+
+sys.modules.pop("backend.services.classifier_service", None)
+_spec = importlib.util.spec_from_file_location(
+    "classifier_service_real_empty_validation",
+    os.path.join(os.path.dirname(__file__), "..", "services", "classifier_service.py"),
+)
+_classifier_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_classifier_module)
+
+ClassifierService = _classifier_module.ClassifierService
+
+
+@pytest.mark.parametrize("text", [None, "", "   "])
+def test_predict_rejects_empty_text_before_loading_model(text):
+    service = ClassifierService()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        service.predict(text)

--- a/backend/tests/test_classifier_service.py
+++ b/backend/tests/test_classifier_service.py
@@ -216,12 +216,13 @@ class TestClassifierPredict:
         assert result["category"] == "Unknown"
         assert result["subcategory"] == "Unknown"
 
-    def test_predict_empty_text(self, predict_fixture):
-        """predict() handles empty string input."""
-        svc, predict = predict_fixture
-        svc.id2label = {"0": "General | Unknown"}
-        result = predict("", confidence_val=0.30)
-        assert result["category"] == "General"
+    @pytest.mark.parametrize("text", [None, "", "   "])
+    def test_predict_empty_text_raises(self, predict_fixture, text):
+        """predict() rejects missing or whitespace-only text at the boundary."""
+        _svc, predict = predict_fixture
+
+        with pytest.raises(ValueError, match="must not be empty"):
+            predict(text)
 
     def test_predict_auto_resolve_subcategories(self, predict_fixture):
         """predict() marks auto_resolve=True for known simple issues."""


### PR DESCRIPTION
Closes #1496.

## Summary
- Raise `ValueError` at the start of `ClassifierService.predict()` when text is `None`, empty, or whitespace-only.
- Update the existing classifier unit-test expectation for empty text.
- Add a focused validation test that loads the real classifier service module and verifies the error is raised before model loading.

## Verification
- `PYTHONPATH=backend python -m pytest backend\tests\test_classifier_predict_validation.py -q` -> 3 passed
- `python -m py_compile backend\services\classifier_service.py`
- `git diff --check` -> no errors; only existing LF/CRLF working-tree warnings on Windows