### PR TITLE
fix : added realtime notification badge refresh in useTicketsRealtime.js

### DIFF
--- a/Frontend/src/hooks/useTicketsRealtime.js
+++ b/Frontend/src/hooks/useTicketsRealtime.js
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { supabase } from '../lib/supabaseClient';
+import useAuthStore from '../store/authStore';
 import useTicketStore from '../store/ticketStore';
 import {
     applyTicketRealtimePayload,
@@ -49,10 +50,20 @@ const useTicketsRealtime = ({
                     ));
 
                     const ticketStore = useTicketStore.getState();
+                    const { user } = useAuthStore.getState();
                     if (payload.eventType === 'DELETE') {
                         ticketStore.removeTicket(ticketId);
                     } else if (payload.new) {
                         ticketStore.upsertTicket(payload.new);
+                        // Create notification for ticket updates from other users
+                        if (payload.eventType === 'UPDATE' && user && payload.new.user_id !== user.id) {
+                            ticketStore.addNotification({
+                                type: 'message',
+                                ticketId: payload.new.ticket_id || ticketId,
+                                title: 'Ticket Updated',
+                                message: `Ticket "${payload.new.subject || 'Unknown'}" has been updated.`
+                            });
+                        }
                     }
 
                     if (payload.eventType === 'INSERT' && payload.new && onInsert) {


### PR DESCRIPTION
Closes #2251.

Summary of What Has Been Done:
Extended the useTicketsRealtime.js hook to call addNotification when tickets are updated by other users, ensuring the notification badge count updates in real-time.

Changes Made:
- Added useAuthStore import
- Added addNotification call in UPDATE event handler when ticket is updated by another user
- Uses ticketStore.addNotification for consistent notification management