### PR TITLE
fix : added debounce to search input in AdminTickets.tsx

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.tsx
+++ b/Frontend/src/admin/pages/AdminTickets.tsx
@@ -286,6 +286,7 @@ const AdminTickets = () => {
 
     // ── Filter State ────────────────────────────────
     const [searchQuery, setSearchQuery] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
     const [statusFilter, setStatusFilter] = useState('All');
     const [categoryFilter, setCategoryFilter] = useState('All');
     const [priorityFilter, setPriorityFilter] = useState('All');
@@ -463,6 +464,12 @@ const AdminTickets = () => {
         return () => { supabase.removeChannel(channelSla); };
     }, []);
 
+    // Debounce search query
+    useEffect(() => {
+        const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300);
+        return () => clearTimeout(timer);
+    }, [searchQuery]);
+
     // Seed search from URL
     useEffect(() => {
         const params = new URLSearchParams(location.search);
@@ -559,8 +566,8 @@ const AdminTickets = () => {
     // ── Derived / Filtered ──────────────────────────
     const filteredTickets = useMemo(() => {
         let result = tickets;
-        if (searchQuery) {
-            const q = sanitizeSearchQuery(searchQuery).toLowerCase();
+        if (debouncedSearch) {
+            const q = sanitizeSearchQuery(debouncedSearch).toLowerCase();
             result = result.filter(t =>
                 String(t.id).includes(q) ||
                 (t.subject || '').toLowerCase().includes(q) ||


### PR DESCRIPTION
Closes #2242.

Summary of What Has Been Done:
Added 300ms debounce to the search input in Frontend/src/admin/pages/AdminTickets.tsx to prevent excessive re-renders on every keystroke.

Changes Made:
- Added debouncedSearch state
- Added useEffect to update debouncedSearch 300ms after searchQuery changes
- Updated filteredTickets useMemo to use debouncedSearch instead of searchQuery
- Applied to TypeScript file (AdminTickets.tsx) as per gssoc branch
- No lint errors introduced