### PR TITLE
feat: add ticket export to CSV and PDF for admin dashboard

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -25,6 +25,8 @@
     "date-fns": "^4.1.0",
     "framer-motion": "^12.34.2",
     "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.2",
+    "jspdf-autotable": "^3.8.5",
     "lucide-react": "^0.574.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -20,11 +20,15 @@ import {
     Loader2,
     Save,
     RotateCcw,
+    Download,
+    FileText,
+    Table2,
 } from 'lucide-react';
 import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
 import { formatTimelineDate } from "../../utils/dateUtils";
+import { exportTicketsToCSV, exportTicketsToPDF } from "../services/exportService";
 
 const AdminTickets = () => {
     const navigate = useNavigate();
@@ -193,6 +197,35 @@ const AdminTickets = () => {
         );
     }, [tickets, searchQuery]);
 
+    const [isExporting, setIsExporting] = useState(false);
+
+    const handleExportCSV = () => {
+        try {
+            const result = exportTicketsToCSV(
+                filteredTickets,
+                `tickets-export-${new Date().toISOString().slice(0, 10)}.csv`
+            );
+            showToast(`Exported ${result.count} tickets to CSV`, 'success');
+        } catch (err) {
+            showToast(err.message || 'CSV export failed', 'error');
+        }
+    };
+
+    const handleExportPDF = async () => {
+        setIsExporting(true);
+        try {
+            const result = await exportTicketsToPDF(
+                filteredTickets,
+                `tickets-export-${new Date().toISOString().slice(0, 10)}.pdf`
+            );
+            showToast(`Exported ${result.count} tickets to PDF`, 'success');
+        } catch (err) {
+            showToast(err.message || 'PDF export failed', 'error');
+        } finally {
+            setIsExporting(false);
+        }
+    };
+
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();
         if (p === 'high' || p === 'critical') return 'text-red-600 bg-red-50 border-red-100';
@@ -216,6 +249,31 @@ const AdminTickets = () => {
                     <p className="text-sm font-bold text-slate-400 mt-1 flex items-center gap-2">
                         <Activity size={14} className="text-indigo-500" /> {filteredTickets.length} tickets matching current filters.
                     </p>
+                </div>
+                {/* Export Controls */}
+                <div className="flex items-center gap-2">
+                    <button
+                        onClick={handleExportCSV}
+                        disabled={filteredTickets.length === 0}
+                        title="Export visible tickets to CSV"
+                        className="flex items-center gap-1.5 px-3.5 py-2 text-xs font-bold text-emerald-700 bg-emerald-50 hover:bg-emerald-100 border border-emerald-200 rounded-xl transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        <Table2 size={13} />
+                        Export CSV
+                    </button>
+                    <button
+                        onClick={handleExportPDF}
+                        disabled={filteredTickets.length === 0 || isExporting}
+                        title="Export visible tickets to PDF"
+                        className="flex items-center gap-1.5 px-3.5 py-2 text-xs font-bold text-blue-700 bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-xl transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        {isExporting ? (
+                            <Loader2 size={13} className="animate-spin" />
+                        ) : (
+                            <FileText size={13} />
+                        )}
+                        {isExporting ? 'Generating…' : 'Export PDF'}
+                    </button>
                 </div>
             </div>
 

--- a/Frontend/src/admin/services/exportService.js
+++ b/Frontend/src/admin/services/exportService.js
@@ -1,0 +1,220 @@
+const CSV_FIELDS = [
+  { key: 'id', label: 'Ticket ID' },
+  { key: 'title', label: 'Title' },
+  { key: 'description', label: 'Description' },
+  { key: 'category', label: 'Category' },
+  { key: 'priority', label: 'Priority' },
+  { key: 'status', label: 'Status' },
+  { key: 'created_at', label: 'Created Date' },
+  { key: 'resolved_at', label: 'Resolved Date' },
+  { key: 'assigned_agent', label: 'Assigned Agent' },
+  { key: 'user_email', label: 'User Email' },
+  { key: 'sla_breach', label: 'SLA Breach' },
+];
+
+function escapeCsvCell(value) {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function formatDateForCsv(dateStr) {
+  if (!dateStr) return '';
+  try {
+    return new Date(dateStr).toISOString().replace('T', ' ').slice(0, 19);
+  } catch {
+    return dateStr;
+  }
+}
+
+export function exportTicketsToCSV(tickets, filename = 'tickets-export.csv') {
+  if (!tickets || tickets.length === 0) {
+    throw new Error('No tickets to export');
+  }
+
+  const header = CSV_FIELDS.map((f) => escapeCsvCell(f.label)).join(',');
+  const rows = tickets.map((ticket) => {
+    return CSV_FIELDS.map(({ key }) => {
+      const value =
+        key === 'created_at' || key === 'resolved_at'
+          ? formatDateForCsv(ticket[key])
+          : ticket[key];
+      return escapeCsvCell(value);
+    }).join(',');
+  });
+
+  const csv = [header, ...rows].join('\n');
+  const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' });
+  triggerDownload(blob, filename);
+  return { count: tickets.length, filename };
+}
+
+export function exportSingleTicketToCSV(ticket, filename) {
+  return exportTicketsToCSV(
+    [ticket],
+    filename ?? `ticket-${ticket.id ?? 'export'}.csv`
+  );
+}
+
+export async function exportTicketsToPDF(tickets, filename = 'tickets-export.pdf') {
+  if (!tickets || tickets.length === 0) {
+    throw new Error('No tickets to export');
+  }
+
+  const { jsPDF } = await import('jspdf').catch(() => {
+    throw new Error('jsPDF not installed. Run: npm install jspdf');
+  });
+  const { default: autoTable } = await import('jspdf-autotable').catch(() => {
+    throw new Error('jspdf-autotable not installed. Run: npm install jspdf-autotable');
+  });
+
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(16);
+  doc.text('HELPDESK.AI — Ticket Export', 14, 16);
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(9);
+  doc.setTextColor(100);
+  doc.text(
+    `Generated: ${new Date().toLocaleString()}  |  Total tickets: ${tickets.length}`,
+    14,
+    23
+  );
+  doc.setTextColor(0);
+
+  const columns = CSV_FIELDS.slice(0, 9).map((f) => ({
+    header: f.label,
+    dataKey: f.key,
+  }));
+
+  const rows = tickets.map((t) => ({
+    id: t.id ? String(t.id).slice(0, 8) : '',
+    title: t.title ?? '',
+    description: t.description ? String(t.description).slice(0, 60) + (t.description.length > 60 ? '…' : '') : '',
+    category: t.category ?? '',
+    priority: t.priority ?? '',
+    status: t.status ?? '',
+    created_at: formatDateForCsv(t.created_at),
+    resolved_at: formatDateForCsv(t.resolved_at),
+    assigned_agent: t.assigned_agent ?? '',
+  }));
+
+  autoTable(doc, {
+    startY: 28,
+    columns,
+    body: rows,
+    styles: { fontSize: 7.5, cellPadding: 2 },
+    headStyles: { fillColor: [16, 185, 129], textColor: 255, fontStyle: 'bold' },
+    alternateRowStyles: { fillColor: [245, 250, 247] },
+    columnStyles: {
+      0: { cellWidth: 22 },
+      1: { cellWidth: 44 },
+      2: { cellWidth: 55 },
+    },
+    margin: { left: 14, right: 14 },
+  });
+
+  const pageCount = doc.internal.getNumberOfPages();
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i);
+    doc.setFontSize(8);
+    doc.setTextColor(150);
+    doc.text(
+      `Page ${i} of ${pageCount}`,
+      doc.internal.pageSize.getWidth() - 14,
+      doc.internal.pageSize.getHeight() - 8,
+      { align: 'right' }
+    );
+  }
+
+  doc.save(filename);
+  return { count: tickets.length, filename };
+}
+
+export async function exportSingleTicketToPDF(ticket, filename) {
+  const { jsPDF } = await import('jspdf').catch(() => {
+    throw new Error('jsPDF not installed. Run: npm install jspdf');
+  });
+
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageW = doc.internal.pageSize.getWidth();
+  let y = 20;
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(18);
+  doc.text('HELPDESK.AI', 14, y);
+  doc.setFontSize(11);
+  doc.setFont('helvetica', 'normal');
+  doc.setTextColor(100);
+  doc.text('Ticket Detail Report', 14, (y += 7));
+  doc.setTextColor(0);
+
+  doc.setDrawColor(16, 185, 129);
+  doc.setLineWidth(0.5);
+  doc.line(14, (y += 4), pageW - 14, y);
+
+  y += 10;
+
+  const fields = [
+    ['Ticket ID', ticket.id ?? '—'],
+    ['Title', ticket.title ?? '—'],
+    ['Category', ticket.category ?? '—'],
+    ['Priority', ticket.priority ?? '—'],
+    ['Status', ticket.status ?? '—'],
+    ['Assigned Agent', ticket.assigned_agent ?? 'Unassigned'],
+    ['User Email', ticket.user_email ?? '—'],
+    ['Created', formatDateForCsv(ticket.created_at) || '—'],
+    ['Resolved', formatDateForCsv(ticket.resolved_at) || 'Pending'],
+    ['SLA Breach', ticket.sla_breach ? 'Yes' : 'No'],
+  ];
+
+  fields.forEach(([label, value]) => {
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    doc.text(`${label}:`, 14, y);
+    doc.setFont('helvetica', 'normal');
+    doc.text(String(value), 55, y);
+    y += 8;
+  });
+
+  if (ticket.description) {
+    y += 4;
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(9);
+    doc.text('Description:', 14, y);
+    y += 6;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(8.5);
+    const lines = doc.splitTextToSize(ticket.description, pageW - 28);
+    doc.text(lines, 14, y);
+    y += lines.length * 5;
+  }
+
+  doc.setFontSize(7.5);
+  doc.setTextColor(150);
+  doc.text(
+    `Generated: ${new Date().toLocaleString()}`,
+    14,
+    doc.internal.pageSize.getHeight() - 8
+  );
+
+  const outputFilename = filename ?? `ticket-${ticket.id ?? 'detail'}.pdf`;
+  doc.save(outputFilename);
+  return { filename: outputFilename };
+}
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Fixes #1400

**What is the problem**
Company admins had no way to export ticket data for audits, compliance, or offline reporting. All ticket data was locked inside the dashboard UI with no download mechanism. Admins needing to share ticket summaries in meetings or submit audit reports had to manually copy-paste data.

**What was changed**
- `Frontend/src/admin/services/exportService.js` — New 220-line export service with four exported functions:
  - `exportTicketsToCSV(tickets, filename)` — Generates a UTF-8 BOM CSV with 11 fields (Ticket ID, Title, Description, Category, Priority, Status, Created Date, Resolved Date, Assigned Agent, User Email, SLA Breach). Handles commas, quotes, and newlines in cell values per RFC 4180. Triggers browser download without any backend call.
  - `exportSingleTicketToCSV(ticket, filename)` — Wraps the above for single-ticket export.
  - `exportTicketsToPDF(tickets, filename)` — Dynamic import of `jsPDF` + `jspdf-autotable`. Generates a landscape A4 PDF with a branded header (HELPDESK.AI title, generation timestamp, ticket count), an autotable with alternating row colours and emerald header, and page numbers on every page. Truncates description to 60 chars to fit the table.
  - `exportSingleTicketToPDF(ticket, filename)` — Portrait A4 PDF with full ticket detail (all fields, full description, green ruled separator). No table — each field on its own row.
- `Frontend/src/admin/pages/AdminTickets.jsx` — Added `isExporting` state, `handleExportCSV` and `handleExportPDF` handler functions, and two export buttons ("Export CSV" / "Export PDF") in the header toolbar. Buttons are disabled when no tickets are visible. PDF button shows a spinner while generating. Both handlers call `showToast` on success and error.

**Why this approach**
Client-side PDF generation via dynamic `jsPDF` import means no backend changes and no new API endpoints. The dynamic import means the `jsPDF` bundle (~1MB) is only downloaded when the user actually clicks Export PDF — not on every page load. CSV is generated without any library and handles all RFC 4180 edge cases natively.

**How to test**
1. Pull branch, run `npm install jspdf jspdf-autotable && npm run dev` in `Frontend/`
2. Log in as admin, navigate to Ticket Management
3. Click "Export CSV" — confirm a `.csv` file downloads with correct headers and data
4. Open the CSV in Excel/Sheets — confirm no garbled characters (UTF-8 BOM)
5. Click "Export PDF" — confirm a landscape A4 PDF downloads with the HELPDESK.AI header
6. Filter tickets by status, then export — confirm only filtered tickets appear in the export
7. With 0 tickets matching filter — confirm both buttons are disabled

**Edge cases covered**
- Ticket titles/descriptions containing commas, quotes, and newlines: properly escaped in CSV
- Zero-ticket state: export buttons disabled (no empty file generated)
- `jsPDF` not installed: dynamic import throws with a human-readable error message shown in toast
- Long descriptions: truncated to 60 characters in the table PDF; full description in single-ticket PDF
- Resolved date absent: shows "Pending" in single-ticket PDF


**Verification checklist**
- [x] Branch fully synced with latest upstream before coding started
- [x] All original existing code preserved — nothing removed accidentally
- [x] PR raised against original upstream repository and not my fork
- [x] Correct issue number tagged with Fixes #1400
- [x] Root cause fully resolved
- [x] All edge cases and error paths handled
- [x] No regressions introduced
- [x] Code matches project style and conventions throughout
- [x] Not a duplicate of any existing open or closed PR


Please review and merge this under GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ticket export functionality enabling admins to download filtered tickets in CSV and PDF formats
* Export buttons appear in the admin tickets page, contextually enabled based on ticket availability
* PDF generation includes a loading indicator during the export process
* Exported files contain formatted ticket data with all relevant fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->