### PR TITLE
feat(backend): add Hinglish text preprocessor for multilingual classifier

### DIFF
--- a/backend/services/text_preprocessor.py
+++ b/backend/services/text_preprocessor.py
@@ -1,0 +1,304 @@
+"""
+Text Preprocessor — Multilingual normalization for the AI classifier pipeline.
+
+Detects code-mixed (Hinglish) input and normalizes common Romanized Hindi
+tokens into English equivalents so that the DistilBERT tokenizer produces
+fewer [UNK] tokens and classification accuracy improves.
+
+This module is designed to sit in front of any classifier service's predict()
+method as a lightweight pre-processing step.
+
+Reference: Defect D-005 — Classifier V3 failing on mixed-language tickets.
+"""
+
+import re
+import unicodedata
+
+# ── Romanized Hindi → English token map ─────────────────────────────
+# Covers the most frequent Hinglish tokens seen in IT support tickets.
+# Keys are lowercase Romanized Hindi; values are English replacements.
+
+HINGLISH_TOKEN_MAP = {
+    # Pronouns & common words
+    "mera": "my",
+    "meri": "my",
+    "mere": "my",
+    "tera": "your",
+    "teri": "your",
+    "tere": "your",
+    "uska": "his",
+    "uski": "her",
+    "humara": "our",
+    "tumhara": "your",
+    "mujhe": "me",
+    "tujhe": "you",
+    "hum": "we",
+    "tum": "you",
+    "wo": "that",
+    "woh": "that",
+    "yeh": "this",
+    "ye": "this",
+    "kya": "what",
+    "kab": "when",
+    "kahan": "where",
+    "kaun": "who",
+    "kyun": "why",
+    "kaise": "how",
+    "kitna": "how much",
+
+    # Verbs / helpers
+    "hai": "is",
+    "hain": "are",
+    "tha": "was",
+    "thi": "was",
+    "the": "were",
+    "hoga": "will be",
+    "hogi": "will be",
+    "ho": "is",
+    "kar": "do",
+    "karo": "do",
+    "karna": "to do",
+    "kiya": "did",
+    "raha": "ongoing",
+    "rahi": "ongoing",
+    "rahe": "ongoing",
+    "nahi": "not",
+    "nahin": "not",
+    "mat": "don't",
+    "chahiye": "need",
+    "sakta": "can",
+    "sakti": "can",
+    "sakte": "can",
+    "dena": "give",
+    "lena": "take",
+    "batao": "tell",
+    "batana": "tell",
+    "dekhna": "see",
+    "dekho": "see",
+    "aana": "come",
+    "jaana": "go",
+    "chalna": "work",
+    "lagta": "seems",
+    "lagti": "seems",
+
+    # IT support specific
+    "kaam": "work",
+    "kaam nahi kar raha": "not working",
+    "band": "off",
+    "chalu": "on",
+    "theek": "fix",
+    "sahi": "correct",
+    "galat": "wrong",
+    "problem": "problem",
+    "dikkat": "problem",
+    "pareshani": "problem",
+    "mushkil": "difficulty",
+    "madad": "help",
+    "suljhao": "resolve",
+    "error": "error",
+    "screen": "screen",
+    "password": "password",
+    "internet": "internet",
+    "slow": "slow",
+    "dhima": "slow",
+    "dheema": "slow",
+    "fast": "fast",
+    "tez": "fast",
+    "install": "install",
+    "update": "update",
+    "restart": "restart",
+    "laptop": "laptop",
+    "computer": "computer",
+    "phone": "phone",
+    "mobile": "mobile",
+    "printer": "printer",
+    "wifi": "wifi",
+    "network": "network",
+    "file": "file",
+    "folder": "folder",
+    "delete": "delete",
+    "hatao": "remove",
+    "bhejo": "send",
+    "dikhao": "show",
+    "kholo": "open",
+    "band karo": "close",
+    "login": "login",
+    "logout": "logout",
+
+    # Connectors and fillers
+    "aur": "and",
+    "ya": "or",
+    "lekin": "but",
+    "magar": "but",
+    "par": "but",
+    "se": "from",
+    "ko": "to",
+    "me": "in",
+    "pe": "on",
+    "ke": "of",
+    "ka": "of",
+    "ki": "of",
+    "bhi": "also",
+    "sirf": "only",
+    "bas": "just",
+    "abhi": "now",
+    "pehle": "before",
+    "baad": "after",
+    "baar": "times",
+    "bahut": "very",
+    "bohot": "very",
+    "zyada": "more",
+    "thoda": "little",
+    "sab": "all",
+    "kuch": "some",
+    "koi": "any",
+    "please": "please",
+    "plz": "please",
+    "pls": "please",
+
+    # Responses / states
+    "haan": "yes",
+    "ji": "yes",
+    "na": "no",
+    "accha": "okay",
+    "achha": "okay",
+    "theek hai": "okay",
+    "shukriya": "thanks",
+    "dhanyavaad": "thanks",
+}
+
+# ── Devanagari Unicode range detection ──────────────────────────────
+_DEVANAGARI_RE = re.compile(r"[\u0900-\u097F]")
+
+# ── Common Hinglish sentence patterns ──────────────────────────────
+# These regex patterns detect typical Romanized Hindi sentence structures.
+_HINGLISH_PATTERNS = [
+    re.compile(r"\b(mera|meri|mere|tera|teri|humara)\b", re.IGNORECASE),
+    re.compile(r"\b(hai|hain|tha|thi|nahi|nahin)\b", re.IGNORECASE),
+    re.compile(r"\b(kya|kaise|kyun|kahan|kaun)\b", re.IGNORECASE),
+    re.compile(r"\b(karo|karna|batao|dekho|chahiye)\b", re.IGNORECASE),
+    re.compile(r"\b(dikkat|pareshani|madad|theek|galat)\b", re.IGNORECASE),
+    re.compile(r"\b(raha|rahi|rahe|sakta|sakti|sakte)\b", re.IGNORECASE),
+]
+
+# Minimum number of pattern matches to consider text as Hinglish
+_HINGLISH_THRESHOLD = 2
+
+
+def detect_code_mixed(text: str) -> bool:
+    """Detect if text contains mixed-language patterns.
+
+    Returns True if the text contains:
+    - Devanagari script characters mixed with Latin, OR
+    - At least _HINGLISH_THRESHOLD Romanized Hindi patterns
+
+    Args:
+        text: Input text to analyze.
+
+    Returns:
+        True if code-mixed language is detected.
+    """
+    if not text or not text.strip():
+        return False
+
+    # Check 1: Devanagari script present alongside Latin characters
+    has_devanagari = bool(_DEVANAGARI_RE.search(text))
+    has_latin = bool(re.search(r"[a-zA-Z]", text))
+    if has_devanagari and has_latin:
+        return True
+
+    # Check 2: Romanized Hindi pattern matching
+    matches = sum(1 for pattern in _HINGLISH_PATTERNS if pattern.search(text))
+    return matches >= _HINGLISH_THRESHOLD
+
+
+def normalize_hinglish(text: str) -> str:
+    """Normalize Romanized Hindi tokens to their English equivalents.
+
+    Performs word-level replacement using the HINGLISH_TOKEN_MAP.
+    Multi-word phrases are checked first, then individual words.
+
+    Args:
+        text: Input text potentially containing Hinglish tokens.
+
+    Returns:
+        Text with Hinglish tokens replaced by English equivalents.
+    """
+    if not text or not text.strip():
+        return text or ""
+
+    result = text
+
+    # Phase 1: Replace multi-word phrases (longest match first)
+    multi_word_phrases = sorted(
+        [(k, v) for k, v in HINGLISH_TOKEN_MAP.items() if " " in k],
+        key=lambda x: len(x[0]),
+        reverse=True,
+    )
+    for hindi_phrase, english in multi_word_phrases:
+        pattern = re.compile(re.escape(hindi_phrase), re.IGNORECASE)
+        result = pattern.sub(english, result)
+
+    # Phase 2: Replace single-word tokens
+    words = result.split()
+    normalized_words = []
+    for word in words:
+        # Strip punctuation for lookup, preserve it in output
+        stripped = word.strip(".,!?;:'\"()-")
+        prefix = word[: len(word) - len(word.lstrip(".,!?;:'\"()-"))]
+        suffix = word[len(word.rstrip(".,!?;:'\"()-")) :]
+
+        lookup = stripped.lower()
+        if lookup in HINGLISH_TOKEN_MAP and " " not in lookup:
+            normalized_words.append(prefix + HINGLISH_TOKEN_MAP[lookup] + suffix)
+        else:
+            normalized_words.append(word)
+
+    return " ".join(normalized_words)
+
+
+def strip_devanagari(text: str) -> str:
+    """Remove Devanagari characters from text, keeping Latin and common symbols.
+
+    Useful as a fallback when Devanagari tokens cannot be transliterated.
+
+    Args:
+        text: Input text potentially containing Devanagari script.
+
+    Returns:
+        Text with Devanagari characters removed and whitespace normalized.
+    """
+    if not text:
+        return ""
+    cleaned = _DEVANAGARI_RE.sub(" ", text)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def preprocess_for_classifier(text: str) -> str:
+    """Main entry point for text pre-processing before classifier inference.
+
+    Pipeline:
+    1. If text is empty or whitespace, return as-is.
+    2. Detect if text contains code-mixed (Hinglish) patterns.
+    3. If code-mixed: normalize Hinglish tokens and strip residual Devanagari.
+    4. Normalize whitespace and return clean text.
+
+    Args:
+        text: Raw ticket text from user input.
+
+    Returns:
+        Preprocessed text suitable for the DistilBERT tokenizer.
+    """
+    if not text or not text.strip():
+        return text or ""
+
+    cleaned = text.strip()
+
+    if detect_code_mixed(cleaned):
+        cleaned = normalize_hinglish(cleaned)
+        cleaned = strip_devanagari(cleaned)
+
+    # Final whitespace normalization
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+
+    return cleaned

--- a/backend/tests/test_text_preprocessor.py
+++ b/backend/tests/test_text_preprocessor.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for the text_preprocessor module.
+
+Covers: Hinglish detection, token normalization, Devanagari stripping,
+and the main preprocess_for_classifier pipeline.
+
+Reference: Bug #5 / D-005 — Classifier V3 failing on mixed-language tickets.
+"""
+
+import pytest
+import sys
+import os
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from backend.services.text_preprocessor import (
+    detect_code_mixed,
+    normalize_hinglish,
+    strip_devanagari,
+    preprocess_for_classifier,
+    HINGLISH_TOKEN_MAP,
+)
+
+
+# ── detect_code_mixed tests ──────────────────────────────────────────
+
+
+class TestDetectCodeMixed:
+    """Tests for code-mixed language detection."""
+
+    def test_pure_english_not_detected(self):
+        """Plain English text should not be flagged as code-mixed."""
+        assert detect_code_mixed("My laptop keeps restarting") is False
+
+    def test_pure_hinglish_detected(self):
+        """Romanized Hindi with enough patterns is detected."""
+        assert detect_code_mixed("mera laptop kaam nahi kar raha hai") is True
+
+    def test_devanagari_mixed_with_latin(self):
+        """Devanagari script mixed with Latin characters is detected."""
+        assert detect_code_mixed("मेरा laptop काम नहीं कर रहा") is True
+
+    def test_pure_devanagari_no_latin(self):
+        """Pure Devanagari without Latin is not code-mixed."""
+        assert detect_code_mixed("मेरा लैपटॉप काम नहीं कर रहा") is False
+
+    def test_single_hinglish_word_below_threshold(self):
+        """Single Hinglish word below threshold should not trigger detection."""
+        assert detect_code_mixed("The system hai working fine") is False
+
+    def test_multiple_hinglish_words_above_threshold(self):
+        """Multiple Hinglish words should trigger detection."""
+        assert detect_code_mixed("kya laptop hai working nahi") is True
+
+    def test_empty_string(self):
+        """Empty string should not be detected as code-mixed."""
+        assert detect_code_mixed("") is False
+
+    def test_none_input(self):
+        """None input should not be detected as code-mixed."""
+        assert detect_code_mixed(None) is False
+
+    def test_whitespace_only(self):
+        """Whitespace-only input should not be detected."""
+        assert detect_code_mixed("   ") is False
+
+    def test_numbers_only(self):
+        """Numbers-only input should not be detected."""
+        assert detect_code_mixed("12345 67890") is False
+
+    def test_case_insensitive_detection(self):
+        """Detection should be case-insensitive."""
+        assert detect_code_mixed("MERA LAPTOP KAAM NAHI KARTA") is True
+
+    def test_hinglish_it_support_phrase(self):
+        """Common IT support Hinglish phrase should be detected."""
+        assert detect_code_mixed(
+            "mera password reset nahi ho raha hai, kya karu?"
+        ) is True
+
+
+# ── normalize_hinglish tests ─────────────────────────────────────────
+
+
+class TestNormalizeHinglish:
+    """Tests for Hinglish token normalization."""
+
+    def test_basic_normalization(self):
+        """Basic Hinglish tokens should be replaced with English."""
+        result = normalize_hinglish("mera laptop hai")
+        assert "my" in result
+        assert "is" in result
+
+    def test_pure_english_unchanged(self):
+        """Pure English text should pass through unchanged."""
+        text = "My laptop is not working"
+        assert normalize_hinglish(text) == text
+
+    def test_preserves_punctuation(self):
+        """Punctuation around Hinglish tokens should be preserved."""
+        result = normalize_hinglish("kya hai?")
+        assert result == "what is?"
+
+    def test_mixed_sentence(self):
+        """Mixed Hinglish-English sentence is normalized correctly."""
+        result = normalize_hinglish("mera laptop restart nahi ho raha")
+        assert "my" in result
+        assert "laptop" in result
+        assert "restart" in result
+        assert "not" in result
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        assert normalize_hinglish("") == ""
+
+    def test_none_input(self):
+        """None input returns empty string."""
+        assert normalize_hinglish(None) == ""
+
+    def test_multi_word_phrase_replacement(self):
+        """Multi-word phrases in the token map are replaced."""
+        result = normalize_hinglish("mera laptop kaam nahi kar raha")
+        assert "not working" in result
+
+    def test_case_preservation_in_non_hinglish(self):
+        """Non-Hinglish words should keep their original case."""
+        result = normalize_hinglish("URGENT aur problem")
+        assert "URGENT" in result
+        assert "and" in result
+
+    def test_it_support_common_phrases(self):
+        """Common IT support Hinglish phrases normalize correctly."""
+        result = normalize_hinglish("password reset kaise karu, madad chahiye")
+        assert "how" in result
+        assert "help" in result
+        assert "need" in result
+
+    def test_hinglish_token_map_not_empty(self):
+        """Token map should have a reasonable number of entries."""
+        assert len(HINGLISH_TOKEN_MAP) >= 50
+
+
+# ── strip_devanagari tests ───────────────────────────────────────────
+
+
+class TestStripDevanagari:
+    """Tests for Devanagari character removal."""
+
+    def test_removes_devanagari(self):
+        """Devanagari characters should be removed."""
+        result = strip_devanagari("मेरा laptop काम नहीं कर रहा")
+        assert "मेरा" not in result
+        assert "laptop" in result
+
+    def test_pure_latin_unchanged(self):
+        """Pure Latin text should pass through unchanged."""
+        assert strip_devanagari("hello world") == "hello world"
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        assert strip_devanagari("") == ""
+
+    def test_none_input(self):
+        """None input returns empty string."""
+        assert strip_devanagari(None) == ""
+
+    def test_whitespace_normalization(self):
+        """Resulting whitespace from Devanagari removal is normalized."""
+        result = strip_devanagari("test मेरा  word")
+        assert "  " not in result
+
+
+# ── preprocess_for_classifier tests ──────────────────────────────────
+
+
+class TestPreprocessForClassifier:
+    """Tests for the main preprocessing pipeline."""
+
+    def test_english_passes_through(self):
+        """Pure English text passes through the pipeline unchanged."""
+        text = "My laptop is not working properly"
+        result = preprocess_for_classifier(text)
+        assert result == text
+
+    def test_hinglish_normalized(self):
+        """Hinglish text is detected and normalized."""
+        result = preprocess_for_classifier(
+            "mera laptop kaam nahi kar raha hai, kya karu?"
+        )
+        assert "my" in result
+        assert "not working" in result or "not" in result
+
+    def test_mixed_script_cleaned(self):
+        """Mixed Devanagari + Latin text is cleaned."""
+        result = preprocess_for_classifier("मेरा laptop restart nahi ho raha")
+        assert "laptop" in result
+        assert "not" in result
+        # Devanagari should be stripped
+        assert "मेरा" not in result
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        assert preprocess_for_classifier("") == ""
+
+    def test_none_input(self):
+        """None input returns empty string."""
+        assert preprocess_for_classifier(None) == ""
+
+    def test_whitespace_only(self):
+        """Whitespace-only input returns empty-ish string."""
+        result = preprocess_for_classifier("   ")
+        assert result.strip() == ""
+
+    def test_whitespace_normalized(self):
+        """Extra whitespace in output is normalized."""
+        result = preprocess_for_classifier("mera   laptop   hai   slow")
+        assert "  " not in result
+
+    def test_special_characters_preserved(self):
+        """Special characters in English text are preserved."""
+        text = "Error #404: page not found! (urgent)"
+        result = preprocess_for_classifier(text)
+        assert result == text
+
+    def test_emoji_preserved(self):
+        """Emoji in text should be preserved."""
+        text = "System is down 🔥 help needed"
+        result = preprocess_for_classifier(text)
+        assert "🔥" in result
+
+    def test_real_world_hinglish_ticket(self):
+        """Real-world Hinglish IT support ticket is preprocessed correctly."""
+        ticket = "mera laptop baar baar restart ho raha hai aur screen pe error aa raha hai, kya karu?"
+        result = preprocess_for_classifier(ticket)
+        # Should contain English equivalents
+        assert "my" in result
+        assert "laptop" in result
+        assert "restart" in result
+        # Should not contain raw Hinglish tokens
+        assert "mera" not in result.split()


### PR DESCRIPTION
## Summary
Fixes #2418

Adds a text pre-processing module that detects and normalizes Hinglish (mixed Hindi-English) input before it reaches the DistilBERT classifier, reducing `[UNK]` token rates and improving classification accuracy for multilingual tickets.

### New Files
- **`backend/services/text_preprocessor.py`** — Core module with:
  - `detect_code_mixed()` — Detects Devanagari + Latin mixing and Romanized Hindi patterns
  - `normalize_hinglish()` — Maps 130+ common Hinglish tokens to English equivalents
  - `strip_devanagari()` — Removes Devanagari script characters
  - `preprocess_for_classifier()` — Main pipeline entry point
- **`backend/tests/test_text_preprocessor.py`** — 37 unit tests (all passing)

### Defect Reference
- Defect Log: `D-005` (Sprint 6)
- Reported by: Backend Team
- Status: Open (staging testing)

### Testing
```
python -m pytest backend/tests/test_text_preprocessor.py -v
# 37 passed in 0.67s
```
