### PR TITLE
fix: keyword override re-derives subcategory/priority/auto_resolve — bounty #1816

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -136,8 +136,13 @@ class ClassifierService:
                 if category == "General" or confidence < 0.9:
                     category = cat
                     assigned_team = TEAM_MAP.get(cat, "General Support")
+                    # Re-derive fields from the corrected category
+                    # Use Unknown subcategory for keyword-only matches; priority/auto_resolve reset
+                    subcategory = "Unknown"
+                    priority = PRIORITY_MAP.get(subcategory, "Medium")
+                    auto_resolve = subcategory in AUTO_RESOLVE_SUBS
                     # Boost confidence significantly for verified technical signals
-                    confidence = max(confidence, 0.92) 
+                    confidence = max(confidence, 0.92)
                     break
 
         return {


### PR DESCRIPTION
## Fix: Keyword Override Layer now maintains field consistency

### Problem (from #1816)
When the regex keyword override changes , the fields , , and  were derived from the model's original prediction and never updated. This caused inconsistencies.

### Fix
After keyword override reassigns , all derived fields are reset:
-  → "Unknown" (no model prediction on override)
-  → "Medium" (safe default)
-  →  (cannot auto-resolve unknown subcategory)

Closes #1816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved classification accuracy for technical content with enhanced keyword recognition and refinement of prediction confidence scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->