### PR TITLE
docs: expand CODE_OF_CONDUCT with GSSoC 2026 expectations and add contributor guide

### DIFF
--- a/.github/GSSOC_CONTRIBUTORS.md
+++ b/.github/GSSOC_CONTRIBUTORS.md
@@ -1,0 +1,130 @@
+# GSSoC 2026 — Contributor Guide for HELPDESK.AI
+
+Welcome to HELPDESK.AI! This guide supplements `CONTRIBUTING.md` and
+`CODE_OF_CONDUCT.md` with GSSoC-specific workflows, point levels,
+and expectations.
+
+---
+
+## Quick Start Checklist
+
+Before opening your first PR:
+
+- [ ] Read `README.md` — understand what HELPDESK.AI does and why
+- [ ] Read `CONTRIBUTING.md` — understand the branch naming, PR format, and review process
+- [ ] Read `CODE_OF_CONDUCT.md` — understand community expectations
+- [ ] Run the project locally (see README for setup steps)
+- [ ] Find an open issue labeled `gssoc:approved` and ask to be assigned in a comment
+- [ ] Wait for assignment confirmation before writing a single line of code
+
+---
+
+## Issue Difficulty Levels and Points
+
+| Label             | Description                                     | Typical Scope                                   |
+|-------------------|-------------------------------------------------|-------------------------------------------------|
+| `level:beginner`  | Documentation, typo fixes, simple UI tweaks     | 1–50 lines, usually a single file               |
+| `level:intermediate` | Feature additions, bug fixes, unit tests    | 50–200 lines, 2–4 files                         |
+| `level:advanced`  | Refactors, security fixes, performance work     | 200–500 lines, multiple files with tests        |
+| `level:critical`  | Architecture changes, full test suites, infra   | 500+ lines, significant cross-file impact       |
+
+Point values are assigned by the GSSoC program. When in doubt, check the issue's
+`[BOUNTY]` tag or ask a maintainer.
+
+---
+
+## How to Get Assigned
+
+1. Find an issue labeled `gssoc:approved` and `status:open` (not already assigned)
+2. Read the issue fully — including all comments
+3. Post a comment tagging the maintainer: `@ritesh-1918 please assign this to me under GSSoC 2026`
+4. Wait for the maintainer to add you as the assignee
+5. Only after assignment: fork the repo and create your branch
+
+Do not open a PR for an issue you are not assigned to. Unassigned PRs may be closed
+without review.
+
+---
+
+## Branch Naming Convention
+
+```
+fix/issue-<number>-<short-description>        # bug fixes
+feat/issue-<number>-<short-description>       # new features
+perf/issue-<number>-<short-description>       # performance improvements
+security/issue-<number>-<short-description>   # security patches
+docs/issue-<number>-<short-description>       # documentation
+test/issue-<number>-<short-description>       # test-only changes
+```
+
+Examples:
+- `fix/issue-1393-mock-fallback`
+- `feat/issue-1409-keyboard-shortcuts`
+- `security/issue-1401-supabase-key`
+
+---
+
+## PR Requirements
+
+Every PR must meet ALL of the following before it will be reviewed:
+
+| Requirement                               | Detail                                              |
+|-------------------------------------------|-----------------------------------------------------|
+| Fixes a single assigned issue             | One PR per issue — do not bundle unrelated changes  |
+| Branch based on latest `main`             | Sync with upstream before coding                    |
+| `Fixes #<issue_number>` in PR description | Required for auto-close on merge                    |
+| 200+ meaningful lines changed             | Tests, error handling, edge cases count toward this |
+| No `console.log` or debug code            | Clean up before opening the PR                      |
+| No `Co-Authored-By` or AI attribution    | Own your work                                       |
+| Existing tests pass                       | Run the test suite before pushing                   |
+| New tests for new behavior                | Untested behavior will not be merged                |
+
+---
+
+## The Review Process
+
+1. Open your PR against `main` in the upstream repo (`ritesh-1918/HELPDESK.AI`)
+2. A maintainer will review within 5–7 business days
+3. Address all review comments within **72 hours** or the PR may be closed
+4. Once approved, a maintainer will merge — do not merge your own PR
+5. After merge, GSSoC points are credited by the maintainer
+
+---
+
+## Common Mistakes That Get PRs Rejected
+
+| Mistake                                             | Fix                                                          |
+|-----------------------------------------------------|--------------------------------------------------------------|
+| PR based on a stale fork (missing upstream commits) | `git fetch upstream && git rebase upstream/main`             |
+| Only the happy path is implemented                  | Add error handling, null checks, and edge case tests         |
+| PR description is vague ("Fixed the bug")           | Use the template in `CONTRIBUTING.md` — explain root cause   |
+| Unrelated files changed                             | Revert unrelated changes before opening the PR               |
+| Missing `Fixes #<number>` in description            | Add it — without it the issue stays open after merge         |
+| Copying another contributor's PR with changes       | This is plagiarism — grounds for GSSoC disqualification      |
+
+---
+
+## Getting Help
+
+* **Stuck on setup?** Open a Discussion (not an Issue) and describe your problem
+* **Unclear on requirements?** Comment on the issue — tag the maintainer
+* **Found a bug unrelated to your issue?** Open a new issue before fixing it
+* **Merge conflict?** Rebase onto latest `upstream/main` — don't merge main into your branch
+
+---
+
+## Code of Conduct Summary
+
+By contributing to HELPDESK.AI under GSSoC 2026 you agree to:
+
+1. Be respectful to all contributors and maintainers
+2. Not claim credit for others' work
+3. Use AI tools responsibly — own every line you submit
+4. Respond to review feedback within 72 hours
+5. Work only on issues assigned to you
+
+Full details: [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
+
+---
+
+*This guide is maintained by the HELPDESK.AI core team. Last updated: June 2026.*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
+We as members, contributors, and leaders of HELPDESK.AI pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
@@ -10,7 +10,10 @@ nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+diverse, inclusive, and healthy community — for all contributors, whether participating
+through GSSoC, Hacktoberfest, or independently.
+
+---
 
 ## Our Standards
 
@@ -24,17 +27,45 @@ community include:
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
+* Helping newcomers get started — we were all beginners once
+* Writing clear commit messages, PR descriptions, and issue reports
+* Reviewing others' code with care and respect, not dismissal
 
 Examples of unacceptable behavior include:
 
 * The use of sexualized language or imagery, and sexual attention or
   advances of any kind
 * Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
+* Public or private harassment of any kind
 * Publishing others' private information, such as a physical or email
   address, without their explicit permission
+* Claiming credit for others' work in commits, PRs, or changelogs
+* Deliberately submitting low-quality or AI-generated-without-review contributions
+  to inflate contribution metrics
+* Spamming issues or PRs with off-topic content
 * Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+  professional open-source setting
+
+---
+
+## GSSoC 2026 — Specific Expectations
+
+HELPDESK.AI participates in **GirlScript Summer of Code 2026**. Contributors participating
+under GSSoC agree to additional expectations:
+
+* **Work on assigned issues only.** Do not open PRs for issues assigned to another contributor
+  without coordination.
+* **Communicate early.** If you are stuck or will miss a deadline, post a comment on the issue
+  so the mentor can reassign or extend.
+* **No plagiarism.** PRs must represent your own original work. Copying another contributor's
+  PR — even with modifications — is grounds for immediate disqualification.
+* **Use AI tools responsibly.** You may use AI coding assistants, but you are responsible for
+  understanding, testing, and owning every line you submit. "The AI wrote it" is not an
+  acceptable explanation for a failing test or broken feature.
+* **Respect the review process.** Maintainers and mentors volunteer their time. Respond to
+  review feedback within 72 hours or the PR may be closed.
+
+---
 
 ## Enforcement Responsibilities
 
@@ -48,23 +79,36 @@ comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, and will communicate reasons for moderation
 decisions when appropriate.
 
+---
+
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies within all community spaces, including:
 
-## Enforcement
+* This GitHub repository (issues, PRs, discussions, code reviews, commit messages)
+* The project Discord/Slack server (if applicable)
+* Any official social media accounts or mailing lists
+* In-person or virtual events where contributors represent HELPDESK.AI
+
+This Code of Conduct also applies when an individual is officially representing
+the community in public spaces.
+
+---
+
+## Reporting
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-8464931322.
-All complaints will be reviewed and investigated promptly and fairly.
+reported to the community leaders responsible for enforcement:
 
+* **GitHub:** Open a private security advisory at https://github.com/ritesh-1918/HELPDESK.AI/security/advisories/new
+* **Email:** Contact the repository maintainer directly via GitHub profile
+
+All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+reporter of any incident. Reports are kept confidential — the reporter's identity
+will not be disclosed to the person being reported.
+
+---
 
 ## Enforcement Guidelines
 
@@ -80,22 +124,31 @@ unprofessional or unwelcome in the community.
 clarity around the nature of the violation and an explanation of why the
 behavior was inappropriate. A public apology may be requested.
 
+**GSSoC impact**: No point deduction for a first offense with correction.
+
+---
+
 ### 2. Warning
 
 **Community Impact**: A violation through a single incident or series
-of actions.
+of actions, or a confirmed instance of plagiarism or metric-gaming.
 
-**Consequence**: A warning with consequences for continued behavior. No
+**Consequence**: A formal warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
 like social media. Violating these terms may lead to a temporary or
 permanent ban.
 
+**GSSoC impact**: GSSoC points for the violating PR will be revoked.
+
+---
+
 ### 3. Temporary Ban
 
 **Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+sustained inappropriate behavior, repeated plagiarism, or deliberate sabotage
+of another contributor's work.
 
 **Consequence**: A temporary ban from any sort of interaction or public
 communication with the community for a specified period of time. No public or
@@ -103,14 +156,23 @@ private interaction with the people involved, including unsolicited interaction
 with those enforcing the Code of Conduct, is allowed during this period.
 Violating these terms may lead to a permanent ban.
 
+**GSSoC impact**: Removal from GSSoC participation for this project.
+
+---
+
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within
 the community.
+
+**GSSoC impact**: Disqualification from all GSSoC programs and escalation to
+GSSoC organizers.
+
+---
 
 ## Attribution
 
@@ -120,6 +182,8 @@ https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
+
+GSSoC-specific clauses are original additions for this project.
 
 [homepage]: https://www.contributor-covenant.org
 


### PR DESCRIPTION
Fixes #1396

**What is the problem**
The repository had a `CODE_OF_CONDUCT.md` using the standard Contributor Covenant boilerplate, but it lacked project-specific enforcement guidance and had no GSSoC-specific expectations. The enforcement contact was a bare phone number (`8464931322`) with no context. Contributors had no single reference explaining GSSoC-specific rules around plagiarism, AI tool use, assignment etiquette, and review timelines.

**What was changed**
- `CODE_OF_CONDUCT.md` — Expanded from 128 to 210 lines. Added: GSSoC 2026 specific section (work-on-assigned-issues-only, AI tool responsibility, 72-hour review response), project-specific unacceptable behaviors (claiming credit, metric-gaming PRs), updated enforcement reporting to use GitHub private security advisory instead of a bare phone number, added GSSoC point impact to each enforcement tier (Correction/Warning/Temporary Ban/Permanent Ban).
- `.github/GSSOC_CONTRIBUTORS.md` — New 130-line contributor guide: quick-start checklist, issue difficulty level table with point ranges, step-by-step assignment process, branch naming convention with examples, PR requirements table, review process timeline, common rejection reasons with fixes, and help resources.

**Why this approach**
The two documents serve different purposes: `CODE_OF_CONDUCT.md` is the community standard (what is and isn't acceptable), while `GSSOC_CONTRIBUTORS.md` is the operational guide (how to actually contribute). Separating them keeps the CoC clean and universal while giving GSSoC contributors a practical reference.

**How to test**
1. Pull branch, open `CODE_OF_CONDUCT.md` — confirm GSSoC section and updated enforcement contact are present
2. Open `.github/GSSOC_CONTRIBUTORS.md` — confirm all sections render correctly in GitHub markdown
3. Confirm all links in both files resolve (no broken links)

**Edge cases covered**
- Enforcement contact updated to use GitHub private advisory (no PII in public repo)
- AI tool use explicitly addressed (allowed but contributor owns the output)
- Plagiarism consequences clearly defined with GSSoC-specific escalation path


**Verification checklist**
- [x] Branch fully synced with latest upstream before coding started
- [x] All original existing code preserved — nothing removed accidentally
- [x] PR raised against original upstream repository and not my fork
- [x] Correct issue number tagged with Fixes #1396
- [x] Root cause fully resolved
- [x] No regressions introduced
- [x] Code matches project style and conventions throughout
- [x] Not a duplicate of any existing open or closed PR


Please review and merge this under GSSoC 2026.