### PR TITLE
fix: remove unused ShieldCheck import in ForgotPassword.jsx

### DIFF
--- a/Frontend/src/pages/ForgotPassword.jsx
+++ b/Frontend/src/pages/ForgotPassword.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { supabase } from "../lib/supabaseClient";
-import { BrainCircuit, Mail, ArrowLeft, Loader2, CheckCircle2, ShieldCheck, Lock, KeyRound, AlertCircle } from "lucide-react";
+import { BrainCircuit, Mail, ArrowLeft, Loader2, CheckCircle2, Lock, KeyRound, AlertCircle } from "lucide-react";
  
 import { motion, AnimatePresence } from "framer-motion";
 


### PR DESCRIPTION
## Summary
Removes the unused `ShieldCheck` icon import from `ForgotPassword.jsx`.

## Changes
- Removed `ShieldCheck` from the lucide-react import on line 4
- `ShieldCheck` was imported but never referenced anywhere in the component's JSX or logic

## Impact
- Reduces bundle size slightly
- Eliminates linter warning for unused import

Closes #2133