### PR TITLE
fix : added authLoading guard to Profile page useEffect

### DIFF
--- a/Frontend/src/user/pages/Profile.jsx
+++ b/Frontend/src/user/pages/Profile.jsx
@@ -67,6 +67,7 @@ const Profile = () => {
     }, [profile]);
 
     useEffect(() => {
+        if (authLoading) return;
         const fetchUserTickets = async () => {
             if (!user?.id) return;
             const { data } = await supabase
@@ -76,7 +77,7 @@ const Profile = () => {
             setUserTickets(data || []);
         };
         fetchUserTickets();
-    }, [user]);
+    }, [user, authLoading]);
 
     const handleLogout = async () => {
         try {


### PR DESCRIPTION
Closes #2239.

Summary of What Has Been Done:
Added authLoading guard to the Profile page fetchUserTickets useEffect to prevent fetching tickets before auth is initialized.

Changes Made:
- Added early return if authLoading in the fetchUserTickets useEffect
- Added authLoading to useEffect dependency array