### PR TITLE
[BUG] Restore global scrollbar for WCAG accessibility (#1759)

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -93,12 +93,11 @@
 
 html{
   overflow-y: scroll;
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: auto; /* Firefox */
 }
 
 html::-webkit-scrollbar{
-  width: 0;
-  height: 0;
+  
 }
 
 body{


### PR DESCRIPTION
## WCAG Compliance Fix

**Issue:** Global scrollbar was hidden, violating WCAG accessibility guidelines (users cannot identify scrollable content).

**Changes made:**
- Removed `scrollbar-width: none;` (Firefox) → replaced with `scrollbar-width: auto;`
- Removed `width: 0; height: 0;` (WebKit) → restored native scrollbar visibility

**Before:**
```css
html::-webkit-scrollbar{ width: 0; height: 0; }
html{ scrollbar-width: none; }
```

**After:**
```css
html::-webkit-scrollbar{ /* native scrollbar restored */ }
html{ scrollbar-width: auto; }
```

**Testing:** Manual verification in Chrome, Firefox, Safari.

Fixes #1759