### PR TITLE
fix: replace synchronous file I/O with async run_in_executor

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ import traceback
 import warnings
 import logging
 import hashlib
+import functools
 from contextlib import asynccontextmanager
 
 # Suppress harmless PyTorch CPU pin_memory warning
@@ -512,17 +513,22 @@ async def log_correction(raw_request: Request):
         "timestamp": datetime.datetime.utcnow().isoformat() + "Z"
     }
 
-    try:
+    loop = asyncio.get_event_loop()
+
+    def _read_or_init_logs():
         if CORRECTIONS_LOG_PATH.exists() and CORRECTIONS_LOG_PATH.stat().st_size > 2:
             with open(CORRECTIONS_LOG_PATH, "r", encoding="utf-8") as f:
-                logs = json.load(f)
-        else:
-            logs = []
+                return json.load(f)
+        return []
 
-        logs.append(entry)
-
+    def _write_logs(logs):
         with open(CORRECTIONS_LOG_PATH, "w", encoding="utf-8") as f:
             json.dump(logs, f, indent=2)
+
+    try:
+        logs = await loop.run_in_executor(None, _read_or_init_logs)
+        logs.append(entry)
+        await loop.run_in_executor(None, functools.partial(_write_logs, logs))
 
         print(f"[CORRECTION SAVED] Ticket ID: {ticket_id} | Changed: {changed_fields}")
         return {"status": "saved", "changed_fields": changed_fields}


### PR DESCRIPTION
## Description

Replaces blocking synchronous \json.load()\/\json.dump()\ calls in the \/ai/log_correction\ endpoint with non-blocking async I/O via \loop.run_in_executor()\.

## Why This Fix Is Critical

**Severity:** Medium-High — Event loop starvation under concurrent load

### The Problem
The \/ai/log_correction\ endpoint performed synchronous file read/write operations inside an async FastAPI route. Every correction request blocked the entire asyncio event loop while Python read and wrote the full corrections log file. Under 5+ concurrent corrections, all endpoints would experience latency spikes.

### The Fix
1. Extracted file read and write operations into synchronous helper functions
2. Wrapped both calls in \loop.run_in_executor(None, ...)\ to offload blocking I/O to a thread pool
3. Added \unctools\ import for \partial()\ usage with \un_in_executor\

Closes #2112