### PR TITLE
chore(backend): add comprehensive .gitignore for Python project

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,38 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+venv/
+env/
+ENV/
+.env
+.env.local
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Logs
+*.log
+logs/
+
+# Models (large)
+models/*.bin
+models/*.pt
+models/*.onnx
+
+# Build
+build/
+dist/
+*.egg-info/


### PR DESCRIPTION
## Backend .gitignore

Adds standard Python .gitignore for the `backend/` directory. Currently missing, which risks committing:
- `__pycache__/` directories
- Virtual environments (`venv/`, `env/`)
- `.env` files with secrets
- Test caches (`.pytest_cache/`, `.coverage`)
- Large ML model files (`.bin`, `.pt`, `.onnx`)
- IDE configs (`.vscode/`, `.idea/`)

This is a critical security and repo hygiene fix.