### PR TITLE
fix : added loading state guard for company dropdown in Signup.jsx

### DIFF
--- a/Frontend/src/pages/Signup.jsx
+++ b/Frontend/src/pages/Signup.jsx
@@ -67,12 +67,15 @@ function Signup() {
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setIsDropdownOpen(false);
+        // Do not close dropdown while companies are loading
+        if (!isLoadingCompanies) {
+          setIsDropdownOpen(false);
+        }
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  }, [isLoadingCompanies]);
 
   // Filter companies
   useEffect(() => {
@@ -261,7 +264,7 @@ function Signup() {
             {/* Company Dropdown */}
             <div className="relative" ref={dropdownRef}>
               <label className="block mb-2" style={labelStyle}>Company</label>
-              <div onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              <div onClick={() => { if (!isLoadingCompanies) setIsDropdownOpen(!isDropdownOpen); }}
                 style={{ ...inputStyle, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderColor: isDropdownOpen ? '#22c55e' : '#e5e7eb', boxShadow: isDropdownOpen ? '0 0 0 3px rgba(34,160,69,0.1)' : 'none' }}>
                 {selectedCompany ? (
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
Closes #2074.

Summary of What Has Been Done:
Improved the company dropdown loading UX in Frontend/src/pages/Signup.jsx.

Changes Made:
- Dropdown click handler now ignores clicks when isLoadingCompanies is true
- handleClickOutside no longer closes dropdown while companies are loading
- Added isLoadingCompanies to the handleClickOutside dependency array
- User can still see the loading spinner if dropdown is already open

Impact it Made:
- Better UX for company selection during registration
- Prevents user frustration from dropdown closing before data loads
- Provides clear feedback about data fetching state
- No lint errors introduced