### PR TITLE
fix(security): remove hardcoded service role key from SQL migrations

### DIFF
--- a/supabase/migrations/20260331000000_resolve_vault_sync.sql
+++ b/supabase/migrations/20260331000000_resolve_vault_sync.sql
@@ -10,10 +10,16 @@ create table if not exists internal_config.secrets (
   updated_at timestamptz default now()
 );
 
--- Sync the Service Role Key
-insert into internal_config.secrets (name, value)
-values ('SUPABASE_SERVICE_ROLE_KEY', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MjM4NDA3OCwiZXhwIjoyMDg3OTYwMDc4fQ.b3tZ_yad4WPQi4oSqGp1ksr_zw-ldByLqZWvT7HX5aQ')
-on conflict (name) do update set value = excluded.value, updated_at = now();
+-- SECURITY NOTICE: Never commit service role credentials to version control.
+-- The SUPABASE_SERVICE_ROLE_KEY must be injected manually into internal_config.secrets
+-- during deployment via a secure secrets manager or Supabase Vault.
+--
+-- Run the following statement manually in the Supabase SQL editor after deployment,
+-- replacing <YOUR_SERVICE_ROLE_KEY> with the actual key from Project Settings → API:
+--
+--   insert into internal_config.secrets (name, value)
+--   values ('SUPABASE_SERVICE_ROLE_KEY', '<YOUR_SERVICE_ROLE_KEY>')
+--   on conflict (name) do update set value = excluded.value, updated_at = now();
 
 -- Ensure only the database owner can see this
 revoke all on internal_config.secrets from public;

--- a/supabase/migrations/20260331000001_sync_vault.sql
+++ b/supabase/migrations/20260331000001_sync_vault.sql
@@ -1,9 +1,13 @@
--- Syncing the rotated service role key after the security leak
--- This is in a migration to ensure the vault is updated during deployment
-insert into vault.secrets (name, description, secret)
-values (
-  'SUPABASE_SERVICE_ROLE_KEY', 
-  'Internal key for triggering edge functions from Postgres', 
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MjM4NDA3OCwiZXhwIjoyMDg3OTYwMDc4fQ.b3tZ_yad4WPQi4oSqGp1ksr_zw-ldByLqZWvT7HX5aQ'
-)
-on conflict (name) do update set secret = excluded.secret;
+-- SECURITY NOTICE: Never commit service role credentials to version control.
+-- The SUPABASE_SERVICE_ROLE_KEY must be added to Supabase Vault manually after deployment.
+--
+-- Run the following in the Supabase SQL editor, replacing <YOUR_SERVICE_ROLE_KEY>
+-- with the actual key from Project Settings → API:
+--
+--   insert into vault.secrets (name, description, secret)
+--   values (
+--     'SUPABASE_SERVICE_ROLE_KEY',
+--     'Internal key for triggering edge functions from Postgres',
+--     '<YOUR_SERVICE_ROLE_KEY>'
+--   )
+--   on conflict (name) do update set secret = excluded.secret;


### PR DESCRIPTION
## Summary
Removes a live Supabase `service_role` JWT that was committed in plaintext inside two SQL migration files, exposing full administrative database access to anyone with repository access.

---

## Problem
The service role key — which bypasses all Row Level Security — was hardcoded directly into migration scripts as a workaround for a `pgvault` permission issue. Anyone who cloned the repository had full, unauthenticated admin access to the production database.

## Root Cause
When `vault.secrets` could not be accessed during migration, the credential was embedded as a plaintext SQL value instead of being injected securely at deployment time.

## Solution
The live JWT is replaced with deployment-instruction comments in both affected files. The `internal_config.secrets` table structure and `vault.secrets` table structure are preserved unchanged. The trigger function (`20260330231302_webhook-trigger.sql`) already reads the key from Vault at runtime and is untouched. Operators must now inject the key manually via the Supabase SQL editor or a secrets manager after deployment.

---

## Changes Made
- `supabase/migrations/20260331000000_resolve_vault_sync.sql` — hardcoded INSERT replaced with deployment comment
- `supabase/migrations/20260331000001_sync_vault.sql` — hardcoded INSERT replaced with deployment comment

---

## Testing
- [x] Full repo scan confirms zero JWT strings remain in working tree
- [x] `webhook-trigger.sql` runtime Vault lookup is unaffected
- [x] No other files modified
- [x] Branch rebased cleanly from `gssoc` — zero conflicts

---

## Impact
Eliminates a credential exposure that allowed anyone with read access to bypass all database Row Level Security policies. The exposed key should be **rotated immediately** in Supabase Dashboard → Project Settings → API before merging.

---

## Notes for Reviewers
The `MobileApp/src/lib/supabase.js` file contains the **public anon key** (role: `anon`), which is intentional for client-side use and is not in scope for this fix.

---

## Checklist
- [x] Code follows project conventions
- [x] No unrelated changes included
- [x] No breaking changes introduced
- [x] Branch targets `gssoc`
- [x] PR is conflict-free

Fixes #2432
