### PR TITLE
test : added unit tests for formatTicketId utility

### DIFF
--- a/Frontend/src/utils/format.test.js
+++ b/Frontend/src/utils/format.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { formatTicketId } from './format.js';
+
+describe('formatTicketId', () => {
+    it('returns empty string for null input', () => {
+        expect(formatTicketId(null)).toBe('');
+    });
+
+    it('returns empty string for undefined input', () => {
+        expect(formatTicketId(undefined)).toBe('');
+    });
+
+    it('returns empty string for empty string input', () => {
+        expect(formatTicketId('')).toBe('');
+    });
+
+    it('returns short strings as-is (length <= 8)', () => {
+        expect(formatTicketId('ABC-123')).toBe('ABC-123');
+        expect(formatTicketId('TICKET1')).toBe('TICKET1');
+        expect(formatTicketId('A1B2C3')).toBe('A1B2C3');
+        expect(formatTicketId('ABCDEFGH')).toBe('ABCDEFGH'); // exactly 8
+    });
+
+    it('extracts and uppercases first UUID segment', () => {
+        expect(formatTicketId('550e8400-e29b-41d4-a716-446655440000')).toBe('550E8400');
+        expect(formatTicketId('123e4567-e89b-12d3-a456-426614174000')).toBe('123E4567');
+    });
+
+    it('handles non-string number inputs by returning the original value', () => {
+        // Numbers pass the length check (String(12345).length = 5 <= 8) and are returned as-is
+        expect(formatTicketId(12345)).toBe(12345);
+    });
+
+    it('handles empty array by returning the original array (length check passes)', () => {
+        // String([]) = '' (length 0 <= 8), so original [] is returned
+        expect(formatTicketId([])).toEqual([]);
+    });
+
+    it('handles object input by returning uppercased full string as no dash separator', () => {
+        // String({}) = '[object Object]' (length 15 > 8), no dash so whole string uppercased
+        expect(formatTicketId({})).toBe('[OBJECT OBJECT]');
+    });
+});


### PR DESCRIPTION
Closes #2056.

Summary of What Has Been Done:
Added unit tests for the formatTicketId utility function covering null/undefined/empty inputs, short string passthrough, UUID segment extraction, and non-string input coercion behavior.

Changes Made:
- Created Frontend/src/utils/format.test.js with 8 test cases
- Uses vitest (already available in node_modules)
- Tests cover: null, undefined, empty string, short strings (len <= 8), UUID first-segment extraction, and non-string coercion edge cases

Impact it Made:
- Prevents regressions when formatTicketId logic is modified
- Documents actual behavior including edge cases discovered during testing
- All 8 tests pass (verified with vitest run)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for ticket ID formatting functionality, thoroughly validating correct behavior across diverse input scenarios including null values, undefined inputs, empty strings, UUID formats, numeric inputs, array inputs, and various object representations to ensure consistent and reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->