### PR TITLE
fix: import FastAPI Response at module top

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,7 +34,7 @@ from pii_redaction import redact_pii, redact_pii_dict, set_pii_redaction_enabled
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request, WebSocket, WebSocketDisconnect, Header, BackgroundTasks
+from fastapi import FastAPI, Depends, HTTPException, Request, Response, WebSocket, WebSocketDisconnect, Header, BackgroundTasks
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 from slowapi.util import get_remote_address
@@ -1233,8 +1233,6 @@ METRICS_ALLOWED_IPS = {
     if ip.strip()
 }
 
-import ipaddress
-from fastapi import Response
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 instrumentator = Instrumentator(


### PR DESCRIPTION
Closes #1849

## Summary
- Add `Response` to the main FastAPI import list in `backend/main.py`.
- Remove the later duplicate `Response` import so response handlers and annotations are available consistently from module load.
- Keep the metrics route behavior unchanged.

## Verification
- `python -m py_compile backend/main.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code improvements to enhance maintainability and remove redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->