### PR TITLE
fix: add loading state for company dropdown in Signup.jsx (closes #2074)

### DIFF
--- a/Frontend/src/pages/Signup.jsx
+++ b/Frontend/src/pages/Signup.jsx
@@ -66,13 +66,14 @@ function Signup() {
   // Handle clicks outside dropdown
   useEffect(() => {
     const handleClickOutside = (event) => {
+      if (isLoadingCompanies) return; // Prevent closing dropdown on outside click during loading
       if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
         setIsDropdownOpen(false);
       }
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  }, [isLoadingCompanies]);
 
   // Filter companies
   useEffect(() => {
@@ -261,12 +262,17 @@ function Signup() {
             {/* Company Dropdown */}
             <div className="relative" ref={dropdownRef}>
               <label className="block mb-2" style={labelStyle}>Company</label>
-              <div onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              <div onClick={() => { if (isLoadingCompanies) { setIsDropdownOpen(true); } else { setIsDropdownOpen(!isDropdownOpen); } }}
                 style={{ ...inputStyle, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderColor: isDropdownOpen ? '#22c55e' : '#e5e7eb', boxShadow: isDropdownOpen ? '0 0 0 3px rgba(34,160,69,0.1)' : 'none' }}>
                 {selectedCompany ? (
                   <div className="flex items-center gap-2">
                     <div className="w-6 h-6 rounded-md flex items-center justify-center shrink-0" style={{ background: '#f0fdf4' }}><Building2 className="w-3.5 h-3.5" style={{ color: '#16a34a' }} /></div>
                     <span style={{ fontWeight: 600, color: '#111827' }}>{selectedCompany.name}</span>
+                  </div>
+                ) : isLoadingCompanies ? (
+                  <div className="flex items-center gap-2">
+                    <Loader2 className="w-4 h-4 animate-spin text-emerald-500" />
+                    <span style={{ color: '#9ca3af', fontWeight: 500 }}>Loading companies...</span>
                   </div>
                 ) : (<span style={{ color: '#9ca3af', fontWeight: 500 }}>Select your company...</span>)}
                 <ChevronDown className={`w-5 h-5 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} style={{ color: '#9ca3af' }} />


### PR DESCRIPTION
## Summary
This PR addresses **Issue #2074** by enhancing the user experience of the company dropdown selection in `Signup.jsx` during data fetching.

## Proposed Changes
1. **Dropdown Loading Label and Spinner**: Replaced the default label with a loading indicator showing a spinner (`Loader2`) and the text `"Loading companies..."` inside the select trigger while `isLoadingCompanies` is true.
2. **Trigger Toggle Prevention**: Modified the select box trigger click handler to remain open (force `isDropdownOpen` to `true`) if clicked while `isLoadingCompanies` is true.
3. **Outside Click Lock**: Prevented clicks outside the dropdown from closing the panel while companies are loading.
4. **Successful Compilation**: Verified that the frontend builds without any errors using `npm run build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced company dropdown behavior to prevent unintended closing while companies are loading, ensuring a smoother selection experience.
  * Updated the company selection field to display a loading indicator ("Loading companies...") instead of the default placeholder, providing clearer feedback during data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->