### PR TITLE
Fix duplicate service atomic persistence

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -17,6 +17,11 @@ import threading
 from typing import Any, Dict, List, Optional, Tuple
 
 try:
+    import fcntl
+except Exception:  # pragma: no cover - unavailable on Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:
     import numpy as np
 
     _HAS_NUMPY = True
@@ -69,6 +74,7 @@ class DuplicateService:
         self._embedding_matrix_dirty: bool = True
         # Thread-safe access to _tickets and storage_file
         self._lock = threading.Lock()
+        self._file_lock = threading.Lock()
         self._indexing: bool = False
 
     # ------------------------------------------------------------------
@@ -233,24 +239,58 @@ class DuplicateService:
 
     def save_to_disk(self, ticket_id: str, text: str) -> None:
         """Append a new ticket entry to the JSON persistence file."""
-        data: list = []
-        try:
-            os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
-            if os.path.exists(self.storage_file):
-                with open(self.storage_file, "r") as f:
-                    try:
-                        data = json.load(f)
-                        if not isinstance(data, list):
-                            data = []
-                    except Exception:
-                        data = []
+        storage_dir = os.path.dirname(self.storage_file)
+        tmp_path = None
 
-            data.append({"ticket_id": ticket_id, "text": text})
-            data = data[-MAX_CACHE_ENTRIES:]
-            with open(self.storage_file, "w") as f:
-                json.dump(data, f, indent=2)
+        try:
+            os.makedirs(storage_dir, exist_ok=True)
+            lock_path = f"{self.storage_file}.lock"
+
+            with self._file_lock:
+                with open(lock_path, "w", encoding="utf-8") as lock_file:
+                    if fcntl is not None:
+                        fcntl.flock(lock_file, fcntl.LOCK_EX)
+
+                    try:
+                        data: list = []
+                        if os.path.exists(self.storage_file):
+                            with open(self.storage_file, "r", encoding="utf-8") as f:
+                                try:
+                                    data = json.load(f)
+                                    if not isinstance(data, list):
+                                        data = []
+                                except Exception:
+                                    data = []
+
+                        data.append({"ticket_id": ticket_id, "text": text})
+                        data = data[-MAX_CACHE_ENTRIES:]
+
+                        with tempfile.NamedTemporaryFile(
+                            "w",
+                            encoding="utf-8",
+                            dir=storage_dir,
+                            prefix=".case_history_cache.",
+                            suffix=".tmp",
+                            delete=False,
+                        ) as tmp_file:
+                            tmp_path = tmp_file.name
+                            json.dump(data, tmp_file, indent=2)
+                            tmp_file.flush()
+                            os.fsync(tmp_file.fileno())
+
+                        os.replace(tmp_path, self.storage_file)
+                        tmp_path = None
+                    finally:
+                        if fcntl is not None:
+                            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
             print(f"[DuplicateService] Indexed ticket {ticket_id} to case history.")
         except Exception as exc:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
             print(f"[DuplicateService] Failed to save to disk: {exc}")
 
     def add_ticket(self, ticket_id: str, text: str) -> None:
@@ -342,9 +382,9 @@ class DuplicateService:
                 "[DuplicateService] DEGRADED: Duplicate check skipped (model not available)"
             )
             return {
-                "duplicate_ticket_id": ticket_id,
-                "similarity_score": round(best_score, 4),
-                "original_text": original_text,
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "similarity": 0.0,
             }
 
         use_default_threshold = threshold is None

--- a/backend/tests/test_duplicate_cache_limit.py
+++ b/backend/tests/test_duplicate_cache_limit.py
@@ -1,5 +1,6 @@
 import json
 import importlib.util
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -47,6 +48,56 @@ def test_save_to_disk_keeps_only_most_recent_cache_entries(tmp_path, monkeypatch
         {"ticket_id": "old-2", "text": "old two"},
         {"ticket_id": "new-3", "text": "new three"},
     ]
+
+
+def test_save_to_disk_uses_atomic_replace(tmp_path, monkeypatch):
+    storage_file = tmp_path / "case_history_cache.json"
+    service = DuplicateService()
+    service.storage_file = str(storage_file)
+
+    replace_calls = []
+    real_replace = duplicate_module.os.replace
+
+    def tracking_replace(src, dst):
+        replace_calls.append((Path(src), Path(dst)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(duplicate_module.os, "replace", tracking_replace)
+
+    service.save_to_disk("new-1", "new one")
+
+    assert replace_calls
+    tmp_path_used, destination = replace_calls[0]
+    assert tmp_path_used.parent == tmp_path
+    assert tmp_path_used.suffix == ".tmp"
+    assert destination == storage_file
+    assert json.loads(storage_file.read_text()) == [
+        {"ticket_id": "new-1", "text": "new one"},
+    ]
+
+
+def test_concurrent_save_to_disk_preserves_valid_json(tmp_path):
+    storage_file = tmp_path / "case_history_cache.json"
+    service = DuplicateService()
+    service.storage_file = str(storage_file)
+    errors = []
+
+    def save(i):
+        try:
+            service.save_to_disk(f"ticket-{i}", f"text {i}")
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=save, args=(i,)) for i in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    saved = json.loads(storage_file.read_text())
+    assert len(saved) == 20
+    assert {entry["ticket_id"] for entry in saved} == {f"ticket-{i}" for i in range(20)}
 
 
 def test_load_reencodes_only_most_recent_cache_entries(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #1824

## Summary
- make duplicate service JSON persistence atomic with a same-directory temporary file and `os.replace`
- serialize concurrent writes with an in-process lock and a file lock on platforms that support `fcntl`
- return a safe non-duplicate response when duplicate checks run in degraded mode without an embedding model
- add regression coverage for atomic replacement and concurrent `save_to_disk` calls preserving valid JSON

## Verification
- `PYTHONPATH=backend python -m pytest backend/tests/test_duplicate_cache_limit.py backend/tests/test_duplicate_threshold_validation.py -q` -> 8 passed
- `python -m py_compile backend/services/duplicate_service.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate detection cache now employs atomic write operations to ensure data integrity during updates.
  * Enhanced handling and safety for simultaneous cache modification requests.
  * Improved response consistency when operating in degraded-mode scenarios.

* **Tests**
  * Added tests to verify atomic file replacement behavior.
  * Added concurrency tests to validate safe simultaneous cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->