### PR TITLE
Fix OCR-enriched text being discarded in analyze_ticket

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -725,6 +725,7 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
         local_ocr_text = ocr_service.extract_text(request_body.image_base64)
         if local_ocr_text:
             text = f"{text} {local_ocr_text}".strip()
+            request_body.text = text
             print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
 
     # Initalize Timeline

--- a/backend/tests/test_analyze_ticket_ocr_writeback.py
+++ b/backend/tests/test_analyze_ticket_ocr_writeback.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_analyze_ticket_writes_ocr_enriched_text_before_delegating():
+    source = Path(__file__).resolve().parents[1].joinpath("main.py").read_text(encoding="utf-8")
+
+    ocr_merge_index = source.index('text = f"{text} {local_ocr_text}".strip()')
+    writeback_index = source.index("request_body.text = text", ocr_merge_index)
+    delegation_index = source.index("return await analyze_only(request_body)", writeback_index)
+
+    assert ocr_merge_index < writeback_index < delegation_index

--- a/backend/tests/test_analyze_ticket_ocr_writeback.py
+++ b/backend/tests/test_analyze_ticket_ocr_writeback.py
@@ -1,11 +1,57 @@
+import ast
+import asyncio
 from pathlib import Path
+from types import SimpleNamespace
+
+
+MAIN_PATH = Path(__file__).resolve().parents[1].joinpath("main.py")
+
+
+def load_analyze_ticket_with_mocks(ocr_text="[OCR_MARKER]"):
+    tree = ast.parse(MAIN_PATH.read_text(encoding="utf-8"))
+    analyze_ticket_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "analyze_ticket"
+    )
+    analyze_ticket_node.decorator_list = []
+
+    captured = {}
+
+    async def analyze_only(request_body):
+        captured["delegated_text"] = request_body.text
+        return {"delegated": True}
+
+    namespace = {
+        "Request": object,
+        "TicketRequest": object,
+        "analyze_only": analyze_only,
+        "get_system_settings": lambda company: {
+            "ai_confidence_threshold": 0.8,
+            "duplicate_sensitivity": 0.85,
+            "enable_auto_resolve": False,
+        },
+        "ocr_service": SimpleNamespace(extract_text=lambda image_base64: ocr_text),
+    }
+    module = ast.Module(body=[analyze_ticket_node], type_ignores=[])
+    exec(compile(ast.fix_missing_locations(module), str(MAIN_PATH), "exec"), namespace)
+    return namespace["analyze_ticket"], captured
 
 
 def test_analyze_ticket_writes_ocr_enriched_text_before_delegating():
-    source = Path(__file__).resolve().parents[1].joinpath("main.py").read_text(encoding="utf-8")
+    analyze_ticket, captured = load_analyze_ticket_with_mocks()
+    request_body = SimpleNamespace(
+        text="User description",
+        image_base64="fake_base64_data",
+        company=None,
+    )
+    request = SimpleNamespace(
+        client=SimpleNamespace(host="127.0.0.1"),
+        headers={},
+    )
 
-    ocr_merge_index = source.index('text = f"{text} {local_ocr_text}".strip()')
-    writeback_index = source.index("request_body.text = text", ocr_merge_index)
-    delegation_index = source.index("return await analyze_only(request_body)", writeback_index)
+    result = asyncio.run(analyze_ticket(request_body, request))
 
-    assert ocr_merge_index < writeback_index < delegation_index
+    assert result == {"delegated": True}
+    assert request_body.text == "User description [OCR_MARKER]"
+    assert captured["delegated_text"] == "User description [OCR_MARKER]"


### PR DESCRIPTION
## Summary
Fixes #1449 by writing OCR-enriched text back to `request_body.text` before `analyze_ticket` delegates to `analyze_only`.

## Problem
`analyze_ticket` appended local OCR output to a local `text` variable, but then called `analyze_only(request_body)`. Since `analyze_only` reads `request_body.text`, downstream classification/NER/duplicate detection still received the original non-enriched text.

## Changes
- Preserve OCR-enriched text with `request_body.text = text` after local OCR extraction succeeds.
- Add a focused regression guard that ensures the writeback happens before delegation.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest backend/tests/test_analyze_ticket_ocr_writeback.py -q`
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile backend/main.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OCR-extracted content is now correctly included in ticket analysis so analyses reflect any text extracted from images or uploads.

* **Tests**
  * Added automated coverage to ensure OCR-enriched text is written back into the request before analysis, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->