### PR TITLE
fix: harden Content Security Policy - remove unsafe-inline and unsafe-eval from script-src (critical)

### DIFF
--- a/backend/sanitization.py
+++ b/backend/sanitization.py
@@ -182,7 +182,7 @@ def get_security_headers() -> dict[str, str]:
     return {
         "Content-Security-Policy": (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.tailwindcss.com; "
+            "script-src 'self' https://cdn.tailwindcss.com; "
             "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com; "
             "img-src 'self' data: https:; "
             "font-src 'self' data: https://fonts.gstatic.com; "

--- a/backend/security_middleware.py
+++ b/backend/security_middleware.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_CSP = (
     "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; "
+    "script-src 'self' https://cdn.jsdelivr.net; "
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
     "font-src 'self' https://fonts.gstatic.com data:; "
     "img-src 'self' data: blob: https://*.supabase.co https://*.supabase.in; "
@@ -45,7 +45,7 @@ def _resolve_csp() -> str:
     origins_joined = " ".join(origins)
     return (
         f"default-src 'self' {origins_joined}; "
-        f"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net {origins_joined}; "
+        f"script-src 'self' https://cdn.jsdelivr.net {origins_joined}; "
         f"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         f"font-src 'self' https://fonts.gstatic.com data:; "
         f"img-src 'self' data: blob: https://*.supabase.co https://*.supabase.in {origins_joined}; "


### PR DESCRIPTION
## Summary

Removes 'unsafe-inline' and 'unsafe-eval' from script-src directives in both the active security middleware and sanitization helpers. These directives completely defeat CSP-based XSS protection by allowing arbitrary inline script execution and dynamic code evaluation.

## Changes

### backend/security_middleware.py
- Removed 'unsafe-inline' and 'unsafe-eval' from script-src in default CSP
- Removed 'unsafe-inline' and 'unsafe-eval' from script-src in CSP_ALLOWED_SOURCES dynamic resolution

### backend/sanitization.py
- Removed 'unsafe-inline' and 'unsafe-eval' from script-src in get_security_headers()

### Preserved for style-src
- 'unsafe-inline' remains in style-src because Tailwind CSS requires inline style injection at runtime

Closes #2330