### PR TITLE
fix : replaced hardcoded backend URL in AutoResolve.jsx with API_CONFIG

### DIFF
--- a/Frontend/src/user/pages/AutoResolve.jsx
+++ b/Frontend/src/user/pages/AutoResolve.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bot, User, CheckCircle2, XCircle, Send, RefreshCcw, ShieldCheck } from 'lucide-react';
 import useTicketStore from '../../store/ticketStore';
+import { API_CONFIG } from '../../config';
 
 function AutoResolve() {
     const { aiTicket } = useTicketStore();
@@ -15,7 +16,7 @@ function AutoResolve() {
     const fetchNextStep = async (history = []) => {
         setIsThinking(true);
         try {
-            const response = await fetch('http://127.0.0.1:8000/ai/troubleshoot', {
+            const response = await fetch(`${API_CONFIG.BACKEND_URL}/ai/troubleshoot`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({


### PR DESCRIPTION
Closes #2233.

Summary of What Has Been Done:
Replaced hardcoded http://127.0.0.1:8000/ai/troubleshoot with dynamic API_CONFIG.BACKEND_URL in Frontend/src/user/pages/AutoResolve.jsx.

Changes Made:
- Added import of API_CONFIG from ../../config
- Replaced hardcoded URL with template literal using API_CONFIG.BACKEND_URL
- No lint errors introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI troubleshooting backend connection to use a configurable API endpoint instead of a hardcoded URL, enabling better flexibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->