### PR TITLE
Fix duplicate ticket inserts in ticket store

### DIFF
--- a/Frontend/src/store/ticketStore.js
+++ b/Frontend/src/store/ticketStore.js
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 import { createPersistedStore } from './persistenceMiddleware';
+import {
+    removeTicketFromQueue,
+    updateTicketInQueue,
+    upsertTicketInQueue,
+} from './ticketStoreUtils';
 
 const useTicketStore = create(
     createPersistedStore(
@@ -23,8 +28,41 @@ const useTicketStore = create(
 
             clearNotifications: () => set({ notifications: [] }),
 
+            addTicket: (ticket) => set((state) => ({
+                tickets: upsertTicketInQueue(state.tickets, ticket)
+            })),
+
+            upsertTicket: (ticket) => set((state) => ({
+                tickets: upsertTicketInQueue(state.tickets, ticket)
+            })),
+
+            updateTicket: (ticketId, updates) => set((state) => ({
+                tickets: updateTicketInQueue(state.tickets, ticketId, updates)
+            })),
+
+            removeTicket: (ticketId) => set((state) => ({
+                tickets: removeTicketFromQueue(state.tickets, ticketId)
+            })),
+
             updateTicketLocally: (ticketId, updates) => set((state) => ({
-                tickets: state.tickets.map(t => t.id === ticketId ? { ...t, ...updates } : t)
+                tickets: updateTicketInQueue(state.tickets, ticketId, updates)
+            })),
+
+            appendMessage: (ticketId, message) => set((state) => ({
+                tickets: updateTicketInQueue(
+                    state.tickets,
+                    ticketId,
+                    {
+                        messages: [
+                            ...(
+                                state.tickets.find((ticket) => (
+                                    ticket.id === ticketId || ticket.ticket_id === ticketId
+                                ))?.messages || []
+                            ),
+                            message,
+                        ],
+                    },
+                )
             })),
 
             reset: () => set({

--- a/Frontend/src/store/ticketStoreUtils.js
+++ b/Frontend/src/store/ticketStoreUtils.js
@@ -1,0 +1,42 @@
+export const getTicketRecordId = (ticket) => ticket?.id ?? ticket?.ticket_id ?? null;
+
+export const mergeTicketRecord = (existingTicket, nextTicket) => ({
+    ...existingTicket,
+    ...nextTicket,
+});
+
+export const upsertTicketInQueue = (tickets, nextTicket) => {
+    const currentTickets = Array.isArray(tickets) ? tickets : [];
+    const nextTicketId = getTicketRecordId(nextTicket);
+
+    if (!nextTicketId) {
+        return [nextTicket, ...currentTickets];
+    }
+
+    const existingIndex = currentTickets.findIndex(
+        (ticket) => getTicketRecordId(ticket) === nextTicketId,
+    );
+
+    if (existingIndex === -1) {
+        return [nextTicket, ...currentTickets];
+    }
+
+    return currentTickets.map((ticket, index) => (
+        index === existingIndex ? mergeTicketRecord(ticket, nextTicket) : ticket
+    ));
+};
+
+export const updateTicketInQueue = (tickets, ticketId, updates) => {
+    const currentTickets = Array.isArray(tickets) ? tickets : [];
+
+    return currentTickets.map((ticket) => (
+        getTicketRecordId(ticket) === ticketId
+            ? mergeTicketRecord(ticket, updates)
+            : ticket
+    ));
+};
+
+export const removeTicketFromQueue = (tickets, ticketId) => {
+    const currentTickets = Array.isArray(tickets) ? tickets : [];
+    return currentTickets.filter((ticket) => getTicketRecordId(ticket) !== ticketId);
+};

--- a/Frontend/src/store/ticketStoreUtils.test.js
+++ b/Frontend/src/store/ticketStoreUtils.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    removeTicketFromQueue,
+    updateTicketInQueue,
+    upsertTicketInQueue,
+} from './ticketStoreUtils.js';
+
+test('upsertTicketInQueue prepends new tickets', () => {
+    const tickets = [{ id: 1, subject: 'Existing' }];
+
+    const next = upsertTicketInQueue(tickets, { id: 2, subject: 'New' });
+
+    assert.deepEqual(next.map((ticket) => ticket.id), [2, 1]);
+});
+
+test('upsertTicketInQueue merges duplicates instead of adding another row', () => {
+    const tickets = [
+        { id: 1, subject: 'Existing', status: 'open' },
+        { id: 2, subject: 'Other', status: 'open' },
+    ];
+
+    const next = upsertTicketInQueue(tickets, { id: 1, status: 'resolved' });
+
+    assert.equal(next.length, 2);
+    assert.deepEqual(next[0], { id: 1, subject: 'Existing', status: 'resolved' });
+});
+
+test('upsertTicketInQueue deduplicates ticket_id records', () => {
+    const tickets = [{ ticket_id: 'T-100', subject: 'Existing' }];
+
+    const next = upsertTicketInQueue(tickets, {
+        ticket_id: 'T-100',
+        priority: 'high',
+    });
+
+    assert.equal(next.length, 1);
+    assert.deepEqual(next[0], {
+        ticket_id: 'T-100',
+        subject: 'Existing',
+        priority: 'high',
+    });
+});
+
+test('updateTicketInQueue updates id and ticket_id matches', () => {
+    const tickets = [{ id: 1 }, { ticket_id: 'T-2' }];
+
+    assert.deepEqual(updateTicketInQueue(tickets, 1, { status: 'open' }), [
+        { id: 1, status: 'open' },
+        { ticket_id: 'T-2' },
+    ]);
+
+    assert.deepEqual(updateTicketInQueue(tickets, 'T-2', { status: 'resolved' }), [
+        { id: 1 },
+        { ticket_id: 'T-2', status: 'resolved' },
+    ]);
+});
+
+test('removeTicketFromQueue removes id and ticket_id matches', () => {
+    const tickets = [{ id: 1 }, { ticket_id: 'T-2' }, { id: 3 }];
+
+    assert.deepEqual(removeTicketFromQueue(tickets, 'T-2'), [{ id: 1 }, { id: 3 }]);
+    assert.deepEqual(removeTicketFromQueue(tickets, 1), [{ ticket_id: 'T-2' }, { id: 3 }]);
+});


### PR DESCRIPTION
## Summary
- Add ticket queue helpers for id/ticket_id based upsert, update, and remove operations
- Wire addTicket/upsertTicket to merge existing records instead of prepending duplicates
- Restore store actions already used by realtime hooks and ticket pages, including updateTicket/removeTicket/appendMessage
- Add node:test coverage for insert, dedupe merge, ticket_id handling, update, and remove

## Verification
- `node --test Frontend\src\store\ticketStoreUtils.test.js` -> 5 passed
- `node --check Frontend\src\store\ticketStore.js`
- `node --check Frontend\src\store\ticketStoreUtils.js`
- `node --check Frontend\src\store\ticketStoreUtils.test.js`
- `git diff --check` -> no errors; Windows LF/CRLF warning only

Closes #1526