### PR TITLE
fix: remove duplicate addTicket/updateTicket/removeTicket in ticketStore (closes #1526)

### DIFF
--- a/Frontend/src/store/ticketStore.js
+++ b/Frontend/src/store/ticketStore.js
@@ -65,18 +65,8 @@ const useTicketStore = create(
                 )
             })),
 
-            addTicket: (ticket) => set((state) => {
-                if (state.tickets.some(t => t.id === ticket.id)) return state;
-                return { tickets: [...state.tickets, ticket] };
-            }),
-
-            updateTicket: (ticketId, updates) => set((state) => ({
-                tickets: state.tickets.map(t => t.id === ticketId ? { ...t, ...updates } : t)
-            })),
-
-            removeTicket: (ticketId) => set((state) => ({
-                tickets: state.tickets.filter(t => t.id !== ticketId)
-            })),
+            // Note: addTicket, updateTicket, and removeTicket are defined above
+            // using the utility helpers from ticketStoreUtils for proper dedup.
 
             reset: () => set({
                 aiTicket: null,


### PR DESCRIPTION
## Summary

Removed duplicate method definitions for ddTicket, updateTicket, and emoveTicket in Frontend/src/store/ticketStore.js.

## Problem

The store had **two definitions** of each method. The first set used proper utility helpers from 	icketStoreUtils (with dedup via upsertTicketInQueue). The second set used naive implementations that silently **overwrote** the first:

`js
// First definition (proper, with dedup) — gets overwritten:
addTicket: (ticket) => set((state) => ({
    tickets: upsertTicketInQueue(state.tickets, ticket)
})),

// Second definition (naive, no dedup) — wins at runtime:
addTicket: (ticket) => set((state) => {
    if (state.tickets.some(t => t.id === ticket.id)) return state;
    return { tickets: [...state.tickets, ticket] };
}),
`

This caused:
- **Duplicate entries** in the admin ticket queue when real-time INSERT events combined with store rehydration
- updateTicket used 	.id === ticketId instead of the utility that also checks 	icket_id
- emoveTicket had the same id-only issue

## Fix

Removed the duplicate definitions so only the proper utility-based implementations remain. The upsertTicketInQueue helper already handles dedup correctly by checking both id and 	icket_id.

## Changes

- Frontend/src/store/ticketStore.js: Removed 12 lines of duplicate method definitions, replaced with a comment noting the proper implementations above.

## Related Issue

Closes #1526