### PR TITLE
fix: restore frontend package json validity

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -80,7 +80,6 @@
     "tailwindcss": "^3.4.19",
     "vite": "^7.3.1",
     "vitest": "^4.1.8"
-    "cypress": "^14.0.0"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
## Summary
- remove the duplicate trailing `cypress` devDependency entry that made `Frontend/package.json` invalid JSON
- keep the existing single `cypress` dependency and the `lint-staged` object config intact
- restore npm's ability to parse the frontend package manifest and read pre-commit config

Closes #1345

## Verification
- `node -e "const p=JSON.parse(require('fs').readFileSync('Frontend/package.json','utf8')); if (typeof p['lint-staged'] !== 'object' || Array.isArray(p['lint-staged'])) throw new Error('lint-staged is not object'); console.log(JSON.stringify({name:p.name, cypress:p.devDependencies.cypress, lintStaged:p['lint-staged']}))"`
- `npm --prefix Frontend pkg get lint-staged devDependencies.cypress scripts.prepare`
- `git diff --check` (passes; Windows LF/CRLF warning only)

Note: On current `gssoc`, the lint-staged config is already an object in `Frontend/package.json`, but the manifest could not be parsed because the duplicate `cypress` entry was missing a separator. This caused the same practical failure mode: npm/pre-commit tooling could not read the frontend package config.