### PR TITLE
fix: add rehype-sanitize to ReactMarkdown to prevent stored XSS (closes #1987)

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
         "recharts": "^3.7.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "source-map": "^0.7.6",
         "tailwind-merge": "^3.5.0",
@@ -5933,6 +5934,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -9000,6 +9016,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -33,6 +33,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
     "recharts": "^3.7.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "source-map": "^0.7.6",
     "tailwind-merge": "^3.5.0",

--- a/Frontend/src/docs/pages/DocsPortal.jsx
+++ b/Frontend/src/docs/pages/DocsPortal.jsx
@@ -6,6 +6,7 @@ import {
 import { Link, useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import { DOCS_CATEGORIES, DOCS_ARTICLES } from '../data/docsArticles';
 import { Card } from '../../components/ui/card';
 
@@ -223,6 +224,7 @@ const DocsPortal = () => {
                                 {/* Custom Premium Markdown rendering */}
                                 <ReactMarkdown 
                                     remarkPlugins={[remarkGfm]}
+                                    rehypePlugins={[rehypeSanitize]}
                                     components={{
                                         h1: ({node, ...props}) => <h2 className="text-2xl font-black text-gray-900 tracking-tight mt-2 mb-6 border-b border-gray-100 pb-3" {...props} />,
                                         h2: ({node, ...props}) => <h3 className="text-lg font-bold text-gray-800 tracking-tight mt-6 mb-3" {...props} />,

--- a/Frontend/src/user/pages/AutoResolveChat.jsx
+++ b/Frontend/src/user/pages/AutoResolveChat.jsx
@@ -10,6 +10,7 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
 import useTicketStore from '../../store/ticketStore';
 import { Card, CardContent } from "../../components/ui/card";
 import { askAI } from '../../services/aiAssistant';
@@ -281,6 +282,7 @@ const AutoResolveChat = () => {
                                                 {msg.role === 'bot' ? (
                                                     <ReactMarkdown
                                                         remarkPlugins={[remarkGfm]}
+                                                        rehypePlugins={[rehypeSanitize]}
                                                         components={{
                                                             ul: ({ ...props }) => <ul className="list-disc ml-4 space-y-2 mb-3" {...props} />,
                                                             ol: ({ ...props }) => <ol className="list-decimal ml-4 space-y-2 mb-3" {...props} />,


### PR DESCRIPTION
## Description

Adds \ehype-sanitize\ to both \ReactMarkdown\ instances in the app to prevent stored XSS attacks via AI-generated markdown output.

### Changes
- **AutoResolveChat.jsx**: Added \ehypePlugins={[rehypeSanitize]}\ to the \ReactMarkdown\ rendering bot messages
- **DocsPortal.jsx**: Added \ehypePlugins={[rehypeSanitize]}\ to the \ReactMarkdown\ rendering article content

### Why
AI-generated responses could contain malicious markdown/HTML (e.g., \<script>\, \javascript:\ URLs, \onerror\ handlers). \ehype-sanitize\ strips these before rendering.