### PR TITLE
fix: add Privacy Policy and Terms of Service links in ContactSales.jsx

### DIFF
--- a/Frontend/src/pages/ContactSales.jsx
+++ b/Frontend/src/pages/ContactSales.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
  
 import { motion } from 'framer-motion';
 import { Building2, Mail, User, Phone, MessageSquare, ArrowRight, CheckCircle2, ShieldCheck, Zap, Server } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { supabase } from '../lib/supabaseClient';
 
 export default function ContactSales() {
@@ -266,7 +266,7 @@ export default function ContactSales() {
                                 )}
                             </button>
                             <p className="text-xs text-center text-gray-400 mt-4">
-                                By submitting this form, you agree to our Privacy Policy and Terms of Service.
+                                By submitting this form, you agree to our <Link to="/privacy" className="text-emerald-700 font-bold hover:underline">Privacy Policy</Link> and <Link to="/terms" className="text-emerald-700 font-bold hover:underline">Terms of Service</Link>.
                             </p>
                         </form>
                     </div>


### PR DESCRIPTION
## Summary
Converts plain text "Privacy Policy" and "Terms of Service" into clickable links in `ContactSales.jsx`.

## Changes
- Added `Link` to the `react-router-dom` import
- Wrapped "Privacy Policy" with `<Link to="/privacy">`
- Wrapped "Terms of Service" with `<Link to="/terms">`
- Styling matches the existing pattern in `AdminSignup.jsx`

## Before
Plain unclickable text — users had no way to navigate to the actual policy pages.

## After
Both terms are clickable green links navigating to `/privacy` and `/terms`.

Closes #2134