### PR TITLE
fix: use package-safe imports in backend main

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,9 +28,9 @@ import contextlib
 from logging.handlers import RotatingFileHandler
 
 # Suppress harmless PyTorch CPU pin_memory warning
-from encryption import encrypt_pii, decrypt_pii, is_encrypted
+from backend.encryption import encrypt_pii, decrypt_pii, is_encrypted
 from services.encryption_service import encrypt_ticket_pii, decrypt_ticket_pii
-from pii_redaction import redact_pii, redact_pii_dict, set_pii_redaction_enabled, is_pii_redaction_enabled
+from backend.pii_redaction import redact_pii, redact_pii_dict, set_pii_redaction_enabled, is_pii_redaction_enabled
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
@@ -4093,7 +4093,7 @@ async def scan_text_for_pii(
     if not text:
         return {"findings": {}, "message": "No text provided"}
 
-    from pii_redaction import scan_pii
+    from backend.pii_redaction import scan_pii
     findings = scan_pii(text)
     return {
         "findings": findings,

--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,7 @@ from logging.handlers import RotatingFileHandler
 
 # Suppress harmless PyTorch CPU pin_memory warning
 from backend.encryption import encrypt_pii, decrypt_pii, is_encrypted
-from services.encryption_service import encrypt_ticket_pii, decrypt_ticket_pii
+from backend.services.encryption_service import encrypt_ticket_pii, decrypt_ticket_pii
 from backend.pii_redaction import redact_pii, redact_pii_dict, set_pii_redaction_enabled, is_pii_redaction_enabled
 warnings.filterwarnings("ignore", message="'pin_memory'")
 

--- a/backend/tests/test_main_package_imports.py
+++ b/backend/tests/test_main_package_imports.py
@@ -1,10 +1,42 @@
+import ast
+import importlib
+import sys
+import types
 from pathlib import Path
+
+import pytest
 
 
 def test_main_uses_package_safe_imports_for_local_modules():
     source = (Path(__file__).resolve().parents[2] / "backend" / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    import_from_modules = [node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)]
 
-    assert "from encryption import" not in source
-    assert "from pii_redaction import" not in source
-    assert "from backend.encryption import encrypt_pii, decrypt_pii, is_encrypted" in source
-    assert "from backend.pii_redaction import" in source
+    assert "encryption" not in import_from_modules
+    assert "pii_redaction" not in import_from_modules
+    assert "services.encryption_service" not in import_from_modules
+    assert "backend.encryption" in import_from_modules
+    assert "backend.pii_redaction" in import_from_modules
+    assert "backend.services.encryption_service" in import_from_modules
+
+
+def test_main_imports_as_package_module(monkeypatch):
+    monkeypatch.setenv("ALLOW_DEGRADED_STARTUP", "1")
+    monkeypatch.setenv("SUPABASE_URL", "https://placeholder.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "placeholder_key")
+    sys.modules.pop("backend.main", None)
+    monkeypatch.setitem(sys.modules, "Crypto", types.ModuleType("Crypto"))
+    monkeypatch.setitem(sys.modules, "Crypto.Cipher", types.ModuleType("Crypto.Cipher"))
+    monkeypatch.setitem(sys.modules, "Crypto.Random", types.ModuleType("Crypto.Random"))
+    fake_aes = types.SimpleNamespace(MODE_GCM=1, new=lambda *args, **kwargs: None)
+    sys.modules["Crypto.Cipher"].AES = fake_aes
+    sys.modules["Crypto.Random"].get_random_bytes = lambda size: b"0" * size
+
+    try:
+        module = importlib.import_module("backend.main")
+    except ModuleNotFoundError as exc:
+        if exc.name in {"encryption", "pii_redaction", "services"}:
+            raise
+        pytest.skip(f"backend.main import requires optional dependency {exc.name!r}")
+
+    assert hasattr(module, "app")

--- a/backend/tests/test_main_package_imports.py
+++ b/backend/tests/test_main_package_imports.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_main_uses_package_safe_imports_for_local_modules():
+    source = (Path(__file__).resolve().parents[2] / "backend" / "main.py").read_text(encoding="utf-8")
+
+    assert "from encryption import" not in source
+    assert "from pii_redaction import" not in source
+    assert "from backend.encryption import encrypt_pii, decrypt_pii, is_encrypted" in source
+    assert "from backend.pii_redaction import" in source


### PR DESCRIPTION
## Summary
- switch `backend/main.py` local imports for encryption and PII redaction to package-qualified imports
- update the deferred PII scan import to use `backend.pii_redaction`
- add a regression test that prevents top-level local imports from returning

Fixes #1996.

## Verification
- `python -m pytest backend\tests\test_main_package_imports.py -q` -> 1 passed
- `python -m py_compile backend\main.py backend\tests\test_main_package_imports.py` -> OK
- `git diff --check` -> no whitespace errors

Note: `python -m pytest backend\tests\test_import_smoke.py -q` currently still has pre-existing failures in the Supabase mock setup (`supabase.create_client` missing on the local namespace package) before this package-import assertion can be isolated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized internal module import paths to a consistent package namespace, improving reliability and organization.

* **Tests**
  * Added tests that validate the updated import patterns statically and verify runtime import behavior under different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->