### PR TITLE
Fix: Remove dead env_metadata code in analyze_ticket endpoint (fixes #1988)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2965,17 +2965,6 @@ async def analyze_ticket(request_body: TicketRequest, request: Request, current_
     returns the consolidated ``TicketResponse``. Throttled to 10 requests per
     minute per IP."""
     text = request_body.text
-    
-    # Grab client metadata
-    client_ip = request.client.host if request.client else "unknown"
-    user_agent = request.headers.get("user-agent", "unknown")
-    origin_host = request.headers.get("origin", "unknown")
-    
-    env_metadata = {
-        "ip": client_ip,
-        "user_agent": user_agent,
-        "origin": origin_host
-    }
 
     # --- Layer 1: Local OCR (CPU, no API required) ---
     local_ocr_text = ""


### PR DESCRIPTION
## Summary
Removed dead code in `/ai/analyze_ticket` that computed `env_metadata` (client_ip, user_agent, origin) but never used it or passed it downstream.

## Changes
- Removed unused `client_ip`, `user_agent`, `origin_host`, `env_metadata` computation
- OCR-enriched text is already correctly passed to `analyze_only` via `model_copy`
- No functional change