### PR TITLE
fix: replace hardcoded USE_MOCK with env-var and health-probe detection

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -2,10 +2,40 @@ import axios from 'axios';
 import { MOCK_TICKETS } from './mockData';
 import { API_CONFIG } from '../config';
 
-const USE_MOCK = true;
 const API_BASE_URL = API_CONFIG.BACKEND_URL;
 
-const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+// Mock mode: env var overrides, else auto-detect via health probe
+let USE_MOCK = null;
+
+const checkBackendHealth = async () => {
+  try {
+    const resp = await axios.get(`${API_BASE_URL}/health`, { timeout: 3000 });
+    return resp.status === 200;
+  } catch {
+    return false;
+  }
+};
+
+const shouldUseMock = async () => {
+  const envOverride = import.meta.env.VITE_USE_MOCK;
+  if (envOverride !== undefined && envOverride !== '') {
+    return envOverride === 'true' || envOverride === '1';
+  }
+  const healthy = await checkBackendHealth();
+  return !healthy;
+};
+
+const resolveMockMode = async () => {
+  if (USE_MOCK === null) {
+    USE_MOCK = await shouldUseMock();
+    if (USE_MOCK) {
+      console.info('[API] Backend unreachable — using mock data');
+    } else {
+      console.info('[API] Backend reachable — using live API');
+    }
+  }
+  return USE_MOCK;
+};
 
 // Safe helper to get data from storage or default
 const getStorage = (key, defaultData) => {
@@ -28,25 +58,27 @@ const setStorage = (key, data) => {
     localStorage.setItem(key, JSON.stringify(data));
   } catch (error) {
     console.warn(`[Storage Error] Failed to write '${key}'. Possible quota exceeded:`, error);
-    // If quota exceeded, we could trim the data, but for now we fail gracefully.
   }
 };
 
 export const api = {
   // Login and Signup have been fully migrated to Supabase via authStore.js
-  // Ensure that no component tries to use api.login or api.signup anymore.
-
 
   getTickets: async () => {
-    if (USE_MOCK) {
-      await delay(500);
+    if (await resolveMockMode()) {
+      return getStorage('tickets', MOCK_TICKETS);
+    }
+    try {
+      const resp = await axios.get(`${API_BASE_URL}/tickets`);
+      return resp.data;
+    } catch (error) {
+      console.error('[API] Failed to fetch tickets, falling back to mock:', error);
       return getStorage('tickets', MOCK_TICKETS);
     }
   },
 
   createTicket: async (ticketData) => {
-    if (USE_MOCK) {
-      await delay(800);
+    if (await resolveMockMode()) {
       const tickets = getStorage('tickets', MOCK_TICKETS);
       const newTicket = {
         ticket_id: "TCKT-" + Math.floor(Math.random() * 10000),
@@ -61,15 +93,21 @@ export const api = {
           }
         ]
       };
-      tickets.unshift(newTicket); // Add to beginning
+      tickets.unshift(newTicket);
       setStorage('tickets', tickets);
       return { data: newTicket };
+    }
+    try {
+      const resp = await axios.post(`${API_BASE_URL}/tickets`, ticketData);
+      return resp.data;
+    } catch (error) {
+      console.error('[API] Failed to create ticket, falling back to mock:', error);
+      return { data: { ...ticketData, ticket_id: "TCKT-" + Math.floor(Math.random() * 10000) } };
     }
   },
 
   predictTicket: async (issueText, imageBase64 = "") => {
     try {
-      // ALWAYS call the real backend for prediction if possible
       const response = await axios.post(`${API_BASE_URL}/ai/analyze_ticket`, {
         text: issueText,
         image_base64: imageBase64,
@@ -78,7 +116,6 @@ export const api = {
 
       const result = response.data;
 
-      // Map backend response to frontend format
       return {
         data: {
           ticket_id: "TCKT-" + Math.floor(Math.random() * 10000),
@@ -100,8 +137,6 @@ export const api = {
       };
     } catch (error) {
       console.error("AI Backend Error, falling back to mock:", error);
-      // Fallback to mock logic if backend fails
-      await delay(1000);
       return {
         data: {
           ticket_id: "TCKT-MOCK-" + Math.floor(Math.random() * 10000),
@@ -122,7 +157,6 @@ export const api = {
     try {
       await axios.post(`${API_BASE_URL}/ai/log_correction`, correctionPayload);
     } catch (error) {
-      // Non-fatal: log but don't break the UI flow
       console.warn("[Correction Log] Failed to save correction:", error);
     }
   }


### PR DESCRIPTION
﻿## Description

Replaces the hardcoded const USE_MOCK = true; with a runtime mock toggle system that prioritizes an environment variable (VITE_USE_MOCK) and falls back to automatic backend health probing.

## Why This Fix Is Critical

**Severity:** Medium — Hardcoded mock mode prevents production use

### The Problem
The USE_MOCK flag was hardcoded to 	rue, meaning the frontend never actually made real backend API calls for tickets. Additionally, artificial delay(500) and delay(800) calls in mock mode made the UI feel slow even locally. When USE_MOCK was alse (manually changed), getTickets() and createTicket() returned undefined — they had no real backend fallback.

### The Fix
1. Replaced const USE_MOCK = true; with runtime detection via VITE_USE_MOCK env var
2. When VITE_USE_MOCK is unset, probes GET /health with a 3s timeout to auto-detect backend availability
3. Removed artificial delay() calls — mock data returns instantly
4. getTickets and createTicket now make real backend calls when not in mock mode, with graceful fallback to mock data on failure

Closes #2119
