### PR TITLE
fix: add missing logger import to authStore.ts to prevent ReferenceError on all auth operations (closes #2085)

### DIFF
--- a/Frontend/src/store/authStore.ts
+++ b/Frontend/src/store/authStore.ts
@@ -9,6 +9,7 @@ const validatePassword = (password) => {
 import { create } from 'zustand';
 import { supabase } from '../lib/supabaseClient';
 import { API_CONFIG } from '../config';
+import { logger } from '../utils/logger';
 import useTicketStore from './ticketStore';
 
 const BACKEND_URL = API_CONFIG.BACKEND_URL;


### PR DESCRIPTION
## Description

Fixes a critical ReferenceError that breaks all authentication in the frontend.

### The Bug

\Frontend/src/store/authStore.ts\ makes 15+ calls to \logger.log()\, \logger.warn()\, and \logger.error()\ across login, signup, magic link, OTP verification, and profile update code paths — but **never imports a logger**.

This throws \ReferenceError: logger is not defined\ on every auth operation, making the app completely unusable for authentication.

The project has a logger utility at \src/utils/logger.js\ that should be imported.

### Fix

Added \import { logger } from '../utils/logger';\ to the imports in \uthStore.ts\.

Closes #2085