### PR TITLE
fix: accept Supabase service key alias

### DIFF
--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -57,13 +57,13 @@ def _build_client():
         EnvironmentError: If required environment variables are missing.
     """
     url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
 
     missing = []
     if not url:
         missing.append("SUPABASE_URL")
     if not key:
-        missing.append("SUPABASE_SERVICE_ROLE_KEY")
+        missing.append("SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SERVICE_KEY")
 
     if missing:
         raise EnvironmentError(

--- a/backend/services/auto_close_service.py
+++ b/backend/services/auto_close_service.py
@@ -46,7 +46,7 @@ class AutoCloseService:
         """
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")
         )
         # Global fallback default (used when company has no settings)
         self.default_auto_close_days = int(os.getenv("AUTO_CLOSE_DAYS", "7"))

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -99,7 +99,7 @@ class NotificationRoutingMiddleware:
             return
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY"),
+            os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY"),
         )
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()
         self._initialised = True

--- a/backend/tests/test_seed_company_settings.py
+++ b/backend/tests/test_seed_company_settings.py
@@ -114,6 +114,7 @@ def test_dry_run_skips_insert_but_reports_pending_records():
 def test_build_client_reports_missing_environment(monkeypatch):
     monkeypatch.delenv("SUPABASE_URL", raising=False)
     monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.delenv("SUPABASE_SERVICE_KEY", raising=False)
 
     with pytest.raises(EnvironmentError) as exc_info:
         seed_mod._build_client()
@@ -121,6 +122,26 @@ def test_build_client_reports_missing_environment(monkeypatch):
     message = str(exc_info.value)
     assert "SUPABASE_URL" in message
     assert "SUPABASE_SERVICE_ROLE_KEY" in message
+    assert "SUPABASE_SERVICE_KEY" in message
+
+
+def test_build_client_accepts_service_key_alias(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.delenv("SUPABASE_SERVICE_ROLE_KEY", raising=False)
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "service-key")
+
+    with patch.dict("sys.modules", {"supabase": MagicMock()}):
+        import supabase
+
+        supabase.create_client.return_value = "client"
+
+        client = seed_mod._build_client()
+
+    assert client == "client"
+    supabase.create_client.assert_called_once_with(
+        "https://example.supabase.co",
+        "service-key",
+    )
 
 
 def test_main_reuses_one_client_for_seed_and_verify():

--- a/backend/tests/test_seed_company_settings.py
+++ b/backend/tests/test_seed_company_settings.py
@@ -144,6 +144,25 @@ def test_build_client_accepts_service_key_alias(monkeypatch):
     )
 
 
+def test_build_client_prefers_service_role_key_over_alias(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "primary-key")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "fallback-key")
+
+    with patch.dict("sys.modules", {"supabase": MagicMock()}):
+        import supabase
+
+        supabase.create_client.return_value = "client"
+
+        client = seed_mod._build_client()
+
+    assert client == "client"
+    supabase.create_client.assert_called_once_with(
+        "https://example.supabase.co",
+        "primary-key",
+    )
+
+
 def test_main_reuses_one_client_for_seed_and_verify():
     client = FakeSupabase({
         "tickets": [{"company_id": "c1"}],

--- a/backend/tests/test_supabase_service_key_aliases.py
+++ b/backend/tests/test_supabase_service_key_aliases.py
@@ -13,4 +13,5 @@ def test_supabase_client_initializers_accept_service_key_alias():
     ]:
         source = (ROOT / relative_path).read_text(encoding="utf-8")
 
-        assert 'os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")' in source
+        assert "SUPABASE_SERVICE_ROLE_KEY" in source
+        assert "SUPABASE_SERVICE_KEY" in source

--- a/backend/tests/test_supabase_service_key_aliases.py
+++ b/backend/tests/test_supabase_service_key_aliases.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_supabase_client_initializers_accept_service_key_alias():
+    for relative_path in [
+        "services/auto_close_service.py",
+        "services/notification_routing.py",
+    ]:
+        source = (ROOT / relative_path).read_text(encoding="utf-8")
+
+        assert 'os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_SERVICE_KEY")' in source


### PR DESCRIPTION
## Summary
- Accept `SUPABASE_SERVICE_KEY` as a fallback alias for service-role client initialization in auto-close and notification routing.
- Allow `seed_company_settings.py` to build its Supabase client with either `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_SERVICE_KEY`.
- Add focused regression coverage for the alias behavior.

## Verification
- `python -m pytest backend\tests\test_seed_company_settings.py backend\tests\test_supabase_service_key_aliases.py -q` -> 8 passed
- `python -m py_compile backend\services\auto_close_service.py backend\services\notification_routing.py backend\scripts\seed_company_settings.py backend\tests\test_seed_company_settings.py backend\tests\test_supabase_service_key_aliases.py` -> OK
- `git diff --check` -> no errors

Closes #1974
Closes #1986

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Extended authentication configuration to accept an alternative credential variable in addition to the standard option, providing greater flexibility for various deployment scenarios.

* **Tests**
  * Added comprehensive test coverage to verify the extended authentication configuration works reliably across backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->