### PR TITLE
fix: clear TicketChat typing timeout on cleanup

### DIFF
--- a/Frontend/src/components/shared/TicketChat.jsx
+++ b/Frontend/src/components/shared/TicketChat.jsx
@@ -227,9 +227,12 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
       .on('broadcast', { event: 'typing' }, (payload) => {
         if (payload.payload.user_id !== user?.id) {
           setIsTyping(true);
-          clearTimeout(window.typingTimeout);
-          window.typingTimeout = setTimeout(() => {
+          if (typingIndicatorTimeoutRef.current) {
+            clearTimeout(typingIndicatorTimeoutRef.current);
+          }
+          typingIndicatorTimeoutRef.current = window.setTimeout(() => {
             setIsTyping(false);
+            typingIndicatorTimeoutRef.current = null;
           }, 3000);
           setTimeout(() => scrollToBottom(), 50);
         }
@@ -237,6 +240,10 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
       .subscribe();
 
     return () => {
+      if (typingIndicatorTimeoutRef.current) {
+        clearTimeout(typingIndicatorTimeoutRef.current);
+        typingIndicatorTimeoutRef.current = null;
+      }
       supabase.removeChannel(channel);
     };
   }, [ticketId]);
@@ -345,6 +352,10 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
             .subscribe();
 
         return () => {
+            if (typingIndicatorTimeoutRef.current) {
+                clearTimeout(typingIndicatorTimeoutRef.current);
+                typingIndicatorTimeoutRef.current = null;
+            }
             supabase.removeChannel(channel);
             if (callTimerRef.current) clearInterval(callTimerRef.current);
             if (recordTimerRef.current) clearInterval(recordTimerRef.current);

--- a/Frontend/src/components/shared/TicketChat.structure.test.js
+++ b/Frontend/src/components/shared/TicketChat.structure.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./TicketChat.jsx", import.meta.url), "utf8");
+
+test("typing indicator timeout stays component-scoped", () => {
+  assert.equal(source.includes("window.typingTimeout"), false);
+  assert.match(source, /typingIndicatorTimeoutRef\s*=\s*useRef\(null\)/);
+  assert.match(source, /typingIndicatorTimeoutRef\.current\s*=\s*window\.setTimeout/);
+});
+
+test("typing indicator timeout is cleared during subscription cleanup", () => {
+  const cleanupBlocks = [...source.matchAll(/return \(\) => \{([\s\S]*?)supabase\.removeChannel\(channel\);/g)];
+
+  assert.ok(cleanupBlocks.length >= 1);
+  assert.ok(
+    cleanupBlocks.some((block) => block[1].includes("clearTimeout(typingIndicatorTimeoutRef.current)")),
+    "expected a subscription cleanup to clear typingIndicatorTimeoutRef"
+  );
+});


### PR DESCRIPTION
Closes #1978

## Summary
- Replace the remaining global `window.typingTimeout` usage with the existing component-scoped `typingIndicatorTimeoutRef`.
- Clear the typing indicator timeout during realtime subscription cleanup so unmounted `TicketChat` instances do not receive delayed state updates.
- Add a structural Node test to guard against reintroducing `window.typingTimeout` and to verify cleanup clears the ref.

## Verification
- `node --test Frontend/src/components/shared/TicketChat.structure.test.js` -> 2 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved stale typing indicators in ticket chat that could persist after users stopped typing, improving real-time communication clarity.

* **Tests**
  * Added test coverage for typing indicator cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->