### PR TITLE
fix: enforce JWT-based identity for ticket creation

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -62,6 +62,95 @@ from backend.services.rag_service import RagService
 
 
 # ---------------------------------------------------------------------------
+# Auth helpers — must be defined before any route using Depends(get_current_user)
+# ---------------------------------------------------------------------------
+ACCESS_COOKIE = "access_token"
+REFRESH_COOKIE = "refresh_token"
+ACCESS_MAX_AGE = 60 * 60
+REFRESH_MAX_AGE = 60 * 60 * 24 * 7
+
+def _cookie_kwargs() -> dict:
+    secure = os.getenv("ENV", "production").lower() != "development"
+    return {
+        "httponly": True,
+        "secure": secure,
+        "samesite": "strict",
+        "path": "/",
+    }
+
+def extract_token(request: Request) -> str | None:
+    cookie_token = request.cookies.get(ACCESS_COOKIE)
+    if cookie_token:
+        return cookie_token
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth.split(" ", 1)[1].strip() or None
+    return None
+
+def _set_session_cookies(response: Response, session) -> None:
+    if not session or not getattr(session, "access_token", None):
+        return
+    response.set_cookie(
+        ACCESS_COOKIE,
+        session.access_token,
+        max_age=ACCESS_MAX_AGE,
+        **_cookie_kwargs(),
+    )
+    refresh = getattr(session, "refresh_token", None)
+    if refresh:
+        response.set_cookie(
+            REFRESH_COOKIE,
+            refresh,
+            max_age=REFRESH_MAX_AGE,
+            **_cookie_kwargs(),
+        )
+
+def _clear_session_cookies(response: Response) -> None:
+    kwargs = _cookie_kwargs()
+    response.delete_cookie(ACCESS_COOKIE, path=kwargs["path"])
+    response.delete_cookie(REFRESH_COOKIE, path=kwargs["path"])
+
+def _resolve_caller_company(current_user: dict) -> dict:
+    """Fetch the profile (company_id, company) for the authenticated user.
+    Raises HTTPException on failure — never returns an ambiguous empty dict."""
+    user_id = current_user.get("id") or current_user.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="User identity not found in session")
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database connection not initialized")
+    try:
+        res = supabase.table("profiles").select("company_id, company").eq("id", user_id).single().execute()
+        if not res.data:
+            raise HTTPException(status_code=404, detail="User profile not found")
+        return res.data
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Failed to resolve tenant: {exc}") from exc
+
+async def get_current_user(request: Request) -> dict:
+    token = extract_token(request)
+    if not token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database connection offline")
+    try:
+        result = supabase.auth.get_user(token)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Invalid session: {exc}",
+        ) from exc
+    user = getattr(result, "user", None) or (result.get("user") if isinstance(result, dict) else None)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid session")
+    if hasattr(user, "model_dump"):
+        return user.model_dump()
+    if hasattr(user, "dict"):
+        return user.dict()
+    return dict(user)
+
+# ---------------------------------------------------------------------------
 # Request / Response models
 # ---------------------------------------------------------------------------
 def get_system_settings(company_id: str) -> dict:
@@ -541,19 +630,19 @@ async def get_tickets(current_user: dict = Depends(get_current_user), company_id
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
 
-    # Resolve the caller's company_id from their profile
+    # Resolve company_id — fail closed if tenant not resolvable
     caller_profile = _resolve_caller_company(current_user)
     caller_company_id = caller_profile.get("company_id")
+    if not caller_company_id:
+        raise HTTPException(status_code=403, detail="Authenticated user has no tenant assignment")
 
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
 
-    # If user provides a company_id filter, ensure it matches their own company
     if company_id:
-        if caller_company_id and company_id != caller_company_id:
+        if company_id != caller_company_id:
             raise HTTPException(status_code=403, detail="Not authorized to view tickets from this tenant")
         query = query.eq("company_id", company_id)
-    elif caller_company_id:
-        # Restrict to caller's own company if they have a tenant assignment
+    else:
         query = query.eq("company_id", caller_company_id)
 
     res = query.execute()
@@ -670,13 +759,13 @@ async def get_ticket_by_id(ticket_id: str, current_user: dict = Depends(get_curr
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
     
-    # Resolve the caller's company_id
+    # Resolve company_id — fail closed if tenant not resolvable
     caller_profile = _resolve_caller_company(current_user)
     caller_company_id = caller_profile.get("company_id")
+    if not caller_company_id:
+        raise HTTPException(status_code=403, detail="Authenticated user has no tenant assignment")
     
-    query = supabase.table("tickets").select("*").eq("id", ticket_id)
-    if caller_company_id:
-        query = query.eq("company_id", caller_company_id)
+    query = supabase.table("tickets").select("*").eq("id", ticket_id).eq("company_id", caller_company_id)
     
     res = query.execute()
     if not res.data:
@@ -1090,87 +1179,8 @@ async def analyze_ticket_v2(request: TicketRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 # ---------------------------------------------------------------------------
-# Clean cookie-based Supabase Auth endpoints for /auth/me backward-compatibility
+# Auth endpoints (Depends(get_current_user) is safe here — helper is defined above)
 # ---------------------------------------------------------------------------
-ACCESS_COOKIE = "access_token"
-REFRESH_COOKIE = "refresh_token"
-ACCESS_MAX_AGE = 60 * 60
-REFRESH_MAX_AGE = 60 * 60 * 24 * 7
-
-def _cookie_kwargs() -> dict:
-    secure = os.getenv("ENV", "production").lower() != "development"
-    return {
-        "httponly": True,
-        "secure": secure,
-        "samesite": "strict",
-        "path": "/",
-    }
-
-def extract_token(request: Request) -> str | None:
-    cookie_token = request.cookies.get(ACCESS_COOKIE)
-    if cookie_token:
-        return cookie_token
-    auth = request.headers.get("authorization") or request.headers.get("Authorization")
-    if auth and auth.lower().startswith("bearer "):
-        return auth.split(" ", 1)[1].strip() or None
-    return None
-
-def _set_session_cookies(response: Response, session) -> None:
-    if not session or not getattr(session, "access_token", None):
-        return
-    response.set_cookie(
-        ACCESS_COOKIE,
-        session.access_token,
-        max_age=ACCESS_MAX_AGE,
-        **_cookie_kwargs(),
-    )
-    refresh = getattr(session, "refresh_token", None)
-    if refresh:
-        response.set_cookie(
-            REFRESH_COOKIE,
-            refresh,
-            max_age=REFRESH_MAX_AGE,
-            **_cookie_kwargs(),
-        )
-
-def _clear_session_cookies(response: Response) -> None:
-    kwargs = _cookie_kwargs()
-    response.delete_cookie(ACCESS_COOKIE, path=kwargs["path"])
-    response.delete_cookie(REFRESH_COOKIE, path=kwargs["path"])
-
-def _resolve_caller_company(current_user: dict) -> dict:
-    """Fetch the profile (company_id, company) for the authenticated user."""
-    user_id = current_user.get("id") or current_user.get("sub")
-    if not user_id or not supabase:
-        return {}
-    try:
-        res = supabase.table("profiles").select("company_id, company").eq("id", user_id).single().execute()
-        return res.data or {}
-    except Exception:
-        return {}
-
-async def get_current_user(request: Request) -> dict:
-    token = extract_token(request)
-    if not token:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    if not supabase:
-        raise HTTPException(status_code=503, detail="Database connection offline")
-    try:
-        result = supabase.auth.get_user(token)
-    except Exception as exc:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Invalid session: {exc}",
-        ) from exc
-    user = getattr(result, "user", None) or (result.get("user") if isinstance(result, dict) else None)
-    if not user:
-        raise HTTPException(status_code=401, detail="Invalid session")
-    if hasattr(user, "model_dump"):
-        return user.model_dump()
-    if hasattr(user, "dict"):
-        return user.dict()
-    return dict(user)
-
 class LoginBody(BaseModel):
     email: str
     password: str

--- a/backend/main.py
+++ b/backend/main.py
@@ -536,74 +536,87 @@ async def log_correction(raw_request: Request):
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
-    """Fetch persistent tickets from Supabase."""
+async def get_tickets(current_user: dict = Depends(get_current_user), company_id: str | None = None):
+    """Fetch persistent tickets from Supabase. Scoped to the authenticated user's company."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    # Resolve the caller's company_id from their profile
+    caller_profile = _resolve_caller_company(current_user)
+    caller_company_id = caller_profile.get("company_id")
+
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
+
+    # If user provides a company_id filter, ensure it matches their own company
     if company_id:
+        if caller_company_id and company_id != caller_company_id:
+            raise HTTPException(status_code=403, detail="Not authorized to view tickets from this tenant")
         query = query.eq("company_id", company_id)
-        
+    elif caller_company_id:
+        # Restrict to caller's own company if they have a tenant assignment
+        query = query.eq("company_id", caller_company_id)
+
     res = query.execute()
     return res.data
 
 @app.post("/tickets/save")
-async def save_ticket(request_body: TicketSaveRequest):
+async def save_ticket(request_body: TicketSaveRequest, current_user: dict = Depends(get_current_user)):
     """
     OFFICIAL PERSISTENCE: Saves the analyzed ticket to Supabase.
-    This is called AFTER the user confirms the analysis results.
+    The authenticated user's identity is used — user_id from the body is ignored for authorization.
     """
     if not supabase:
         raise HTTPException(status_code=500, detail="Supabase connection not initialized.")
 
     logger = logging.getLogger(__name__)
     try:
-        final_data = request_body.dict()
+        # Use the authenticated user's ID, not the one from the request body
+        authenticated_user_id = current_user.get("id") or current_user.get("sub")
+        if not authenticated_user_id:
+            raise HTTPException(status_code=401, detail="Authenticated user ID not resolvable")
 
-        # Resolve tenant linkage from user profile with authorization validation.
+        final_data = request_body.dict()
+        # Override user_id with authenticated user
+        final_data["user_id"] = authenticated_user_id
+
+        # Resolve tenant linkage from the authenticated user's profile
         profile = {}
-        if request_body.user_id:
-            try:
-                profile_res = (
-                    supabase.table("profiles")
-                    .select("company_id, company")
-                    .eq("id", request_body.user_id)
-                    .single()
-                    .execute()
-                )
-                profile = profile_res.data or {}
-                if not profile:
-                    raise HTTPException(status_code=404, detail="User profile not found")
-            except HTTPException:
-                raise
-            except Exception as profile_error:
-                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
-                logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
-                raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
+        try:
+            profile_res = (
+                supabase.table("profiles")
+                .select("company_id, company")
+                .eq("id", authenticated_user_id)
+                .single()
+                .execute()
+            )
+            profile = profile_res.data or {}
+            if not profile:
+                raise HTTPException(status_code=404, detail="User profile not found")
+        except HTTPException:
+            raise
+        except Exception as profile_error:
+            user_hash = hashlib.sha256(str(authenticated_user_id).encode()).hexdigest()[:8]
+            logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
+            raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
 
         # Validate tenant consistency and authorization.
         profile_company_id = profile.get("company_id")
         if final_data.get("company_id"):
-            # User provided company_id: verify it matches their profile.
             if profile_company_id and final_data["company_id"] != profile_company_id:
-                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+                user_hash = hashlib.sha256(str(authenticated_user_id).encode()).hexdigest()[:8]
                 logger.warning(f"Tenant mismatch: user {user_hash} attempted {final_data['company_id']}, assigned to {profile_company_id}")
                 raise HTTPException(status_code=403, detail="User not authorized for this tenant")
         elif profile_company_id:
-            # Backfill company_id from profile.
             final_data["company_id"] = profile_company_id
-        elif request_body.user_id:
-            # User has no tenant assignment.
+        else:
             raise HTTPException(status_code=400, detail="User has no tenant assignment")
 
         # Backfill company name if missing.
         if not final_data.get("company") and profile.get("company"):
             final_data["company"] = profile["company"]
 
-        user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+        user_hash = hashlib.sha256(str(authenticated_user_id).encode()).hexdigest()[:8]
         logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
-
 
         res = supabase.table("tickets").insert(final_data).execute()
         
@@ -636,7 +649,7 @@ async def save_ticket(request_body: TicketSaveRequest):
 
         supabase.table("ticket_messages").insert({
             "ticket_id": ticket_id,
-            "sender_id": "00000000-0000-0000-0000-000000000000", # System ID
+            "sender_id": "00000000-0000-0000-0000-000000000000",
             "sender_name": "AI Assistant",
             "sender_role": "admin",
             "message": msg
@@ -652,12 +665,20 @@ async def save_ticket(request_body: TicketSaveRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/tickets/{ticket_id}")
-async def get_ticket_by_id(ticket_id: str):
-    """Fetch single persistent ticket."""
+async def get_ticket_by_id(ticket_id: str, current_user: dict = Depends(get_current_user)):
+    """Fetch single persistent ticket. Scoped to the authenticated user's tenant."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
     
-    res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
+    # Resolve the caller's company_id
+    caller_profile = _resolve_caller_company(current_user)
+    caller_company_id = caller_profile.get("company_id")
+    
+    query = supabase.table("tickets").select("*").eq("id", ticket_id)
+    if caller_company_id:
+        query = query.eq("company_id", caller_company_id)
+    
+    res = query.execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return res.data
@@ -1116,6 +1137,17 @@ def _clear_session_cookies(response: Response) -> None:
     kwargs = _cookie_kwargs()
     response.delete_cookie(ACCESS_COOKIE, path=kwargs["path"])
     response.delete_cookie(REFRESH_COOKIE, path=kwargs["path"])
+
+def _resolve_caller_company(current_user: dict) -> dict:
+    """Fetch the profile (company_id, company) for the authenticated user."""
+    user_id = current_user.get("id") or current_user.get("sub")
+    if not user_id or not supabase:
+        return {}
+    try:
+        res = supabase.table("profiles").select("company_id, company").eq("id", user_id).single().execute()
+        return res.data or {}
+    except Exception:
+        return {}
 
 async def get_current_user(request: Request) -> dict:
     token = extract_token(request)

--- a/backend/main.py
+++ b/backend/main.py
@@ -181,7 +181,7 @@ class TicketRequest(BaseModel):
     duplicate_sensitivity: float = 0.85
 
 class TicketSaveRequest(BaseModel):
-    user_id: str
+    # user_id is NOT accepted from the caller — derived from JWT token
     subject: str
     description: str
     category: str


### PR DESCRIPTION
﻿## Description

Removes the user_id field from TicketSaveRequest and derives identity exclusively from the JWT token via Depends(get_current_user). This prevents callers from impersonating other users by supplying an arbitrary user_id in the request body.

## Why This Fix Is Critical

**Severity:** High — Identity spoofing vulnerability

### The Problem
The POST /tickets/save endpoint accepted user_id as a request body field without verifying that it matched the authenticated caller. A malicious user could craft a request with a different user UUID to create tickets on behalf of another user.

### The Fix
1. Removed user_id from TicketSaveRequest model — the schema no longer accepts it
2. Enforces authentication via Depends(get_current_user)
3. Extracts user_id from JWT token and overrides any caller-supplied value
4. Fixed NameError by ensuring auth helpers are defined before route decorators
5. Tenant resolution now fails closed (raises HTTPException) instead of silently proceeding

Closes #2118
