### PR TITLE
[CRITICAL] Fix env var name mismatch - SUPABASE_SERVICE_ROLE_KEY -> SUPABASE_SERVICE_KEY

### DIFF
--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -47,7 +47,7 @@ def seed_company_settings():
     # Initialize Supabase client
     supabase = create_client(
         os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY")
     )
     
     logger.info("Starting company settings seed script...")
@@ -141,7 +141,7 @@ def verify_seed():
     
     supabase = create_client(
         os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY")
     )
     
     try:

--- a/backend/services/auto_close_service.py
+++ b/backend/services/auto_close_service.py
@@ -36,7 +36,7 @@ class AutoCloseService:
         """Initialize the auto-close service with Supabase client."""
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_KEY")
         )
         self.enabled = os.getenv("AUTO_CLOSE_ENABLED", "true").lower() == "true"
         self.default_auto_close_days = int(os.getenv("AUTO_CLOSE_DAYS", "7"))

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -53,7 +53,7 @@ class NotificationRoutingMiddleware:
         """Initialize the notification routing middleware."""
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_KEY")
         )
         self._settings_cache: Dict[str, Dict] = {}
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()


### PR DESCRIPTION
## Description
Fixes inconsistent environment variable naming across the backend. Three service files used \SUPABASE_SERVICE_ROLE_KEY\ while \main.py\ and \.env.example\ use \SUPABASE_SERVICE_KEY\. Since the env var is never set under the wrong name, all three services silently failed to initialize their Supabase client.

## Changes
- \ackend/services/auto_close_service.py\: Changed \SUPABASE_SERVICE_ROLE_KEY\ → \SUPABASE_SERVICE_KEY\
- \ackend/services/notification_routing.py\: Changed \SUPABASE_SERVICE_ROLE_KEY\ → \SUPABASE_SERVICE_KEY\
- \ackend/scripts/seed_company_settings.py\: Changed \SUPABASE_SERVICE_ROLE_KEY\ → \SUPABASE_SERVICE_KEY\ (2 occurrences)

## Impact
Fixes ticket auto-closure, admin notification routing, and company settings seeding — all of which were completely broken due to the env var mismatch.

Fixes #1986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend authentication configuration across multiple services to use standardized credentials for database operations, including company settings management, auto-close job execution, and notification routing middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->