### PR TITLE
fix: create shared CORS utility for all Supabase Edge Functions

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared CORS utility for all HELPDESK.AI Supabase Edge Functions.
+ *
+ * Usage:
+ *   import { corsHeaders, handleCors } from "../_shared/cors.ts";
+ *
+ *   Deno.serve(async (req) => {
+ *     const cors = handleCors(req);
+ *     if (cors) return cors;
+ *     // ... your handler
+ *   });
+ *
+ * In production, the allowed origin is read from the ALLOWED_ORIGIN
+ * environment variable. Defaults to the production frontend URL.
+ */
+
+const DEFAULT_ALLOWED_ORIGIN = "https://helpdeskaiv1.vercel.app";
+
+function getAllowedOrigin(): string {
+  return Deno.env.get("ALLOWED_ORIGIN") || DEFAULT_ALLOWED_ORIGIN;
+}
+
+export function corsHeaders(): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": getAllowedOrigin(),
+    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+    "Access-Control-Allow-Headers":
+      "authorization, x-client-info, apikey, content-type",
+  };
+}
+
+/**
+ * Handle a CORS preflight OPTIONS request.
+ * Returns a Response with CORS headers if it is an OPTIONS request,
+ * or null if the request should continue to the handler.
+ */
+export function handleCors(req: Request): Response | null {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders() });
+  }
+  return null;
+}

--- a/supabase/functions/ai-proxy/index.ts
+++ b/supabase/functions/ai-proxy/index.ts
@@ -14,11 +14,7 @@
  * Keys are NEVER exposed in the browser JavaScript bundle.
  */
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "https://helpdeskaiv1.vercel.app",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, apikey, x-client-info",
-};
+import { corsHeaders, handleCors } from "../_shared/cors.ts";
 
 // Key pools — pulled from Supabase Secrets (env vars, never shipped to browser)
 const GEMINI_KEYS = [
@@ -60,12 +56,14 @@ async function tryWithFailover(keys, buildRequest) {
   throw lastError ?? new Error("All keys exhausted");
 }
 
+// CORS headers helper — reuses the shared corsHeaders() function
+const CH = () => corsHeaders();
+
 // Deno.serve is built into the Deno runtime — no import required
 Deno.serve(async (req) => {
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
-  }
+  // Handle CORS preflight via shared utility
+  const corsResp = handleCors(req);
+  if (corsResp) return corsResp;
 
   try {
     const body = await req.json();
@@ -121,20 +119,20 @@ Deno.serve(async (req) => {
     else {
       return new Response(
         JSON.stringify({ error: `Unknown provider: "${provider}". Use gemini | openrouter | groq` }),
-        { status: 400, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } }
+        { status: 400, headers: { ...CH(), "Content-Type": "application/json" } }
       );
     }
 
     const data = await upstreamResponse.json();
     return new Response(JSON.stringify(data), {
       status: upstreamResponse.status,
-      headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+      headers: { ...CH(), "Content-Type": "application/json" },
     });
 
   } catch (err) {
     return new Response(
       JSON.stringify({ error: err instanceof Error ? err.message : "Proxy error" }),
-      { status: 500, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } }
+      { status: 500, headers: { ...CH(), "Content-Type": "application/json" } }
     );
   }
 });

--- a/supabase/functions/email-notifier/index.ts
+++ b/supabase/functions/email-notifier/index.ts
@@ -1,5 +1,6 @@
-import { serve } from "https://deno.land/std@0.177.0/http/server.ts"
+import "https://deno.land/std@0.177.0/http/server.ts"
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.42.0"
+import { corsHeaders, handleCors } from "../_shared/cors.ts"
 
 // Standard Supabase Secrets
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
@@ -9,7 +10,11 @@ const SUPABASE_SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") || "";
 const FROM_EMAIL = "HELPDESK.AI <bonthalamadhavi1@gmail.com>";
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
+  // Handle CORS via shared utility
+  const corsResp = handleCors(req);
+  if (corsResp) return corsResp;
+
   try {
     if (!RESEND_API_KEY) throw new Error("Missing RESEND_API_KEY");
 
@@ -138,9 +143,15 @@ serve(async (req: Request) => {
     });
 
     const data = await resendRes.json();
-    return new Response(JSON.stringify(data), { status: resendRes.status });
+    return new Response(JSON.stringify(data), {
+      status: resendRes.status,
+      headers: { ...corsHeaders(), "Content-Type": "application/json" },
+    });
 
   } catch (err: any) {
-    return new Response(JSON.stringify({ error: err.message }), { status: 500 });
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { ...corsHeaders(), "Content-Type": "application/json" },
+    });
   }
 });

--- a/supabase/functions/send-user-approval-email/index.ts
+++ b/supabase/functions/send-user-approval-email/index.ts
@@ -1,16 +1,10 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import 'https://deno.land/std@0.168.0/http/server.ts';
+import { corsHeaders as sharedCorsHeaders, handleCors } from "../_shared/cors.ts";
 
-const corsHeaders = {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
-
-serve(async (req) => {
-    // Handle CORS preflight requests
-    if (req.method === 'OPTIONS') {
-        return new Response(null, { status: 204, headers: corsHeaders });
-    }
+Deno.serve(async (req) => {
+    // Handle CORS via shared utility
+    const corsResp = handleCors(req);
+    if (corsResp) return corsResp;
 
     try {
         const { userId, email, name, company } = await req.json();
@@ -54,7 +48,7 @@ serve(async (req) => {
             }),
             {
                 status: 200,
-                headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+                headers: { ...sharedCorsHeaders(), 'Content-Type': 'application/json' }
             }
         );
     } catch (error) {
@@ -62,7 +56,7 @@ serve(async (req) => {
             JSON.stringify({ error: error.message }),
             {
                 status: 400,
-                headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+                headers: { ...sharedCorsHeaders(), 'Content-Type': 'application/json' }
             }
         );
     }


### PR DESCRIPTION
## Description

Creates a shared CORS utility module and migrates all three Supabase Edge Functions to use it, replacing both the overly-restrictive hardcoded origin and the overly-permissive wildcard policies.

## Why This Fix Is Critical

**Severity:** Medium — Inconsistent CORS exposes email functions while blocking AI proxy in dev

### The Problem
The AI proxy had a hardcoded single-origin policy blocking all non-production clients, while the email functions used wildcard \'*'\ — a completely inconsistent CORS posture across the function suite.

### The Fix
1. Created \supabase/functions/_shared/cors.ts\ — a shared CORS utility with:
   - \corsHeaders()\ — returns standard CORS headers
   - \handleCors(req)\ — handles OPTIONS preflight requests
   - Configurable origin via \ALLOWED_ORIGIN\ environment variable
   - Sensible default: \https://helpdeskaiv1.vercel.app\
2. Updated all three functions (\i-proxy\, \email-notifier\, \send-user-approval-email\) to use the shared module
3. Added CORS headers to error responses in \email-notifier\ that were missing them entirely

Closes #2116