### PR TITLE
fix: normalize digest email subjects

### DIFF
--- a/backend/services/digest_service.py
+++ b/backend/services/digest_service.py
@@ -5,6 +5,7 @@ import urllib.request
 import urllib.error
 import json
 import asyncio
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -24,6 +25,14 @@ DEFAULT_SENDER = "Helpdesk.AI <onboarding@resend.dev>"
 
 # Template directory
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+
+
+def _build_digest_email_subject(stats: dict) -> str:
+    """Return a UTF-8-safe weekly digest subject for email APIs."""
+    company_name = str(stats.get("company_name") or "Your Company")
+    cleaned_company = re.sub(r"[\x00-\x1f\x7f]+", " ", company_name)
+    cleaned_company = re.sub(r"\s+", " ", cleaned_company).strip() or "Your Company"
+    return f"Weekly Helpdesk Operations Digest - {cleaned_company}"
 
 
 def get_weekly_stats(company_id: str) -> dict:
@@ -300,11 +309,11 @@ def _build_team_performance_html(team_performance: list) -> str:
 
         rows.append(
             f'<tr style="border-bottom: 1px solid #f3f4f6;">'
-            f'<td style="padding: 10px 12px; font-weight: 600; color: #111827;">{tm["team"]}</td>'
-            f'<td style="padding: 10px 12px; text-align: center;">{tm["total"]}</td>'
-            f'<td style="padding: 10px 12px; text-align: center;">{tm["resolved"]}</td>'
-            f'<td style="padding: 10px 12px; text-align: center; color: {rate_color}; font-weight: 600;">{tm["resolution_rate"]}%</td>'
-            f'<td style="padding: 10px 12px; text-align: center;">{tm["avg_resolution_time"]}</td>'
+            f'<td style="padding: 10px 12px; font-weight: 600; color: #111827;">{tm.get("team", "Unassigned")}</td>'
+            f'<td style="padding: 10px 12px; text-align: center;">{tm.get("total", 0)}</td>'
+            f'<td style="padding: 10px 12px; text-align: center;">{tm.get("resolved", 0)}</td>'
+            f'<td style="padding: 10px 12px; text-align: center; color: {rate_color}; font-weight: 600;">{tm.get("resolution_rate", 0)}%</td>'
+            f'<td style="padding: 10px 12px; text-align: center;">{tm.get("avg_resolution_time", "N/A")}</td>'
             f'<td style="padding: 10px 12px; text-align: center; color: {breach_color}; font-weight: 600;">{breaches}</td>'
             f'</tr>'
         )
@@ -405,13 +414,13 @@ def send_digest_email(admin_email: str, stats: dict, ai_summary: str) -> bool:
     payload = {
         "from": sender_email,
         "to": [admin_email],
-        "subject": f"Weekly Helpdesk Operations Digest — {stats['company_name']}",
-        "html": email_html
+        "html": email_html,
+        "subject": _build_digest_email_subject(stats)
     }
     
     req = urllib.request.Request(
         "https://api.resend.com/emails",
-        data=json.dumps(payload).encode("utf-8"),
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
         headers={
             "Authorization": f"Bearer {resend_api_key}",
             "Content-Type": "application/json"

--- a/backend/tests/test_digest_service_helpers.py
+++ b/backend/tests/test_digest_service_helpers.py
@@ -16,6 +16,7 @@ import unittest
 from backend.services.digest_service import (
     _build_team_performance_html,
     _build_category_list_html,
+    _build_digest_email_subject,
 )
 
 
@@ -71,6 +72,25 @@ class TestBuildTeamPerformanceHtml(unittest.TestCase):
         ]
         result = _build_team_performance_html(teams)
         self.assertIn("#059669", result)
+
+
+class TestBuildDigestEmailSubject(unittest.TestCase):
+    """Tests for digest email subject formatting."""
+
+    def test_preserves_special_characters(self):
+        result = _build_digest_email_subject({"company_name": "Soporte Nino & Cafe \"VIP\" 🚀"})
+
+        self.assertEqual(result, 'Weekly Helpdesk Operations Digest - Soporte Nino & Cafe "VIP" 🚀')
+
+    def test_strips_control_characters(self):
+        result = _build_digest_email_subject({"company_name": "ACME\r\n\tOps\x00Team"})
+
+        self.assertEqual(result, "Weekly Helpdesk Operations Digest - ACME Ops Team")
+
+    def test_falls_back_when_company_name_is_blank(self):
+        result = _build_digest_email_subject({"company_name": "\n\t"})
+
+        self.assertEqual(result, "Weekly Helpdesk Operations Digest - Your Company")
 
     def test_medium_resolution_rate_uses_amber(self):
         """Resolution rate 50-79 should use amber (#d97706)."""


### PR DESCRIPTION
Closes #1900

## Summary
- Add a digest email subject helper that removes control characters while preserving special characters.
- Send the Resend payload as UTF-8 JSON with `ensure_ascii=False` so subjects render cleanly in notification emails.
- Harden team performance HTML defaults that the existing helper tests expect.
- Add regression coverage for special characters, control characters, and blank company names in digest subjects.

## Verification
- `python -m pytest backend/tests/test_digest_service_helpers.py -q` -> 18 passed
- `python -m py_compile backend/services/digest_service.py backend/tests/test_digest_service_helpers.py`
- `git diff --check`