### PR TITLE
docs: add PULL_REQUEST_TEMPLATE.md for standardized PR submissions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+<!-- Brief description of changes -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Related Issues
+
+<!-- Link related issues: Fixes #123, Closes #456 -->
+
+## Testing
+
+- [ ] Unit tests pass
+- [ ] Manual testing completed
+- [ ] New tests added (if applicable)
+
+## Checklist
+
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] I have updated the documentation accordingly
+
+## Screenshots (if applicable)
+
+<!-- Add screenshots to help explain your changes -->


### PR DESCRIPTION
## PR Template

Adds `.github/PULL_REQUEST_TEMPLATE.md` to standardize PR submissions.

**Currently missing** despite having `CONTRIBUTING.md` and issue templates.

Template includes:
- Description field
- Type of change checkboxes (bug fix, feature, breaking, docs)
- Related issues linking
- Testing checklist
- Code style/review checklist
- Screenshots placeholder

GitHub auto-populates the PR body with this template, ensuring every contributor provides consistent information.