### PR TITLE
fix: guard realtime subscription company id

### DIFF
--- a/Frontend/src/hooks/useRealtimeNotifications.js
+++ b/Frontend/src/hooks/useRealtimeNotifications.js
@@ -13,6 +13,10 @@ const useTicketsRealtime = () => {
     // Only admins see the live ticket queue
     const isAdmin = profile.role === 'admin' || profile.role === 'master_admin';
     if (!isAdmin) return;
+    if (!profile.company_id) {
+      console.warn('useTicketsRealtime: profile.company_id is missing, skipping realtime subscription');
+      return;
+    }
 
     const channel = supabase
       .channel('tickets-realtime-dashboard')

--- a/Frontend/src/hooks/useRealtimeNotifications.structure.test.js
+++ b/Frontend/src/hooks/useRealtimeNotifications.structure.test.js
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert';
+import test from 'node:test';
+
+const source = readFileSync('Frontend/src/hooks/useRealtimeNotifications.js', 'utf8');
+
+test('guards realtime subscription when admin profile has no company id', () => {
+  assert.match(source, /if \(!profile\.company_id\) \{/);
+  assert.match(source, /console\.warn\('useTicketsRealtime: profile\.company_id is missing, skipping realtime subscription'\)/);
+  assert.match(source, /filter: `company_id=eq\.\$\{profile\.company_id\}`/);
+});
+
+test('company id guard runs before creating the Supabase channel', () => {
+  const guardIndex = source.indexOf('if (!profile.company_id)');
+  const channelIndex = source.indexOf("supabase\n      .channel('tickets-realtime-dashboard')");
+
+  assert.notStrictEqual(guardIndex, -1);
+  assert.notStrictEqual(channelIndex, -1);
+  assert.ok(guardIndex < channelIndex);
+});


### PR DESCRIPTION
## Summary
- Skip the admin ticket realtime subscription when an admin profile has no `company_id`.
- Avoid generating `company_id=eq.undefined` / `company_id=eq.null` filters that silently match no tickets.
- Add a focused structural regression test for the guard and filter ordering.

## Verification
- `node --test Frontend\src\hooks\useRealtimeNotifications.structure.test.js` -> 2 passed
- `node --check Frontend\src\hooks\useRealtimeNotifications.js` -> OK
- `git diff --check` -> no errors

Closes #1975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the real-time notifications system to validate that required profile information is present before creating subscriptions. If profile information is incomplete, the system logs a warning and prevents subscription initialization.

* **Tests**
  * Added tests to verify proper validation behavior when profile information is missing and to confirm validation checks execute before subscription creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->