### PR TITLE
Fix hidden global scrollbars for accessibility

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -94,12 +94,7 @@
 
 html{
   overflow-y: scroll;
-  scrollbar-width: none; /* Firefox */
-}
-
-html::-webkit-scrollbar{
-  width: 0;
-  height: 0;
+  scrollbar-gutter: stable;
 }
 
 body{


### PR DESCRIPTION
## Summary
- Stop hiding the root document scrollbar in Firefox and WebKit browsers
- Keep `overflow-y: scroll` so page scroll remains stable and visible
- Use `scrollbar-gutter: stable` to preserve layout spacing without hiding the scrollbar

Closes #1759

## Verification
- `rg -n "scrollbar-width:\\s*none|html::-webkit-scrollbar|width:\\s*0|height:\\s*0" Frontend\\src\\index.css` -> no matches
- `git diff --check` -> no errors; Windows LF/CRLF warning only
- `npm --prefix Frontend pkg get name scripts.build devDependencies.vite` -> package manifest parses correctly

Note: `npm --prefix Frontend run build` was attempted but could not run because `Frontend/node_modules` is not installed in this local checkout, so `vite` is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved scrollbar handling to enhance layout stability and prevent content shifting when scrollbars appear or disappear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->