### PR TITLE
ci: add Dependabot config and CODEOWNERS for automated dependency management

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Default owners for everything
+* @ritesh-1918
+
+# Frontend
+/Frontend/ @ritesh-1918
+
+# Backend
+/backend/ @ritesh-1918
+
+# CI/CD & GitHub config
+/.github/ @ritesh-1918
+
+# Documentation
+/docs/ @ritesh-1918
+*.md @ritesh-1918

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/Frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "frontend"
+    
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "backend"
+    
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Automation & Governance

Adds two critical automation files:

1. **`.github/dependabot.yml`** — Auto-creates PRs for:
   - npm packages in `/Frontend` (weekly)
   - pip packages in `/backend` (weekly)
   - GitHub Actions versions (weekly)
   - Max 5 open PRs per ecosystem to avoid spam

2. **`.github/CODEOWNERS`** — Auto-assigns `@ritesh-1918` as reviewer for all PRs touching:
   - Frontend, backend, CI, docs

Both are missing despite the project's complexity. This reduces manual maintenance burden and improves security posture.