### PR TITLE
fix: pass current user through analyze ticket

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2988,7 +2988,7 @@ async def analyze_ticket(request_body: TicketRequest, request: Request, current_
 
     # Pass OCR-enriched text downstream so the analyze_only endpoint uses it.
     enriched = request_body.model_copy(update={"text": text, "image_text": local_ocr_text})
-    return await analyze_only(enriched, request, user)
+    return await analyze_only(enriched, request, current_user)
 
 @app.post("/ai/analyze")
 @limiter.limit("10/minute")

--- a/backend/tests/test_analyze_ticket_delegation.py
+++ b/backend/tests/test_analyze_ticket_delegation.py
@@ -1,0 +1,27 @@
+import ast
+from pathlib import Path
+
+
+def test_analyze_ticket_delegates_current_user_to_analyze_only():
+    source = (Path(__file__).resolve().parents[2] / "backend" / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    analyze_ticket = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "analyze_ticket"
+        and any(arg.arg == "current_user" for arg in node.args.args)
+    )
+    analyze_only_calls = [
+        node
+        for node in ast.walk(analyze_ticket)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "analyze_only"
+    ]
+
+    assert analyze_only_calls
+    delegated_args = analyze_only_calls[-1].args
+    assert isinstance(delegated_args[2], ast.Name)
+    assert delegated_args[2].id == "current_user"


### PR DESCRIPTION
## Summary
- fix `/ai/analyze_ticket` delegation to pass `current_user` instead of an undefined `user` name
- add an AST regression test that verifies the endpoint delegates the authenticated user to `analyze_only`

Related to #1988.

## Verification
- `python -m pytest backend\tests\test_analyze_ticket_delegation.py -q` -> 1 passed
- `python -m py_compile backend\main.py backend\tests\test_analyze_ticket_delegation.py` -> OK
- `git diff --check` -> no whitespace errors