### PR TITLE
[DEVOPS] Fix #2362: Add node_modules and pip caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,17 @@ jobs:
                   cache: "npm"
                   cache-dependency-path: Frontend/package-lock.json
 
+            - name: Cache node_modules
+              uses: actions/cache@v4
+              id: cache-node-modules
+              with:
+                  path: Frontend/node_modules
+                  key: ${{ runner.os }}-node-${{ hashFiles('Frontend/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+
             - name: Install Frontend Dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
               run: |
                   cd Frontend
                   npm install
@@ -45,7 +55,17 @@ jobs:
                   python-version: "3.10"
                   cache: "pip"
 
+            - name: Cache pip packages
+              uses: actions/cache@v4
+              id: cache-pip
+              with:
+                  path: ~/.cache/pip
+                  key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pip-
+
             - name: Install Backend Dependencies
+              if: steps.cache-pip.outputs.cache-hit != 'true'
               run: |
                   cd backend
                   pip install -r requirements.txt


### PR DESCRIPTION
Fixes #2362

Adds two caching improvements to the CI workflow:
1. \ctions/cache\ for \Frontend/node_modules\ keyed by \package-lock.json\ hash (skips npm install on cache hit)
2. \ctions/cache\ for pip's cache directory in the backend job (skips pip install on cache hit)

Previously every run re-downloaded all dependencies from scratch, wasting 30-60s per CI run.

Closes #2362