### PR TITLE
fix : added isAdmin dependency to useEffect in useRealtimeNotifications

### DIFF
--- a/Frontend/src/hooks/useRealtimeNotifications.js
+++ b/Frontend/src/hooks/useRealtimeNotifications.js
@@ -7,11 +7,13 @@ const useTicketsRealtime = () => {
     const { user, profile } = useAuthStore();
     const { addTicket, updateTicket, removeTicket } = useTicketStore();
 
+    // Derive admin status from profile role to include in dependency array
+    const isAdmin = profile?.role === 'admin' || profile?.role === 'master_admin';
+
     useEffect(() => {
         if (!user || !profile) return;
 
         // Only admins see the live ticket queue
-        const isAdmin = profile.role === 'admin' || profile.role === 'master_admin';
         if (!isAdmin) return;
 
         const channel = supabase
@@ -45,7 +47,7 @@ const useTicketsRealtime = () => {
         return () => {
             supabase.removeChannel(channel);
         };
-    }, [user, profile, addTicket, updateTicket, removeTicket]);
+    }, [user, profile, isAdmin, addTicket, updateTicket, removeTicket]);
 };
 
 export default useTicketsRealtime;


### PR DESCRIPTION
Closes #2064.

Summary of What Has Been Done:
Fixed the missing isAdmin dependency in the useEffect hook in Frontend/src/hooks/useRealtimeNotifications.js.

Changes Made:
- Moved isAdmin computation outside the useEffect (before it runs)
- Added isAdmin to the dependency array: [user, profile, isAdmin, addTicket, updateTicket, removeTicket]
- Ensures the realtime subscription re-initializes when admin role changes

Impact it Made:
- Prevents stale realtime subscription when user role changes mid-session
- Ensures admins always see the live ticket queue
- Follows React hooks exhaustive-deps linting rules
- No lint errors introduced