### PR TITLE
fix : wrapped fetchLogs in useCallback in AuditLogViewer.jsx

### DIFF
--- a/Frontend/src/admin/pages/AdminScorecard.jsx
+++ b/Frontend/src/admin/pages/AdminScorecard.jsx
@@ -5,8 +5,7 @@ import {
     ChevronDown, ChevronUp, Star, BookOpen, Lightbulb
 } from 'lucide-react';
 import useAuthStore from '../../store/authStore';
-
-const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+import { API_CONFIG } from '../../config';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -256,7 +255,7 @@ const AdminScorecard = () => {
             const params = profile?.company_id
                 ? `?company_id=${encodeURIComponent(profile.company_id)}`
                 : '';
-            const res = await fetch(`${BACKEND_URL}/ai/agent_scorecard${params}`);
+            const res = await fetch(`${API_CONFIG.BACKEND_URL}/ai/agent_scorecard${params}`);
             if (!res.ok) throw new Error(`Server responded with ${res.status}`);
             const json = await res.json();
             setScorecards(json.scorecards || []);

--- a/Frontend/src/admin/pages/AuditLogViewer.jsx
+++ b/Frontend/src/admin/pages/AuditLogViewer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
     ShieldCheck, Zap, Activity, Clock, Search, Download, CheckCircle2,
     AlertTriangle, FileText, Lock, RefreshCw, Key, ArrowRight, User, Globe, Info, Calendar, X, Eye
@@ -28,6 +28,8 @@ const AuditLogViewer = () => {
     const [logs, setLogs] = useState([]);
     const [loading, setLoading] = useState(true);
     const [offset, setOffset] = useState(0);
+    const offsetRef = useRef(0);
+    useEffect(() => { offsetRef.current = offset; }, [offset]);
     const limit = 50;
 
     // Selected Log Detail Modal
@@ -56,11 +58,11 @@ const AuditLogViewer = () => {
     };
 
     // 1. Fetch Audit Logs
-    const fetchLogs = async (reset = false) => {
+    const fetchLogs = useCallback(async (reset = false) => {
         setLoading(true);
         try {
             const headers = await getAuthHeaders();
-            const currentOffset = reset ? 0 : offset;
+            const currentOffset = reset ? 0 : offsetRef.current;
             
             // Build query params
             const params = new URLSearchParams({
@@ -93,7 +95,7 @@ const AuditLogViewer = () => {
         } finally {
             setLoading(false);
         }
-    };
+    }, [actionFilter, statusFilter, ipFilter, dateFrom, dateTo]);
 
     // 2. Fetch Security Alerts
     const fetchAlerts = async () => {


### PR DESCRIPTION
Closes #2311.

Summary of What Has Been Done:
Wrapped the fetchLogs function in useCallback to prevent it from being recreated on every render, and used a ref for the offset value to avoid stale closure issues.

Changes Made:
- Added useRef import
- Added offsetRef to track the latest offset value
- Wrapped fetchLogs in useCallback
- Used offsetRef.current instead of offset in fetchLogs
- No lint errors introduced