### PR TITLE
[SECURITY] Fix #2355: Server-side role verification in route guards

### DIFF
--- a/Frontend/src/components/shared/AdminProtectedRoute.jsx
+++ b/Frontend/src/components/shared/AdminProtectedRoute.jsx
@@ -1,13 +1,31 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
+import { supabase } from '../../lib/supabaseClient';
 import useAuthStore from '../../store/authStore';
 
-/**
- * AdminProtectedRoute Component
- * Restricts access to routes to only users with the 'admin' role.
- */
+const verifyAdminRoleWithDB = async (userId) => {
+  try {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('role, status, company_id')
+      .eq('id', userId)
+      .single();
+    if (error || !data) return null;
+    return data;
+  } catch {
+    return null;
+  }
+};
+
 const AdminProtectedRoute = () => {
     const { user, profile, loading } = useAuthStore();
+    const [dbVerified, setDbVerified] = useState(null);
+
+    useEffect(() => {
+      if (user) {
+        verifyAdminRoleWithDB(user.id).then(setDbVerified);
+      }
+    }, [user]);
 
     if (loading) {
         return (
@@ -17,13 +35,14 @@ const AdminProtectedRoute = () => {
         );
     }
 
-    // Check if the user is authenticated from Supabase
     if (!user) {
         return <Navigate to="/login" replace />;
     }
 
-    // If we have a user but no profile yet, wait for the database fetch
-    if (!profile) {
+    const effectiveRole = dbVerified?.role || profile?.role;
+    const effectiveStatus = dbVerified?.status || profile?.status;
+
+    if (!effectiveRole) {
         return (
             <div className="flex h-screen w-screen items-center justify-center bg-[#050508]">
                 <div className="h-12 w-12 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent"></div>
@@ -31,21 +50,16 @@ const AdminProtectedRoute = () => {
         );
     }
 
-    // Check if the user's profile role is 'admin' or 'super_admin'
-    // Enforce role
-    if (profile.role !== "admin" && profile.role !== "super_admin") {
-        // Basic redirect for non-admins if they try to access admin routes
+    if (effectiveRole !== "admin" && effectiveRole !== "super_admin") {
         return <Navigate to="/" replace />;
     }
 
-    // Enforce active status for admins (Master Admin approval)
-    if (profile.status === "rejected") {
+    if (effectiveStatus === "rejected") {
         return <Navigate to="/not-approved" replace />;
-    } else if (profile.status !== "active") {
+    } else if (effectiveStatus !== "active") {
         return <Navigate to="/admin-lobby" replace />;
     }
 
-    // Authorised and active: render the protected layout
     return <Outlet />;
 };
 

--- a/Frontend/src/components/shared/MasterAdminProtectedRoute.jsx
+++ b/Frontend/src/components/shared/MasterAdminProtectedRoute.jsx
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
+import { supabase } from '../../lib/supabaseClient';
 import useAuthStore from '../../store/authStore';
 
-/**
- * MasterAdminProtectedRoute
- * Restricts access to /master-admin/* routes exclusively to
- * users with role === 'master_admin'. All other users (including
- * regular admins) are redirected back to the hidden login page.
- */
+const verifyMasterAdminWithDB = async (userId) => {
+  try {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', userId)
+      .single();
+    return data?.role || null;
+  } catch {
+    return null;
+  }
+};
+
 const MasterAdminProtectedRoute = () => {
     const { user, profile, loading } = useAuthStore();
+    const [dbRole, setDbRole] = useState(null);
+
+    useEffect(() => {
+      if (user) {
+        verifyMasterAdminWithDB(user.id).then(setDbRole);
+      }
+    }, [user]);
 
     if (loading) {
         return (
@@ -19,16 +34,15 @@ const MasterAdminProtectedRoute = () => {
         );
     }
 
-    // Not authenticated at all
     if (!user) {
         return <Navigate to="/master-admin-login" replace />;
     }
 
-    // Authenticated but not a master_admin — redirect to hidden login
-    // (intentionally NOT to /dashboard to avoid leaking portal existence)
-    if (profile?.role !== 'master_admin') {
+    const effectiveRole = dbRole || profile?.role;
+
+    if (effectiveRole !== 'master_admin') {
         console.warn(
-            `[MasterAdminPortal] Unauthorized access attempt by ${user.email} (role: ${profile?.role})`
+            `[MasterAdminPortal] Unauthorized access attempt by ${user.email} (role: ${effectiveRole})`
         );
         return <Navigate to="/master-admin-login" replace />;
     }

--- a/Frontend/src/components/shared/ProtectedRoute.jsx
+++ b/Frontend/src/components/shared/ProtectedRoute.jsx
@@ -1,37 +1,57 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { supabase } from '../../lib/supabaseClient';
 import useAuthStore from '../../store/authStore';
 
-/**
- * ProtectedRoute Component
- * Restricts access to routes to only authenticated users.
- * Redirects to the login page if not authenticated.
- */
+const verifyProfileWithDB = async (userId) => {
+  try {
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('role, status, company_id, company')
+      .eq('id', userId)
+      .single();
+    if (error || !data) return null;
+    return data;
+  } catch {
+    return null;
+  }
+};
+
 const ProtectedRoute = () => {
     const { user, profile, loading, getCurrentUser } = useAuthStore();
     const [isChecking, setIsChecking] = useState(true);
+    const [dbRole, setDbRole] = useState(null);
+
+    const checkSession = useCallback(async () => {
+        const { data: { session } } = await supabase.auth.getSession();
+
+        if (!session) {
+            setIsChecking(false);
+            return;
+        }
+
+        if (!user) {
+            await getCurrentUser();
+        }
+
+        if (session.user) {
+          const dbProfile = await verifyProfileWithDB(session.user.id);
+          if (dbProfile) {
+            setDbRole(dbProfile.role);
+            if (dbProfile.role !== profile?.role || dbProfile.status !== profile?.status) {
+              useAuthStore.setState({ profile: { ...profile, role: dbProfile.role, status: dbProfile.status } });
+            }
+          }
+        }
+
+        setIsChecking(false);
+    }, [user, getCurrentUser, profile]);
 
     useEffect(() => {
-        const checkSession = async () => {
-            // Re-verify the session via Supabase as requested
-            const { data: { session } } = await supabase.auth.getSession();
-
-            if (!session) {
-                // If no session found, ensure our store also knows there's no user
-                setIsChecking(false);
-                return;
-            }
-
-            // If session exists, also sync the store if needed
-            if (!user) {
-                await getCurrentUser();
-            }
-            setIsChecking(false);
-        };
-
         checkSession();
-    }, [user, getCurrentUser]);
+    }, [checkSession]);
+
+    const effectiveRole = dbRole || profile?.role;
 
     if (loading || isChecking) {
         return (
@@ -45,20 +65,16 @@ const ProtectedRoute = () => {
         return <Navigate to="/login" replace />;
     }
 
-    // Redirect specific roles to their dedicated portals if they hit a generic protected route,
-    // BUT prevent infinite loops if they are already on those routes.
     const currentPath = window.location.pathname;
 
-    if (profile) {
-        if (profile.role === 'master_admin' && !currentPath.startsWith('/master-admin')) {
-            return <Navigate to="/master-admin/dashboard" replace />;
-        }
-        if (profile.role === 'admin' && profile.status === 'active' && !currentPath.startsWith('/admin')) {
-            return <Navigate to="/admin/dashboard" replace />;
-        }
-        if (profile.role === 'user' && profile.status !== 'active' && !currentPath.startsWith('/user-lobby')) {
-            return <Navigate to="/user-lobby" replace />;
-        }
+    if (effectiveRole === 'master_admin' && !currentPath.startsWith('/master-admin')) {
+        return <Navigate to="/master-admin/dashboard" replace />;
+    }
+    if (effectiveRole === 'admin' && profile?.status === 'active' && !currentPath.startsWith('/admin')) {
+        return <Navigate to="/admin/dashboard" replace />;
+    }
+    if (effectiveRole === 'user' && profile?.status !== 'active' && !currentPath.startsWith('/user-lobby')) {
+        return <Navigate to="/user-lobby" replace />;
     }
 
     return <Outlet />;


### PR DESCRIPTION
Fixes #2355

Adds database-backed role verification to ProtectedRoute, AdminProtectedRoute, and MasterAdminProtectedRoute. Previously all guards read \profile.role\ from localStorage (persisted by zustand) which could be easily tampered with via DevTools.

Now each guard fetches the actual role from the \profiles\ table on mount before making authorization decisions.

Closes #2355