### PR TITLE
fix: replace alert() with inline error banner in ContactSales.jsx

### DIFF
--- a/Frontend/src/pages/ContactSales.jsx
+++ b/Frontend/src/pages/ContactSales.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
  
 import { motion } from 'framer-motion';
-import { Building2, Mail, User, Phone, MessageSquare, ArrowRight, CheckCircle2, ShieldCheck, Zap, Server } from 'lucide-react';
+import { Building2, Mail, User, Phone, MessageSquare, ArrowRight, CheckCircle2, ShieldCheck, Zap, Server, AlertCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabaseClient';
 
@@ -9,6 +9,7 @@ export default function ContactSales() {
     const navigate = useNavigate();
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isSuccess, setIsSuccess] = useState(false);
+    const [error, setError] = useState("");
     const [formData, setFormData] = useState({
         name: '',
         email: '',
@@ -45,7 +46,7 @@ export default function ContactSales() {
             setIsSuccess(true);
         } catch (error) {
             console.error('Error submitting form:', error);
-            alert("There was an issue submitting your request. Please try again.");
+            setError("There was an issue submitting your request. Please try again.");
         } finally {
             setIsSubmitting(false);
         }
@@ -248,6 +249,13 @@ export default function ContactSales() {
                                     onChange={handleChange}
                                 ></textarea>
                             </div>
+
+                            {error && (
+                                <div className="flex items-center gap-2 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700">
+                                    <AlertCircle className="w-4 h-4 shrink-0" />
+                                    <span className="text-sm font-medium">{error}</span>
+                                </div>
+                            )}
 
                             <button 
                                 type="submit" 


### PR DESCRIPTION
## Summary
Replaces the native browser `alert()` with an inline red error banner in `ContactSales.jsx`, consistent with the rest of the app.

## Changes
- Added `AlertCircle` to lucide-react imports
- Added `error` state via `useState("")`
- Replaced `alert()` on line 48 with `setError()`
- Added inline error banner JSX above the submit button

## Before
Native browser popup blocked the UI on form submission error.

## After
Inline red banner with `AlertCircle` icon appears inside the form, matching the pattern used in `Login.jsx`, `Signup.jsx`, and `ForgotPassword.jsx`.

Closes #2131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in the contact form—submission errors now display as inline alerts instead of browser popups for better visibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->