### PR TITLE
fix: add CSRF protection middleware for cookie-based auth (critical security)

### DIFF
--- a/backend/csrf.py
+++ b/backend/csrf.py
@@ -1,0 +1,67 @@
+import secrets
+import logging
+from typing import Optional
+from fastapi import Request, Response, HTTPException, status
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger(__name__)
+
+CSRF_COOKIE_NAME = "csrf_token"
+CSRF_HEADER_NAME = "X-CSRF-Token"
+CSRF_COOKIE_MAX_AGE = 60 * 60 * 24
+
+SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
+
+
+def generate_csrf_token() -> str:
+    return secrets.token_hex(32)
+
+
+class CSRFTokenMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app):
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        if request.method in SAFE_METHODS:
+            return await call_next(request)
+
+        csrf_cookie = request.cookies.get(CSRF_COOKIE_NAME)
+        csrf_header = request.headers.get(CSRF_HEADER_NAME)
+
+        if not csrf_cookie or not csrf_header:
+            logger.warning(
+                "CSRF validation failed: missing %s (method=%s path=%s)",
+                "cookie" if not csrf_cookie else "header",
+                request.method,
+                request.url.path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="CSRF validation failed: missing or invalid token",
+            )
+
+        if not secrets.compare_digest(csrf_cookie, csrf_header):
+            logger.warning(
+                "CSRF validation failed: token mismatch (method=%s path=%s)",
+                request.method,
+                request.url.path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="CSRF validation failed: token mismatch",
+            )
+
+        return await call_next(request)
+
+
+def set_csrf_cookie(response: Response) -> str:
+    token = generate_csrf_token()
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=token,
+        max_age=CSRF_COOKIE_MAX_AGE,
+        secure=True,
+        samesite="strict",
+        path="/",
+    )
+    return token

--- a/main.py
+++ b/main.py
@@ -1,10 +1,24 @@
-from fastapi import FastAPI
+import logging
+from fastapi import FastAPI, Request
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
+
+from backend.csrf import CSRFTokenMiddleware, set_csrf_cookie, CSRF_COOKIE_NAME
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
-# ... existing code ...
+app.add_middleware(CSRFTokenMiddleware)
+
+
+@app.get("/auth/csrf-token")
+async def get_csrf_token(response: JSONResponse):
+    token = set_csrf_cookie(response)
+    return {"csrf_token": token}
+
 
 @app.get("/docs", include_in_schema=False)
 async def get_docs():


### PR DESCRIPTION
## Summary

Adds Cross-Site Request Forgery (CSRF) protection using the double-submit cookie pattern. The application uses HttpOnly cookies for session management but had no CSRF validation, making state-changing endpoints vulnerable to cross-origin attacks.

## Changes

### New File: backend/csrf.py
- CSRFTokenMiddleware - Validates X-CSRF-Token header matches csrf_token cookie on all POST/PATCH/DELETE/PUT requests
- set_csrf_cookie() - Sets a secure, SameSite=Strict CSRF token cookie readable by JavaScript
- Uses secrets.compare_digest() for timing-safe comparison
- Safe HTTP methods (GET, HEAD, OPTIONS, TRACE) are exempt

### Modified: main.py
- Added CSRFTokenMiddleware to the FastAPI app
- Added GET /auth/csrf-token endpoint for frontend to initialize CSRF token

Closes #2327