### PR TITLE
Fix duplicate WebSocket heartbeat intervals

### DIFF
--- a/Frontend/src/hooks/useWebSocket.js
+++ b/Frontend/src/hooks/useWebSocket.js
@@ -85,20 +85,6 @@ export default function useWebSocket(companyId, accessToken) {
     }
   }, [clearTimers]);
 
-  // ---- Start heartbeat timers (called after connect) --------------------
-
-  const startHeartbeat = useCallback(() => {
-    // Clear any existing timers first to prevent duplicates on reconnect
-    clearTimers();
-
-    // Periodic pings
-    pingTimerRef.current = setInterval(() => {
-      if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-        wsRef.current.send(JSON.stringify({ type: "ping" }));
-      }
-    }, PING_INTERVAL_MS);
-  }, [clearTimers]);
-
   // ---- WebSocket lifecycle & Reconnection ---------------------------------
 
   const connectRef = useRef(null);
@@ -133,6 +119,8 @@ export default function useWebSocket(companyId, accessToken) {
    *  4. If the deadline fires, the connection is dead — force a reconnect.
    */
   const startHeartbeat = useCallback((socket) => {
+    clearTimers();
+
     pingTimerRef.current = setInterval(() => {
       if (!socket || socket.readyState !== WebSocket.OPEN) return;
 
@@ -160,8 +148,6 @@ export default function useWebSocket(companyId, accessToken) {
   }, [clearTimers, scheduleReconnect]);
 
   // ---- WebSocket lifecycle -----------------------------------------------
-
-  const connectRef = useRef(null);
 
   const connect = useCallback(() => {
     cleanup();

--- a/Frontend/src/hooks/useWebSocket.structure.test.js
+++ b/Frontend/src/hooks/useWebSocket.structure.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./useWebSocket.js", import.meta.url), "utf8");
+
+test("useWebSocket declares one heartbeat starter and one connect ref", () => {
+  assert.equal(source.match(/const startHeartbeat = useCallback/g)?.length, 1);
+  assert.equal(source.match(/const connectRef = useRef/g)?.length, 1);
+});
+
+test("startHeartbeat clears existing timers before opening a new interval", () => {
+  const heartbeatStart = source.indexOf("const startHeartbeat = useCallback((socket) => {");
+  const clearTimersCall = source.indexOf("clearTimers();", heartbeatStart);
+  const intervalStart = source.indexOf("pingTimerRef.current = setInterval", heartbeatStart);
+
+  assert.notEqual(heartbeatStart, -1);
+  assert.notEqual(clearTimersCall, -1);
+  assert.notEqual(intervalStart, -1);
+  assert.ok(clearTimersCall < intervalStart);
+});


### PR DESCRIPTION
Closes #1109

## Summary
- remove the duplicate `startHeartbeat` and `connectRef` declarations from `useWebSocket`
- clear existing heartbeat/reconnect timers before starting a new heartbeat interval
- add a lightweight Node test to prevent duplicate declarations and ensure `clearTimers()` runs before `setInterval`

## Verification
- `node --check Frontend/src/hooks/useWebSocket.js`
- `node --test Frontend/src/hooks/useWebSocket.structure.test.js` -> 2 passed
- `git diff --check`