### PR TITLE
fix : handled null profile gracefully in AdminLobby.jsx

### DIFF
--- a/Frontend/src/pages/AdminLobby.jsx
+++ b/Frontend/src/pages/AdminLobby.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "../lib/supabaseClient";
 import useAuthStore from "../store/authStore";
@@ -13,10 +13,17 @@ function AdminLobby() {
     const navigate = useNavigate();
     const [status, setStatus] = useState(profile?.status || "pending_approval");
     const [isTransitioning, setIsTransitioning] = useState(false);
+    const profileCheckRef = useRef(false);
 
     const currentStatus = profile?.status || status;
 
     useEffect(() => {
+        // Skip on first render if profile is not yet available — re-run when profile changes
+        if (!profile && !profileCheckRef.current) {
+            profileCheckRef.current = true;
+            return;
+        }
+
         // If they are somehow here without being an admin, kick them out
         if (!profile || profile.role !== "admin") {
             navigate("/login");


### PR DESCRIPTION
Closes #2238.

Summary of What Has Been Done:
Added a ref to skip the first render when profile is not yet available, preventing premature redirect to login before auth is initialized.

Changes Made:
- Added useRef import
- Added profileCheckRef to skip first render when profile is null
- Updated guard to wait for profile to be available before checking role