### PR TITLE
fix: use existing classifier trainer in train_all

### DIFF
--- a/backend/tests/test_train_all_imports.py
+++ b/backend/tests/test_train_all_imports.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 def test_train_all_uses_existing_classifier_trainer_module():
-    source = Path("backend/train_all.py").read_text(encoding="utf-8")
+    source = (Path(__file__).resolve().parents[2] / "backend" / "train_all.py").read_text(encoding="utf-8")
 
     assert "backend.training.classifier_trainer import" not in source
     assert "from backend.training.classifier_trainer_v3 import train_v3 as train_classifier" in source

--- a/backend/tests/test_train_all_imports.py
+++ b/backend/tests/test_train_all_imports.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_train_all_uses_existing_classifier_trainer_module():
+    source = Path("backend/train_all.py").read_text(encoding="utf-8")
+
+    assert "backend.training.classifier_trainer import" not in source
+    assert "from backend.training.classifier_trainer_v3 import train_v3 as train_classifier" in source

--- a/backend/train_all.py
+++ b/backend/train_all.py
@@ -14,7 +14,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
 sys.path.insert(0, PROJECT_ROOT)
 
-from backend.training.classifier_trainer import train_classifier
+from backend.training.classifier_trainer_v3 import train_v3 as train_classifier
 from backend.training.ner_trainer import train_ner
 
 


### PR DESCRIPTION
## Summary
- Update `backend/train_all.py` to import the existing `classifier_trainer_v3` implementation.
- Alias `train_v3` as `train_classifier` so the orchestration flow remains unchanged.
- Add a focused regression test that prevents the removed non-existent import path from returning.

## Verification
- `python -m pytest backend\tests\test_train_all_imports.py -q` -> 1 passed
- `python -m py_compile backend\train_all.py backend\tests\test_train_all_imports.py` -> OK
- `git diff --check` -> no errors

Closes #1752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to verify correct training module imports are used

* **Chores**
  * Updated internal training module references to use updated version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->