### PR TITLE
fix: remove dead confidence_threshold/duplicate_sensitivity fields from TicketRequest (closes #1988)

### DIFF
--- a/Frontend/src/user/pages/AIProcessing.jsx
+++ b/Frontend/src/user/pages/AIProcessing.jsx
@@ -114,8 +114,6 @@ const AIProcessing = () => {
                         "System",
                     company_id: profile?.company_id || null,
                     image_url: uploadedImageUrl,
-                    confidence_threshold: settings.aiConfidenceThreshold,
-                    duplicate_sensitivity: settings.duplicateSensitivity,
                     // Smart Template metadata (backend can use for improved routing)
                     template_id: template_id || null,
                     template_used: template_used || false,

--- a/backend/main.py
+++ b/backend/main.py
@@ -88,8 +88,6 @@ class TicketRequest(BaseModel):
     user_id: str | None = None
     company: str | None = None
     image_url: str | None = None
-    confidence_threshold: float = 0.20
-    duplicate_sensitivity: float = 0.85
 
 class TicketSaveRequest(BaseModel):
     user_id: str
@@ -699,35 +697,9 @@ async def update_ticket(ticket_id: str, updates: dict):
 async def analyze_ticket(request_body: TicketRequest, request: Request):
     """
     Main endpoint for analyzing a new ticket using the cascade of local AI models.
+    Delegates to `analyze_only` to avoid duplicated settings fetch, OCR, and metadata
+    gathering that were previously performed here and then discarded.
     """
-    text = request_body.text
-
-    settings = get_system_settings(request_body.company)
-    confidence_threshold = settings["ai_confidence_threshold"]
-    duplicate_sensitivity = settings["duplicate_sensitivity"]
-    enable_auto_resolve = settings["enable_auto_resolve"]
-    
-    # Grab client metadata
-    client_ip = request.client.host if request.client else "unknown"
-    user_agent = request.headers.get("user-agent", "unknown")
-    origin_host = request.headers.get("origin", "unknown")
-    
-    env_metadata = {
-        "ip": client_ip,
-        "user_agent": user_agent,
-        "origin": origin_host
-    }
-
-    # --- Layer 1: Local OCR (CPU, no API required) ---
-    local_ocr_text = ""
-    if request_body.image_base64 and ocr_service:
-        print("[AI] Extracting text via local OCR...")
-        local_ocr_text = ocr_service.extract_text(request_body.image_base64)
-        if local_ocr_text:
-            text = f"{text} {local_ocr_text}".strip()
-            print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
-
-    # Initalize Timeline
     return await analyze_only(request_body)
 
 @app.post("/ai/analyze")


### PR DESCRIPTION
## Description

Removes dead code in the \/ai/analyze_ticket\ pipeline identified in issue #1988.

### Changes
- **\ackend/main.py\**: Removed unused \confidence_threshold\ and \duplicate_sensitivity\ fields from the \TicketRequest\ model
- **\Frontend/src/user/pages/AIProcessing.jsx\**: Removed corresponding keys from the request payload

### Why
These fields were sent by the frontend but never consumed by the backend — \nalyze_only\ always fetches both values from the DB via \get_system_settings()\. Eliminates unnecessary payload bloat.