### PR TITLE
fix: remove dead compute_analysis call that crashes /ai/analyze_stream on every request (closes #2084)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3718,9 +3718,6 @@ async def analyze_stream(request: Request, request_body: TicketRequest):
         yield f"data: {json.dumps({'step': 'Reading your message', 'status': 'in_progress'})}\n\n"
         await asyncio.sleep(0.15)
         yield f"data: {json.dumps({'step': 'Analyzing', 'status': 'in_progress'})}\n\n"
-        # Centralized computation
-        result = compute_analysis(request_body, api_endpoint="/ai/analyze_stream")
-
         gemini_analysis = {"ocr_text": request_body.image_text or "", "image_description": ""}
         if request_body.image_base64 and not gemini_analysis["ocr_text"]:
             try:


### PR DESCRIPTION
## Description

Removes a dead function call that crashes `POST /ai/analyze_stream` on every request.

### The Bug

`backend/main.py:3722` calls `compute_analysis(request_body, api_endpoint="/ai/analyze_stream")`. This function was **never defined** in the codebase. Inside the SSE event generator, this throws `NameError: name 'compute_analysis' is not defined`, which causes a 500 error for every streaming analysis request.

The `result` variable is also never consumed — the endpoint duplicates the full analysis logic inline starting at line 3724.

### Fix

Remove the 2-line dead code block. The remaining inline logic performs the correct analysis.

Closes #2084
