### PR TITLE
fix : made USE_MOCK configurable via VITE_USE_MOCK env var

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -1,0 +1,17 @@
+# AI Helpdesk Frontend Environment Variables
+
+# Backend API URL (optional - defaults to localhost in dev, HF Space in prod)
+# VITE_BACKEND_URL=http://localhost:8000
+
+# Set to 'true' to use mock API responses instead of real backend
+# Useful for local development without a running backend
+# VITE_USE_MOCK=true
+
+# Gemini API Keys (for AI ticket analysis)
+# VITE_GEMINI_API_KEY_1=your_key_here
+
+# OpenRouter API Keys
+# VITE_OPENROUTER_API_KEY_1=your_key_here
+
+# Groq API Keys
+# VITE_GROQ_API_KEY_1=your_key_here

--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { MOCK_TICKETS } from './mockData';
 import { API_CONFIG } from '../config';
 
-const USE_MOCK = true;
+const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
 const API_BASE_URL = API_CONFIG.BACKEND_URL;
 
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
Closes #2062.

Summary of What Has Been Done:
Replaced hardcoded USE_MOCK = true with a configurable flag driven by the VITE_USE_MOCK environment variable.

Changes Made:
- Changed const USE_MOCK = true to const USE_MOCK = import.meta.env.VITE_USE_MOCK === "true"
- Created Frontend/.env.example documenting VITE_USE_MOCK
- Default is false (undefined !== "true"), so production uses real API by default
- Local dev can set VITE_USE_MOCK=true to use mock data

Impact it Made:
- Enables production deployments to use real AI backend
- Removes need for code changes to switch between mock and real APIs
- Follows existing pattern used by other config values in the codebase
- No lint errors introduced