### PR TITLE
[SECURITY] Fix #2354: Remove hardcoded master admin email check

### DIFF
--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -31,14 +31,13 @@ const useAuthStore = create(
                 }
 
                 // Priority 2: Use Auth Metadata (Instant fallback)
-                const isMasterAdmin = user.email === 'masteradmin@helpdesk.ai';
-
+                // Role is always resolved from the database, never from a hardcoded email.
                 const instantProfile = {
                     id: user.id,
                     email: user.email,
-                    full_name: isMasterAdmin ? 'Master Admin' : (metadata.full_name || 'User'),
-                    role: isMasterAdmin ? 'master_admin' : (metadata.role || 'user'),
-                    status: isMasterAdmin ? 'active' : 'pending_email_verification',
+                    full_name: metadata.full_name || 'User',
+                    role: metadata.role || 'user',
+                    status: 'pending_email_verification',
                     company: metadata.company || ''
                 };
 


### PR DESCRIPTION
Fixes #2354

Removes \user.email === 'masteradmin@helpdesk.ai'\ hardcoded check that leaked the master admin email in the client bundle and allowed anyone registering with that email to gain master_admin role.

Closes #2354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user profile initialization to use consistent metadata handling instead of hardcoded email-based logic. Default profile status is now standardized as pending email verification before syncing with actual profile data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->