### PR TITLE
fix: remove silent fallback to mock tickets on backend failure

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -99,22 +99,8 @@ export const api = {
         }
       };
     } catch (error) {
-      console.error("AI Backend Error, falling back to mock:", error);
-      // Fallback to mock logic if backend fails
-      await delay(1000);
-      return {
-        data: {
-          ticket_id: "TCKT-MOCK-" + Math.floor(Math.random() * 10000),
-          category: "Hardware",
-          priority: "Medium",
-          assigned_team: "Hardware Support",
-          auto_resolve: false,
-          routing_confidence: 0.5,
-          duplicate_probability: 0.0,
-          summary: issueText.substring(0, 50) + "...",
-          entities: []
-        }
-      };
+      console.error("AI Backend Error:", error);
+      throw new Error("Failed to communicate with the AI inference engine. Please try again later.");
     }
   },
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,6 @@
 # Supabase Configuration
 SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_SERVICE_KEY=your-service-key
+SUPABASE_ANON_KEY=your-anon-key
 
 # Startup Mode
 # Set ALLOW_DEGRADED_STARTUP=1 to allow backend startup even if duplicate/RAG models fail to load

--- a/backend/main.py
+++ b/backend/main.py
@@ -793,7 +793,7 @@ async def analyze_only(request_body: TicketRequest):
     if request_body.image_base64 and not gemini_analysis["ocr_text"]:
         try:
             print("[AI] Detecting visual context via Gemini...")
-            vision_result = gemini_service.analyze_image(request_body.image_base64, text)
+            vision_result = await asyncio.to_thread(gemini_service.analyze_image, request_body.image_base64, text)
             gemini_analysis.update(vision_result)
         except Exception as e:
             print(f"[VISION ERROR] {e}")
@@ -802,10 +802,10 @@ async def analyze_only(request_body: TicketRequest):
 
     # --- Classification ---
     try:
-        classification_v3_res = classifier_v3.predict(text)
+        classification_v3_res = await asyncio.to_thread(classifier_v3.predict, text)
         if "error" in classification_v3_res:
             # Fallback to V1
-            classification = classifier_service.predict(text)
+            classification = await asyncio.to_thread(classifier_service.predict, text)
         else:
             # Parse V3 output
             cat = classification_v3_res.get("Category", {}).get("prediction", "Unknown")
@@ -837,7 +837,7 @@ async def analyze_only(request_body: TicketRequest):
 
     # --- NER ---
     try:
-        entities = ner_service.extract_entities(text)
+        entities = await asyncio.to_thread(ner_service.extract_entities, text)
     except Exception:
         entities = []
     
@@ -845,14 +845,14 @@ async def analyze_only(request_body: TicketRequest):
 
     # --- Duplicate detection ---
     try:
-        dup_result = duplicate_service.check_duplicate(text, threshold=duplicate_sensitivity)
+        dup_result = await asyncio.to_thread(duplicate_service.check_duplicate, text, threshold=duplicate_sensitivity)
     except Exception:
         dup_result = {"is_duplicate": False, "duplicate_ticket_id": None, "similarity": 0.0}
 
     # --- RAG Knowledge Base Check ---
     rag_match = None
     try:
-        rag_match = rag_service.search_knowledge_base(text, threshold=0.85)
+        rag_match = await asyncio.to_thread(rag_service.search_knowledge_base, text, threshold=0.85)
         if rag_match:
             classification["auto_resolve"] = True
             classification["assigned_team"] = "Auto-Resolve AI"
@@ -947,7 +947,7 @@ async def analyze_stream(request_body: TicketRequest):
         gemini_analysis = {"ocr_text": request_body.image_text or "", "image_description": ""}
         if request_body.image_base64 and not gemini_analysis["ocr_text"]:
             try:
-                vision_result = gemini_service.analyze_image(request_body.image_base64, text)
+                vision_result = await asyncio.to_thread(gemini_service.analyze_image, request_body.image_base64, text)
                 gemini_analysis.update(vision_result)
             except Exception as e:
                 pass
@@ -958,7 +958,7 @@ async def analyze_stream(request_body: TicketRequest):
         yield f"data: {json.dumps({'step': 'Extracting technical entities', 'status': 'in_progress'})}\n\n"
         await asyncio.sleep(0.2)
         try:
-            entities = ner_service.extract_entities(text)
+            entities = await asyncio.to_thread(ner_service.extract_entities, text)
         except Exception:
             entities = []
         timeline["metadata_harvested"] = get_now_ist()
@@ -967,9 +967,9 @@ async def analyze_stream(request_body: TicketRequest):
         yield f"data: {json.dumps({'step': 'Detecting category and priority', 'status': 'in_progress'})}\n\n"
         await asyncio.sleep(0.2)
         try:
-            classification_v3_res = classifier_v3.predict(text)
+            classification_v3_res = await asyncio.to_thread(classifier_v3.predict, text)
             if "error" in classification_v3_res:
-                classification = classifier_service.predict(text)
+                classification = await asyncio.to_thread(classifier_service.predict, text)
             else:
                 cat = classification_v3_res.get("Category", {}).get("prediction", "Unknown")
                 sub = classification_v3_res.get("Subcategory", {}).get("prediction", "Unknown")
@@ -1000,7 +1000,7 @@ async def analyze_stream(request_body: TicketRequest):
         yield f"data: {json.dumps({'step': 'Checking duplicate issues', 'status': 'in_progress'})}\n\n"
         await asyncio.sleep(0.2)
         try:
-            dup_result = duplicate_service.check_duplicate(text, threshold=duplicate_sensitivity)
+            dup_result = await asyncio.to_thread(duplicate_service.check_duplicate, text, threshold=duplicate_sensitivity)
         except Exception:
             dup_result = {"is_duplicate": False, "duplicate_ticket_id": None, "similarity": 0.0}
 
@@ -1009,7 +1009,7 @@ async def analyze_stream(request_body: TicketRequest):
         await asyncio.sleep(0.2)
         rag_match = None
         try:
-            rag_match = rag_service.search_knowledge_base(text, threshold=0.85)
+            rag_match = await asyncio.to_thread(rag_service.search_knowledge_base, text, threshold=0.85)
             if rag_match:
                 classification["auto_resolve"] = True
                 classification["assigned_team"] = "Auto-Resolve AI"
@@ -1082,7 +1082,7 @@ async def legacy_analyze_and_save(request_body: TicketRequest):
 async def analyze_ticket_v2(request: TicketRequest):
     text = request.text
     try:
-        prediction = classifier_v2.predict(text)
+        prediction = await asyncio.to_thread(classifier_v2.predict, text)
         return {
             "status": "success",
             "category": prediction["category"]["prediction"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -536,7 +536,8 @@ async def log_correction(raw_request: Request):
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
+@limiter.limit("60/minute")
+async def get_tickets(request: Request, company_id: str | None = None):
     """Fetch persistent tickets from Supabase."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
@@ -549,6 +550,7 @@ async def get_tickets(company_id: str | None = None):
     return res.data
 
 @app.post("/tickets/save")
+@limiter.limit("30/minute")
 async def save_ticket(request_body: TicketSaveRequest, request: Request):
     """
     OFFICIAL PERSISTENCE: Saves the analyzed ticket to Supabase.
@@ -676,7 +678,8 @@ async def save_ticket(request_body: TicketSaveRequest, request: Request):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/tickets/{ticket_id}")
-async def get_ticket_by_id(ticket_id: str):
+@limiter.limit("60/minute")
+async def get_ticket_by_id(ticket_id: str, request: Request):
     """Fetch single persistent ticket."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
@@ -688,7 +691,8 @@ async def get_ticket_by_id(ticket_id: str):
 
 
 @app.post("/tickets", response_model=TicketRecord)
-async def create_ticket(ticket: TicketRecord):
+@limiter.limit("30/minute")
+async def create_ticket(ticket: TicketRecord, request: Request):
     """Save a new ticket into the system."""
     # Check for duplicates before adding
     existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
@@ -701,7 +705,8 @@ async def create_ticket(ticket: TicketRecord):
 
 
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict):
+@limiter.limit("60/minute")
+async def update_ticket(ticket_id: str, updates: dict, request: Request):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):

--- a/backend/main.py
+++ b/backend/main.py
@@ -283,8 +283,8 @@ app.add_middleware(
         "http://localhost:3000",
     ],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "Accept"],
 )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -664,7 +664,7 @@ async def save_ticket(request_body: TicketSaveRequest, request: Request):
             "ticket_id": ticket_id,
             "sender_id": "00000000-0000-0000-0000-000000000000", # System ID
             "sender_name": "AI Assistant",
-            "sender_role": "admin",
+            "sender_role": "system",
             "message": msg
         }).execute()
         

--- a/backend/main.py
+++ b/backend/main.py
@@ -176,8 +176,7 @@ class TicketRecord(BaseModel):
     timeline: dict = {} # Milestones: created, analyzed, triaged, routed, in_progress, resolved
 
 
-# --- In-Memory Database (to be replaced with SQL later) ---
-TICKETS_DB: list[TicketRecord] = []
+# --- In-Memory Database Removed ---
 
 
 class HealthResponse(BaseModel):
@@ -690,34 +689,33 @@ async def get_ticket_by_id(ticket_id: str, request: Request):
     return res.data
 
 
-@app.post("/tickets", response_model=TicketRecord)
+@app.post("/tickets")
 @limiter.limit("30/minute")
-async def create_ticket(ticket: TicketRecord, request: Request):
-    """Save a new ticket into the system."""
-    # Check for duplicates before adding
-    existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
-    if existing:
-        return existing
-        
-    TICKETS_DB.append(ticket)
-    print(f"[DB] Ticket #{ticket.ticket_id} created for user {ticket.owner_id}")
-    return ticket
+async def create_ticket(ticket: dict, request: Request):
+    """Save a new ticket into the system (persisted to Supabase)."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+    
+    res = supabase.table("tickets").insert(ticket).execute()
+    if not res.data:
+        raise HTTPException(status_code=400, detail="Failed to create ticket")
+    
+    print(f"[DB] Ticket created: {res.data[0].get('id')}")
+    return res.data[0]
 
 
-@app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
+@app.patch("/tickets/{ticket_id}")
 @limiter.limit("60/minute")
 async def update_ticket(ticket_id: str, updates: dict, request: Request):
-    """Partially update a ticket's fields (e.g., status, viewed_at)."""
-    for i, ticket in enumerate(TICKETS_DB):
-        if str(ticket.ticket_id) == str(ticket_id):
-            # Convert to dict, update, then back to model
-            ticket_dict = ticket.dict()
-            ticket_dict.update(updates)
-            updated_ticket = TicketRecord(**ticket_dict)
-            TICKETS_DB[i] = updated_ticket
-            return updated_ticket
+    """Partially update a ticket's fields (e.g., status, viewed_at) via Supabase."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
     
-    raise HTTPException(status_code=404, detail="Ticket not found")
+    res = supabase.table("tickets").update(updates).eq("id", ticket_id).execute()
+    if not res.data:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+        
+    return res.data[0]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
 import asyncio
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 
 # Load environment variables from backend/.env
@@ -82,9 +82,9 @@ def get_system_settings(company_id: str) -> dict:
         print(f"[WARNING] Could not fetch system_settings for company_id={company_id}: {e}")
     return defaults
 class TicketRequest(BaseModel):
-    text: str
-    image_base64: str = ""
-    image_text: str = "" # Keep for backward compatibility
+    text: str = Field(..., max_length=20000)
+    image_base64: str = Field(default="", max_length=15000000)
+    image_text: str = Field(default="", max_length=50000) # Keep for backward compatibility
     user_id: str | None = None
     company: str | None = None
     image_url: str | None = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -472,6 +472,7 @@ async def analyze_bug(request: BugReportAnalysisRequest):
 # Admin Correction Logging endpoint
 # ---------------------------------------------------------------------------
 CORRECTIONS_LOG_PATH = Path(__file__).parent / "data" / "corrections_log.json"
+corrections_log_lock = asyncio.Lock()
 
 @app.post("/ai/log_correction")
 async def log_correction(raw_request: Request):
@@ -512,16 +513,17 @@ async def log_correction(raw_request: Request):
     }
 
     try:
-        if CORRECTIONS_LOG_PATH.exists() and CORRECTIONS_LOG_PATH.stat().st_size > 2:
-            with open(CORRECTIONS_LOG_PATH, "r", encoding="utf-8") as f:
-                logs = json.load(f)
-        else:
-            logs = []
+        async with corrections_log_lock:
+            if CORRECTIONS_LOG_PATH.exists() and CORRECTIONS_LOG_PATH.stat().st_size > 2:
+                with open(CORRECTIONS_LOG_PATH, "r", encoding="utf-8") as f:
+                    logs = json.load(f)
+            else:
+                logs = []
 
-        logs.append(entry)
+            logs.append(entry)
 
-        with open(CORRECTIONS_LOG_PATH, "w", encoding="utf-8") as f:
-            json.dump(logs, f, indent=2)
+            with open(CORRECTIONS_LOG_PATH, "w", encoding="utf-8") as f:
+                json.dump(logs, f, indent=2)
 
         print(f"[CORRECTION SAVED] Ticket ID: {ticket_id} | Changed: {changed_fields}")
         return {"status": "saved", "changed_fields": changed_fields}

--- a/backend/main.py
+++ b/backend/main.py
@@ -35,13 +35,13 @@ from dotenv import load_dotenv
 env_path = Path(__file__).parent / '.env'
 load_dotenv(dotenv_path=env_path)
 
-# Initialize Supabase Client (Service Role for backend bypass)
+# Initialize Supabase Client (Anon Key to respect RLS)
 try:
     from supabase import create_client, Client
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_ANON_KEY")
     if not url or not key:
-        print("[ERROR] SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
+        print("[ERROR] SUPABASE_URL or SUPABASE_ANON_KEY not set in backend/.env")
         supabase = None
     else:
         supabase = create_client(url, key)

--- a/backend/main.py
+++ b/backend/main.py
@@ -549,7 +549,7 @@ async def get_tickets(company_id: str | None = None):
     return res.data
 
 @app.post("/tickets/save")
-async def save_ticket(request_body: TicketSaveRequest):
+async def save_ticket(request_body: TicketSaveRequest, request: Request):
     """
     OFFICIAL PERSISTENCE: Saves the analyzed ticket to Supabase.
     This is called AFTER the user confirms the analysis results.
@@ -558,6 +558,30 @@ async def save_ticket(request_body: TicketSaveRequest):
         raise HTTPException(status_code=500, detail="Supabase connection not initialized.")
 
     logger = logging.getLogger(__name__)
+
+    # --- 1000% Perfect Tenant Auth & Spoofing Protection ---
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid Authorization header")
+    
+    token = auth_header.split(" ")[1]
+    try:
+        user_response = supabase.auth.get_user(token)
+        if not user_response or not getattr(user_response, "user", None):
+            raise HTTPException(status_code=401, detail="Invalid token")
+        trusted_user_id = user_response.user.id
+    except Exception as e:
+        logger.error(f"Authentication failed: {e}")
+        raise HTTPException(status_code=401, detail="Authentication failed")
+
+    # Enforce trusted user ID from token
+    if request_body.user_id and request_body.user_id != trusted_user_id:
+        logger.warning(f"ID Spoofing Attempt: Token user {trusted_user_id} tried to act as {request_body.user_id}")
+        raise HTTPException(status_code=403, detail="User ID mismatch. Spoofing detected.")
+    
+    request_body.user_id = trusted_user_id
+    # --------------------------------------------------------
+
     try:
         final_data = request_body.dict()
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -536,14 +536,26 @@ async def log_correction(raw_request: Request):
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
 @limiter.limit("60/minute")
-async def get_tickets(request: Request, company_id: str | None = None):
+async def get_tickets(
+    request: Request,
+    company_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0
+):
     """Fetch persistent tickets from Supabase."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
     
+    # Prevent excessive limit values
+    if limit > 100:
+        limit = 100
+        
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
     if company_id:
         query = query.eq("company_id", company_id)
+        
+    # Apply pagination
+    query = query.range(offset, offset + limit - 1)
         
     res = query.execute()
     return res.data


### PR DESCRIPTION
Summary
This PR fixes a critical UX and data-consistency flaw where the frontend silently masked backend outages by creating fake, local-only "TCKT-MOCK-" tickets.

Changes Made
Removed the try/catch fallback payload inside the predictTicket method in Frontend/src/services/api.js.
Replaced the mock ticket generation with a hard throw new Error() statement.
When a backend connection error occurs, the frontend will now appropriately fail, ensuring users are aware that their ticket could not be processed and to try again later.
Resolved Issue
Resolves #2156 