### PR TITLE
Use company_id for system settings lookups

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -81,12 +81,27 @@ def get_system_settings(company_id: str) -> dict:
     except Exception as e:
         print(f"[WARNING] Could not fetch system_settings for company_id={company_id}: {e}")
     return defaults
+
+def resolve_company_name_to_id(company_name: str | None) -> str | None:
+    if not supabase or not company_name:
+        return None
+    try:
+        res = supabase.table("companies").select("id").eq("name", company_name).single().execute()
+        return res.data.get("id") if res.data else None
+    except Exception as e:
+        print(f"[WARNING] Could not resolve company name={company_name} to id: {e}")
+    return None
+
+def get_request_company_id(request_body: "TicketRequest") -> str | None:
+    return request_body.company_id or resolve_company_name_to_id(request_body.company)
+
 class TicketRequest(BaseModel):
     text: str
     image_base64: str = ""
     image_text: str = "" # Keep for backward compatibility
     user_id: str | None = None
     company: str | None = None
+    company_id: str | None = None
     image_url: str | None = None
     confidence_threshold: float = 0.20
     duplicate_sensitivity: float = 0.85
@@ -702,7 +717,7 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
     """
     text = request_body.text
 
-    settings = get_system_settings(request_body.company)
+    settings = get_system_settings(get_request_company_id(request_body))
     confidence_threshold = settings["ai_confidence_threshold"]
     duplicate_sensitivity = settings["duplicate_sensitivity"]
     enable_auto_resolve = settings["enable_auto_resolve"]
@@ -739,7 +754,7 @@ async def analyze_only(request_body: TicketRequest):
     """
     text = request_body.text
     print(f"[AI] Starting Analysis (READ-ONLY) for: {text[:50]}...") 
-    settings = get_system_settings(request_body.company)
+    settings = get_system_settings(get_request_company_id(request_body))
     confidence_threshold = settings["ai_confidence_threshold"]
     duplicate_sensitivity = settings["duplicate_sensitivity"]
     enable_auto_resolve = settings["enable_auto_resolve"]
@@ -908,7 +923,7 @@ async def analyze_stream(request_body: TicketRequest):
             "api_endpoint": "/ai/analyze_stream"
         }
         timeline = {"received": get_now_ist()} 
-        settings = get_system_settings(request_body.company)
+        settings = get_system_settings(get_request_company_id(request_body))
         confidence_threshold = settings["ai_confidence_threshold"]
         duplicate_sensitivity = settings["duplicate_sensitivity"]
         enable_auto_resolve = settings["enable_auto_resolve"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -85,12 +85,13 @@ def get_system_settings(company_id: str) -> dict:
 def resolve_company_name_to_id(company_name: str | None) -> str | None:
     if not supabase or not company_name:
         return None
-    try:
-        res = supabase.table("companies").select("id").eq("name", company_name).single().execute()
-        return res.data.get("id") if res.data else None
-    except Exception as e:
-        print(f"[WARNING] Could not resolve company name={company_name} to id: {e}")
-    return None
+    res = supabase.table("companies").select("id").eq("name", company_name).execute()
+    rows = res.data or []
+    if not rows:
+        return None
+    if len(rows) > 1:
+        raise ValueError(f"Multiple companies found for name={company_name!r}; pass company_id instead")
+    return rows[0].get("id")
 
 def get_request_company_id(request_body: "TicketRequest") -> str | None:
     return request_body.company_id or resolve_company_name_to_id(request_body.company)
@@ -743,10 +744,10 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
             print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
 
     # Initalize Timeline
-    return await analyze_only(request_body)
+    return await analyze_only(request_body, settings=settings)
 
 @app.post("/ai/analyze")
-async def analyze_only(request_body: TicketRequest):
+async def analyze_only(request_body: TicketRequest, settings: dict | None = None):
     """
     PERFORMANCE UPGRADE: AI Analysis phase only. 
     Does NOT persist to DB. This allows the user to review the analysis 
@@ -754,7 +755,8 @@ async def analyze_only(request_body: TicketRequest):
     """
     text = request_body.text
     print(f"[AI] Starting Analysis (READ-ONLY) for: {text[:50]}...") 
-    settings = get_system_settings(get_request_company_id(request_body))
+    if settings is None:
+        settings = get_system_settings(get_request_company_id(request_body))
     confidence_threshold = settings["ai_confidence_threshold"]
     duplicate_sensitivity = settings["duplicate_sensitivity"]
     enable_auto_resolve = settings["enable_auto_resolve"]

--- a/backend/tests/test_company_settings_id_source.py
+++ b/backend/tests/test_company_settings_id_source.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1].joinpath("main.py").read_text(encoding="utf-8")
+
+
+def test_ticket_request_accepts_company_id():
+    ticket_request_block = SOURCE.split("class TicketRequest(BaseModel):", 1)[1].split("class TicketSaveRequest", 1)[0]
+
+    assert "company_id: str | None = None" in ticket_request_block
+
+
+def test_settings_lookups_use_company_id_helper():
+    assert "def get_request_company_id" in SOURCE
+    assert "request_body.company_id or resolve_company_name_to_id(request_body.company)" in SOURCE
+    assert "get_system_settings(request_body.company)" not in SOURCE
+    assert SOURCE.count("get_system_settings(get_request_company_id(request_body))") == 3

--- a/backend/tests/test_company_settings_id_source.py
+++ b/backend/tests/test_company_settings_id_source.py
@@ -14,4 +14,14 @@ def test_settings_lookups_use_company_id_helper():
     assert "def get_request_company_id" in SOURCE
     assert "request_body.company_id or resolve_company_name_to_id(request_body.company)" in SOURCE
     assert "get_system_settings(request_body.company)" not in SOURCE
+    assert "await analyze_only(request_body, settings=settings)" in SOURCE
+    assert "if settings is None:" in SOURCE
     assert SOURCE.count("get_system_settings(get_request_company_id(request_body))") == 3
+
+
+def test_company_name_lookup_does_not_swallow_ambiguous_results():
+    resolver_block = SOURCE.split("def resolve_company_name_to_id", 1)[1].split("def get_request_company_id", 1)[0]
+
+    assert ".single().execute()" not in resolver_block
+    assert "raise ValueError" in resolver_block
+    assert "except Exception" not in resolver_block


### PR DESCRIPTION
## Summary
Fixes #1448 by making AI analysis settings lookups use the company UUID instead of the human-readable company name.

## Problem
`TicketRequest.company` contains a display name, but `system_settings.company_id` stores UUIDs. The backend passed the display name into `get_system_settings()`, so per-company settings did not match and defaults were silently used.

## Changes
- Add `company_id` to `TicketRequest` so the existing frontend payload is accepted instead of ignored.
- Add a helper that uses `company_id` first and falls back to resolving `company` by name.
- Update all three settings lookup call sites: `analyze_ticket`, `analyze_only`, and `analyze_stream`.
- Add a source-level regression test for the schema and lookup call path.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest backend/tests/test_company_settings_id_source.py -q`
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile backend/main.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ticket analysis endpoints now accept an optional company ID alongside company name and prefer it when resolving system settings.
  * Settings lookups fall back to resolving company name only when no company ID is provided.

* **Tests**
  * Added tests covering company-ID request handling, settings resolution paths, and proper handling of ambiguous company-name lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->