### PR TITLE
fix: correct _allowed_origins typo to allowed_cors_origins in CORS middleware (closes #2083)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1602,7 +1602,7 @@ print(f"[startup] CORS allowed origins: {allowed_cors_origins}")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=_allowed_origins,
+    allow_origins=allowed_cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allow_headers=["Authorization", "Content-Type", "X-API-Key", "X-CSRF-Token"],


### PR DESCRIPTION
## Description

Fixes a critical `NameError` at server startup that crashes the entire API.

### The Bug

`backend/main.py:1600` defines `allowed_cors_origins = get_allowed_origins()` but `backend/main.py:1605` references `_allowed_origins` (note the underscore prefix), which was **never defined**.

When the server starts, FastAPI evaluates the CORS middleware configuration and throws:
```
NameError: name '_allowed_origins' is not defined
```

This crashes the server before any endpoint can respond.

### Fix

One character fix: `_allowed_origins` → `allowed_cors_origins` on line 1605.

Closes #2083
