### PR TITLE
fix: align password minimum length validation to 8 chars in ForgotPassword.jsx

### DIFF
--- a/Frontend/src/pages/ForgotPassword.jsx
+++ b/Frontend/src/pages/ForgotPassword.jsx
@@ -101,8 +101,8 @@ function ForgotPassword() {
 
     const handleUpdatePassword = async (e) => {
         e.preventDefault();
-        if (!newPassword || newPassword.length < 6) {
-            setError("Password must be at least 6 characters long.");
+        if (!newPassword || newPassword.length < 8) {
+            setError("Password must be at least 8 characters long.");
             return;
         }
 
@@ -301,7 +301,7 @@ function ForgotPassword() {
 
                                         <button
                                             type="submit"
-                                            disabled={loading || newPassword.length < 6}
+                                            disabled={loading || newPassword.length < 8}
                                             className="w-full rounded-2xl py-4 font-bold transition-all flex items-center justify-center gap-2"
                                             style={{ background: 'linear-gradient(135deg, #16a34a, #22c55e)', color: '#fff', boxShadow: '0 10px 30px rgba(34,160,69,0.2)' }}
                                             onMouseEnter={(e) => e.currentTarget.style.transform = 'translateY(-2px)'}


### PR DESCRIPTION
## Summary
Fixes inconsistent password minimum length validation between `ForgotPassword.jsx` (was 6) and `ResetPassword.jsx` / `Signup.jsx` (both require 8).

## Changes
- Line 104: `newPassword.length < 6` → `newPassword.length < 8`
- Line 105: error message updated to "at least 8 characters"
- Line 304: button `disabled` condition updated from `< 6` to `< 8`

## Before
A user could set a weak 6-character password via the forgot-password flow, which would be rejected by the reset-password flow.

## After
All password creation/reset flows consistently enforce a minimum of 8 characters.

Closes #2132