### PR TITLE
fix : prevented infinite re-fetch loop in RecentTickets.jsx

### DIFF
--- a/Frontend/src/user/components/RecentTickets.jsx
+++ b/Frontend/src/user/components/RecentTickets.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Clock, ChevronRight, Inbox, Loader2, AlertCircle } from 'lucide-react';
 import useAuthStore from '../../store/authStore';
@@ -12,7 +12,7 @@ const RecentTickets = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
-    const fetchRecentTickets = async () => {
+    const fetchRecentTickets = useCallback(async () => {
         if (!user?.id) {
             setLoading(false);
             return;
@@ -36,12 +36,11 @@ const RecentTickets = () => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [user]);
 
     useEffect(() => {
         fetchRecentTickets();
-     
-    }, []);
+    }, [fetchRecentTickets]);
 
     const getStatusBadge = (status) => {
         const s = String(status || '').toLowerCase();


### PR DESCRIPTION
Closes #2237.

Summary of What Has Been Done:
Wrapped fetchRecentTickets in useCallback with user as dependency and updated useEffect to use the stable callback reference.

Changes Made:
- Added useCallback import
- Wrapped fetchRecentTickets in useCallback with [user] dependency
- Updated useEffect to use [fetchRecentTickets] instead of []
- No lint errors introduced