### PR TITLE
fix: remove copy-pasted dead code from trigger_webhook_for_new_ticket that silently drops critical/high ticket alerts (closes #2086)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2592,15 +2592,6 @@ def trigger_webhook_for_new_ticket(company_id: str, ticket: dict) -> None:
     if priority not in ("critical", "high"):
         return
 
-    # Clamp per_page to prevent abuse
-    per_page = min(max(int(per_page), 1), 100)
-    offset = (max(int(page), 1) - 1) * per_page
-
-    # Parse comma-separated filter lists
-    status_list: list[str] | None = [s.strip() for s in status.split(",") if s.strip()] if status else None
-    priority_list: list[str] | None = [p.strip() for p in priority.split(",") if p.strip()] if priority else None
-    category_list: list[str] | None = [c.strip() for c in category.split(",") if c.strip()] if category else None
-
     try:
         # Fetch webhook settings for the company
         res = supabase.table("webhook_settings").select("webhook_url, is_enabled").eq("company_id", company_id).maybeSingle().execute()


### PR DESCRIPTION
## Description

Fixes silent notification loss for critical and high priority tickets.

### The Bug

`trigger_webhook_for_new_ticket()` in `backend/main.py:2586` contains copy-pasted dead code (lines 2595-2602) that references undefined variables (per_page, page, status, priority, category) which were copied from a paginated list endpoint.

Since this runs inside `asyncio.create_task(asyncio.to_thread(...))`, the NameError is caught by a generic handler that logs a misleading message, masking the real root cause.

**Result**: Every critical/high priority ticket has its webhook notification silently fail. Admins never receive Slack/Teams alerts.

### Fix

Removed the 8 lines of dead code. The unused variables are never referenced anywhere else in the function.

Closes #2086
