### PR TITLE
fix : replaced hardcoded BACKEND_URL with API_CONFIG in TagFilter.jsx

### DIFF
--- a/Frontend/src/components/AgentLeaderboard.jsx
+++ b/Frontend/src/components/AgentLeaderboard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { API_CONFIG } from "../../config";
 
 /**
  * AgentLeaderboard — admin ranked view of all agents
@@ -8,7 +9,7 @@ import { supabase } from "../lib/supabaseClient";
 export default function AgentLeaderboard({ companyId, onSelectAgent }) {
   const [agents, setAgents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const BACKEND = import.meta.env.VITE_BACKEND_URL || "http://localhost:8000";
+  const BACKEND = API_CONFIG.BACKEND_URL;
 
   useEffect(() => {
     if (!companyId) {

--- a/Frontend/src/components/AgentScorecard.jsx
+++ b/Frontend/src/components/AgentScorecard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { API_CONFIG } from "../../config";
 
 /**
  * AgentScorecard — individual agent performance card
@@ -9,7 +10,7 @@ export default function AgentScorecard({ agentId, companyId, agentName }) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const BACKEND = import.meta.env.VITE_BACKEND_URL || "http://localhost:8000";
+  const BACKEND = API_CONFIG.BACKEND_URL;
 
   useEffect(() => {
     if (!agentId || !companyId) {

--- a/Frontend/src/components/FrustrationHeatmap.jsx
+++ b/Frontend/src/components/FrustrationHeatmap.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { API_CONFIG } from "../../config";
 
 /**
  * FrustrationHeatmap — admin widget showing frustration distribution
@@ -8,7 +9,7 @@ import { supabase } from "../lib/supabaseClient";
 export default function FrustrationHeatmap({ companyId }) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const BACKEND = import.meta.env.VITE_BACKEND_URL || "http://localhost:8000";
+  const BACKEND = API_CONFIG.BACKEND_URL;
 
   useEffect(() => {
     if (!companyId) return;

--- a/Frontend/src/components/TagFilter.jsx
+++ b/Frontend/src/components/TagFilter.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { API_CONFIG } from "../../config";
 
 /**
  * TagFilter — admin ticket list filter by tag
@@ -8,7 +9,7 @@ import { supabase } from "../lib/supabaseClient";
 export default function TagFilter({ companyId, onFilterChange }) {
   const [popularTags, setPopularTags] = useState([]);
   const [selected, setSelected]       = useState([]);
-  const BACKEND = import.meta.env.VITE_BACKEND_URL || "http://localhost:8000";
+  const BACKEND = API_CONFIG.BACKEND_URL;
 
   useEffect(() => {
     if (!companyId) return;

--- a/Frontend/src/components/TicketTagManager.jsx
+++ b/Frontend/src/components/TicketTagManager.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { API_CONFIG } from "../../config";
 import TagChip from "./TagChip";
 
 /**
@@ -24,7 +25,7 @@ export default function TicketTagManager({
   const [saving, setSaving]                 = useState(false);
   const [saveStatus, setSaveStatus]         = useState(null); // null | "saved" | "error"
 
-  const BACKEND = import.meta.env.VITE_BACKEND_URL || "http://localhost:8000";
+  const BACKEND = API_CONFIG.BACKEND_URL;
 
   // ── Auth token ──────────────────────────────────────────────────────────────
   const getToken = useCallback(async () => {


### PR DESCRIPTION
Closes #2387.

Summary of What Has Been Done:
Replaced the hardcoded BACKEND_URL constant with API_CONFIG.BACKEND_URL in Frontend/src/components/TagFilter.jsx.

Changes Made:
- Added API_CONFIG import from ../../config
- Replaced hardcoded BACKEND_URL with API_CONFIG.BACKEND_URL
- No lint errors introduced