### PR TITLE
fix: classifier_service.py — keyword override corrupts subcategory/priority/auto_resolve + category poisoning + fake confidence (4 critical bugs)

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -6,6 +6,7 @@ Priority and other fields are derived from the category mapping.
 
 import os
 import json
+import re
 import torch
 import torch.nn.functional as F
 from transformers import DistilBertTokenizerFast, DistilBertForSequenceClassification
@@ -41,6 +42,37 @@ TEAM_MAP = {
 AUTO_RESOLVE_SUBS = {
     "Password Reset", "Account Unlock", "Software Install",
     "WiFi Issue", "Printer Error", "Monitor Problem",
+}
+
+# Fix Bug 1 & 4: Sensible default subcategory when category is overridden by keyword match.
+# These are used to re-derive priority and auto_resolve after an override so the returned
+# prediction object is always internally consistent.
+_CATEGORY_DEFAULT_SUBCATEGORY = {
+    "Network":  "Internet Slow",
+    "Software": "Application Crash",
+    "Access":   "Login Failure",
+    "Hardware": "Hardware Failure",
+}
+
+# Fix Bug 2: Use word-boundary-safe keyword lists with NO cross-category duplicates.
+# "Latency" was present in both Network and Software — removed from Network to avoid
+# category poisoning via dict-iteration order.
+_TECH_KEYWORDS = {
+    "Network": [
+        r"\bIP address\b", r"\bhostname\b", r"\bconnection\b", r"\bnetwork\b",
+        r"\bbandwidth\b", r"\bDNS\b", r"\bfirewall\b", r"\bVPN\b",
+        r"\bConnectivity\b", r"\bRouting\b", r"\bSpikes\b",
+    ],
+    "Software": [
+        r"\bcrash\b", r"\bload\b", r"\bwebsite\b", r"\bapplication\b",
+        r"\berror\b", r"\bbug\b", r"\bfailing\b", r"\bsoftware\b",
+        r"\bSQL\b", r"\bCluster\b", r"\bDatabase\b", r"\bProduction\b",
+        r"\bLatency\b",
+    ],
+    "Access": [
+        r"\blogin\b", r"\bpassword\b", r"\baccess\b", r"\bauthentication\b",
+        r"\baccount\b", r"\bpermission\b", r"\bMFA\b", r"\bOAuth\b",
+    ],
 }
 
 
@@ -84,7 +116,18 @@ class ClassifierService:
 
     def predict(self, text: str) -> dict:
         """
-        Predict category, subcategory, priority, auto_resolve, assigned_team, and confidence.
+        Predict category, subcategory, priority, auto_resolve, assigned_team, confidence,
+        and keyword_matched.
+
+        Fixes applied:
+          Bug 1 (CWE-704/697): subcategory, priority, and auto_resolve are now re-derived
+            after the keyword override so the returned object is always internally consistent.
+          Bug 2 (CWE-20): keyword matching uses compiled word-boundary regex patterns instead
+            of bare substring search; "Latency" deduplicated from Network list.
+          Bug 3 (CWE-345): real softmax confidence is never inflated; a separate
+            keyword_matched flag is returned so callers can apply their own confidence logic.
+          Bug 4 (CWE-841): auto_resolve is re-derived from the (possibly overridden)
+            subcategory, preventing non-trivial issues from being auto-resolved.
         """
         self.load()
 
@@ -104,47 +147,43 @@ class ClassifierService:
             probs = F.softmax(logits, dim=1)
             confidence, pred_idx = torch.max(probs, dim=1)
 
-        pred_idx = pred_idx.item()
-        confidence = round(confidence.item(), 4)
+        pred_idx   = pred_idx.item()
+        confidence = round(confidence.item(), 4)   # Fix Bug 3: keep real softmax score
 
         # Decode the combined label "Category | SubCategory"
         combined_label = self.id2label.get(str(pred_idx), "Unknown | Unknown")
-        parts = combined_label.split(" | ", 1)
-        category = parts[0].strip() if len(parts) > 0 else "Unknown"
+        parts      = combined_label.split(" | ", 1)
+        category   = parts[0].strip() if len(parts) > 0 else "Unknown"
         subcategory = parts[1].strip() if len(parts) > 1 else "Unknown"
 
-        # Derive priority
-        priority = PRIORITY_MAP.get(subcategory, "Medium")
-
-        # Derive assigned team
+        # Derive priority, team, auto_resolve from model prediction
+        priority      = PRIORITY_MAP.get(subcategory, "Medium")
         assigned_team = TEAM_MAP.get(category, "General Support")
+        auto_resolve  = subcategory in AUTO_RESOLVE_SUBS
 
-        # Derive auto_resolve
-        auto_resolve = subcategory in AUTO_RESOLVE_SUBS
-
-        # --- Regex Override Layer (Boost for Technical Keywords) ---
-        tech_keywords = {
-            "Network": ["IP address", "hostname", "connection", "network", "bandwidth", "DNS", "firewall", "VPN", "Connectivity", "Latency", "Routing", "Spikes"],
-            "Software": ["crash", "load", "website", "application", "error", "bug", "failing", "software", "SQL", "Cluster", "Database", "Production", "Latency"],
-            "Access": ["login", "password", "access", "authentication", "account", "permission", "MFA", "OAuth"]
-        }
-        
-        lower_text = text.lower()
-        for cat, keywords in tech_keywords.items():
-            if any(k.lower() in lower_text for k in keywords):
-                # If current prediction is generic, or we have a high-value technical keyword
+        # ── Keyword Override Layer (Bug 2 fix: word-boundary regex) ───────────────
+        keyword_matched = False
+        for cat, patterns in _TECH_KEYWORDS.items():
+            if any(re.search(pattern, text, re.IGNORECASE) for pattern in patterns):
                 if category == "General" or confidence < 0.9:
-                    category = cat
+                    category      = cat
                     assigned_team = TEAM_MAP.get(cat, "General Support")
-                    # Boost confidence significantly for verified technical signals
-                    confidence = max(confidence, 0.92) 
+
+                    # Fix Bug 1 & 4: re-derive subcategory/priority/auto_resolve
+                    subcategory  = _CATEGORY_DEFAULT_SUBCATEGORY.get(cat, subcategory)
+                    priority     = PRIORITY_MAP.get(subcategory, "Medium")
+                    auto_resolve = subcategory in AUTO_RESOLVE_SUBS
+
+                    # Fix Bug 3: do NOT inflate confidence; use separate flag instead
+                    keyword_matched = True
                     break
 
         return {
-            "category": category,
-            "subcategory": subcategory,
-            "priority": priority,
-            "auto_resolve": auto_resolve,
-            "assigned_team": assigned_team,
-            "confidence": confidence,
+            "category":       category,
+            "subcategory":    subcategory,
+            "priority":       priority,
+            "auto_resolve":   auto_resolve,
+            "assigned_team":  assigned_team,
+            "confidence":     confidence,
+            "keyword_matched": keyword_matched,   # new field — callers may use for display
         }


### PR DESCRIPTION

## Summary

Fixes **4 confirmed critical/advanced bugs** in `backend/services/classifier_service.py` keyword override layer.

Closes #1438
Closes #1816

---

## Bugs Fixed

### Bug 1 — 🔴 CRITICAL (CWE-704/697): Stale `subcategory` / `priority` / `auto_resolve` after keyword override
**Before:** When the override block changed `category` (e.g. to `"Network"`), it left `subcategory`, `priority`, and `auto_resolve` pointing to the original model prediction. A VPN-related ticket could be flagged `auto_resolve=True` because the original subcategory was `"Password Reset"`.

**After:** Added `_CATEGORY_DEFAULT_SUBCATEGORY` map. After any category override, `subcategory`, `priority`, and `auto_resolve` are immediately re-derived from the new category.

### Bug 2 — 🔴 CRITICAL (CWE-20): Category poisoning via substring collision + dict-order bias
**Before:** `k.lower() in lower_text` is a bare substring match. `"Latency"` existed in **both** `Network` and `Software` keyword lists. Because Python dicts are insertion-ordered (3.7+), `Network` always won for tickets that should have been `Software` (e.g. *"SQL Cluster has high Latency"*).

**After:** All patterns are compiled `re.search(r'\bword\b', ...)` word-boundary regexes. `"Latency"` removed from the `Network` list (it belongs exclusively to `Software`).

### Bug 3 — 🟠 HIGH (CWE-345): Fake confidence `0.92` suppresses Gemini cross-check
**Before:** `confidence = max(confidence, 0.92)` inflated the real softmax score (could be 0.40) to `0.92`. `main.py` uses `LOW_CONFIDENCE_THRESHOLD` to trigger Gemini fallback — this boosted value silently bypassed it.

**After:** Real softmax confidence is **never modified**. A new `keyword_matched: bool` field in the return dict lets callers distinguish model-confident predictions from keyword-assisted ones without corrupting the confidence value.

### Bug 4 — 🟠 HIGH (CWE-841): Auto-resolution of non-trivial tickets
**Before:** `auto_resolve` was derived from the original `subcategory` before override, then never updated. A category override to `"Network"` left `auto_resolve=True` if the original subcategory was `"Password Reset"`.

**After:** `auto_resolve` is re-derived from the (possibly updated) `subcategory` inside the override block. Covered by the Bug 1 fix.

---

## Files Changed

| File | Change |
|------|--------|
| `backend/services/classifier_service.py` | Full rewrite of override layer; add `_CATEGORY_DEFAULT_SUBCATEGORY`, `_TECH_KEYWORDS` with word-boundary patterns, `keyword_matched` return field |

---

## Backward Compatibility

The return dict gains one new key: `keyword_matched: bool`. All existing keys (`category`, `subcategory`, `priority`, `auto_resolve`, `assigned_team`, `confidence`) are preserved. `main.py` and any downstream consumer can safely ignore `keyword_matched` if not needed.

---

## Test Commands

```bash
cd backend

# Bug 1 & 4 — VPN ticket should NOT be auto-resolved, priority should be High
python -c "
from services.classifier_service import ClassifierService
s = ClassifierService()
r = s.predict('VPN connection failing to authenticate')
assert r['category'] == 'Network', f'Expected Network, got {r["category"]}'
assert r['auto_resolve'] == False, f'VPN should not auto-resolve, got {r["auto_resolve"]}'
print('Bug 1/4 ✅', r)
"

# Bug 2 — SQL/Latency ticket should be Software, not Network
python -c "
from services.classifier_service import ClassifierService
s = ClassifierService()
r = s.predict('SQL Cluster has high Latency affecting database production')
assert r['category'] == 'Software', f'Expected Software, got {r["category"]}'
print('Bug 2 ✅', r)
"

# Bug 3 — confidence should be real softmax value, not 0.92
python -c "
from services.classifier_service import ClassifierService
s = ClassifierService()
r = s.predict('network connection issue')
assert r['confidence'] != 0.92, 'Confidence should not be hardcoded 0.92'
assert 'keyword_matched' in r, 'keyword_matched field missing'
print('Bug 3 ✅', r)
"
```
