### PR TITLE
fix : added user dependency to useEffect in AdminTickets.tsx

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.tsx
+++ b/Frontend/src/admin/pages/AdminTickets.tsx
@@ -427,8 +427,9 @@ const AdminTickets = () => {
     }, [fetchTickets]);
 
     useEffect(() => {
+        if (!user) return;
         fetchInitialData();
-    }, [statusFilter, categoryFilter, priorityFilter, teamFilter, searchQuery]);
+    }, [user, statusFilter, categoryFilter, priorityFilter, teamFilter, searchQuery, fetchInitialData]);
 
     // SLA breach realtime listener
     useEffect(() => {


### PR DESCRIPTION
Closes #2234.

Summary of What Has Been Done:
Fixed the missing user dependency in the useEffect hook in Frontend/src/admin/pages/AdminTickets.tsx.

Changes Made:
- Added user guard check at start of useEffect
- Added user and fetchInitialData to the useEffect dependency array
- Applied to TypeScript file (AdminTickets.tsx) as per gssoc branch
- No lint errors introduced