### PR TITLE
fix: validate duplicate threshold range

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -310,6 +310,10 @@ class DuplicateService:
                 "similarity": float
             }
         """
+        active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD
+        if not 0.0 <= active_threshold <= 1.0:
+            raise ValueError("Duplicate similarity threshold must be between 0.0 and 1.0")
+
         self.load()
 
         # If model is not available, return no duplicate found
@@ -323,8 +327,6 @@ class DuplicateService:
                 "similarity": 0.0,
             }
 
-        # Use provided threshold or default to global constant
-        active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD
         use_default_threshold = threshold is None
 
         # Try the result cache only when using the default threshold so we

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -528,6 +528,7 @@ def mock_ai_services(request):
         "test_notification_routing.py",
         "test_notification_routing_push.py",
         "test_notification_routing_admin_alert.py",
+        "test_duplicate_threshold_validation.py",
     }:
         yield
         return

--- a/backend/tests/test_duplicate_threshold_validation.py
+++ b/backend/tests/test_duplicate_threshold_validation.py
@@ -1,0 +1,47 @@
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+for mod_name in ["sentence_transformers", "torch"]:
+    sys.modules.setdefault(mod_name, types.ModuleType(mod_name))
+
+sys.modules["sentence_transformers"].SentenceTransformer = MagicMock()
+sys.modules["sentence_transformers"].util = MagicMock()
+
+sys.modules.pop("backend.services.duplicate_service", None)
+_spec = importlib.util.spec_from_file_location(
+    "duplicate_service_real_threshold_validation",
+    os.path.join(os.path.dirname(__file__), "..", "services", "duplicate_service.py"),
+)
+_duplicate_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_duplicate_module)
+
+DuplicateService = _duplicate_module.DuplicateService
+
+
+@pytest.mark.parametrize("threshold", [-0.1, 1.1])
+def test_check_duplicate_rejects_out_of_range_threshold_before_availability_check(threshold):
+    service = DuplicateService()
+    service._load_failed = True
+
+    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        service.check_duplicate("same issue", threshold=threshold)
+
+
+@pytest.mark.parametrize("threshold", [0.0, 1.0])
+def test_check_duplicate_allows_threshold_boundaries_in_degraded_mode(threshold):
+    service = DuplicateService()
+    service._load_failed = True
+
+    result = service.check_duplicate("same issue", threshold=threshold)
+
+    assert result == {
+        "is_duplicate": False,
+        "duplicate_ticket_id": None,
+        "similarity": 0.0,
+    }


### PR DESCRIPTION
Closes #1492.

## Summary
- Computes the active duplicate similarity threshold before model availability checks.
- Raises `ValueError` when a provided/default threshold is outside `[0.0, 1.0]`.
- Adds focused tests proving invalid overrides are rejected even when the duplicate model is unavailable, while `0.0` and `1.0` boundaries remain valid.

## Verification
- `PYTHONPATH=backend python -m pytest backend\tests\test_duplicate_threshold_validation.py -q` -> 4 passed
- `python -m py_compile backend\services\duplicate_service.py`
- `git diff --check` -> no errors; only existing LF/CRLF working-tree warnings on Windows