### PR TITLE
fix: remove unused TicketProcessing import in App.jsx

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -40,7 +40,6 @@ import MyTickets from "./user/pages/MyTickets";
 import TicketResult from "./user/pages/TicketResult";
 import Profile from "./user/pages/Profile";
 import TicketDetail from "./user/pages/TicketDetail";
-import TicketProcessing from "./user/pages/AIProcessing"; // Renamed generic import just in case, but keeping AIProcessing
 import AIProcessing from "./user/pages/AIProcessing";
 import AIUnderstanding from "./user/pages/AIUnderstanding";
 import Notifications from "./user/pages/Notifications";


### PR DESCRIPTION
## Summary
Removes the unused duplicate import `TicketProcessing` from `App.jsx`.

## Problem
Line 43 and 44 both imported from `./user/pages/AIProcessing`:
- Line 43: `import TicketProcessing from "./user/pages/AIProcessing"` ❌ unused
- Line 44: `import AIProcessing from "./user/pages/AIProcessing"` ✅ used on line 189

`TicketProcessing` was never referenced anywhere in the file, causing dead code and linter warnings.

## Fix
Deleted line 43 — the unused `TicketProcessing` import.

Closes #2130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component imports to reflect reorganized module structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->