### PR TITLE
fix: move hardcoded Supabase credentials to environment variables

### DIFF
--- a/MobileApp/.env.example
+++ b/MobileApp/.env.example
@@ -1,0 +1,5 @@
+# Supabase Configuration
+# Copy this file to .env and fill in your Supabase project credentials.
+# Get these values from your Supabase project dashboard: Settings > API
+EXPO_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/MobileApp/.gitignore
+++ b/MobileApp/.gitignore
@@ -31,6 +31,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript

--- a/MobileApp/.gitignore
+++ b/MobileApp/.gitignore
@@ -30,9 +30,9 @@ yarn-error.*
 .DS_Store
 *.pem
 
-# local env files
-.env
-.env*.local
+# local env files (but keep .env.example as documentation)
+.env*
+!.env.example
 
 # typescript
 *.tsbuildinfo

--- a/MobileApp/src/lib/supabase.js
+++ b/MobileApp/src/lib/supabase.js
@@ -1,9 +1,24 @@
 import 'react-native-url-polyfill/auto';
 import { createClient } from '@supabase/supabase-js';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import Constants from 'expo-constants';
 
-const supabaseUrl = 'https://aejuenhqciagpntcqoir.supabase.co';
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzIzODQwNzgsImV4cCI6MjA4Nzk2MDA3OH0.-OxgEW5t4alPGlzV_JZDRZcLsQbbMap6jiWjfAVkMMY';
+// Load Supabase credentials from environment variables via Expo Constants
+// or fall back to a build-time config. Never hardcode production keys in source.
+const supabaseUrl = Constants.expoConfig?.extra?.supabaseUrl
+  || process.env.EXPO_PUBLIC_SUPABASE_URL
+  || '';
+
+const supabaseKey = Constants.expoConfig?.extra?.supabaseAnonKey
+  || process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY
+  || '';
+
+if (!supabaseUrl || !supabaseKey) {
+  console.warn(
+    '[Supabase] Missing credentials. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY '
+    + 'in your .env file or app.json extra config.'
+  );
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey, {
   auth: {

--- a/MobileApp/src/lib/supabase.js
+++ b/MobileApp/src/lib/supabase.js
@@ -14,7 +14,7 @@ const supabaseKey = Constants.expoConfig?.extra?.supabaseAnonKey
   || '';
 
 if (!supabaseUrl || !supabaseKey) {
-  console.warn(
+  throw new Error(
     '[Supabase] Missing credentials. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY '
     + 'in your .env file or app.json extra config.'
   );


### PR DESCRIPTION
## Description

Moves the hardcoded Supabase URL and anonymous key from the MobileApp source code to environment variables loaded via \expo-constants\.

## Why This Fix Is Critical

**Severity:** High — Credential leakage in mobile app bundle

### The Problem
The Supabase URL and anon key were hardcoded as string literals in \MobileApp/src/lib/supabase.js:5-6\. Anyone who inspects the mobile app bundle (APK/IPA) could extract these credentials and query the Supabase project directly, enumerating tables and invoking RPC functions.

### The Fix
1. Added \.env\ to \MobileApp/.gitignore\
2. Created \MobileApp/.env.example\ with placeholder values as documentation
3. Updated \supabase.js\ to load credentials from \expo-constants\ extra config or \EXPO_PUBLIC_*\ environment variables
4. Added a warning log when credentials are missing for easier debugging

Closes #2111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment variable configuration support for Supabase integration, allowing credentials to be set via configuration files instead of hardcoded values.
  * Updated project configuration to protect sensitive environment files from being committed to version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->