### PR TITLE
fix: resolve broken classifier_trainer import in train_all.py (closes #1752)

### DIFF
--- a/backend/train_all.py
+++ b/backend/train_all.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
 sys.path.insert(0, PROJECT_ROOT)
 
-from backend.training.classifier_trainer import train_classifier
+from backend.training.classifier_trainer_v3 import train_v3 as train_classifier
 from backend.training.ner_trainer import train_ner
 
 


### PR DESCRIPTION
## Summary
This PR addresses **Issue #1752** which reports a broken/non-existent import of `classifier_trainer` in `backend/train_all.py`.

## Fixes Applied
- Swapped the non-existent `backend.training.classifier_trainer` import with the correct `backend.training.classifier_trainer_v3` module (specifically importing `train_v3` aliased as `train_classifier`).
