### PR TITLE
feat: improve admin ticket history CSV export

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.tsx
+++ b/Frontend/src/admin/pages/AdminTickets.tsx
@@ -615,6 +615,19 @@ const AdminTickets = () => {
         return 'bg-red-500';
     };
 
+    const handleExportTickets = () => {
+        try {
+            const exportDate = new Date().toISOString().slice(0, 10);
+            downloadCSV(filteredTickets, `ticket-history-${exportDate}`);
+            showToast(`${filteredTickets.length} ticket${filteredTickets.length === 1 ? '' : 's'} exported as CSV.`, 'success');
+            setTicketAnnouncement(`${filteredTickets.length} ticket${filteredTickets.length === 1 ? '' : 's'} exported as CSV.`);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'CSV export failed';
+            showToast(message, 'error');
+            setTicketAnnouncement(message);
+        }
+    };
+
     const isAllSelected = filteredTickets.length > 0 && selectedTickets.length === filteredTickets.length;
     const isSomeSelected = selectedTickets.length > 0 && selectedTickets.length < filteredTickets.length;
 
@@ -636,7 +649,7 @@ const AdminTickets = () => {
                     {/* Export CSV */}
                     <button
                         type="button"
-                        onClick={() => downloadCSV(filteredTickets, `tickets-export-${new Date().toISOString().slice(0, 10)}`)}
+                        onClick={handleExportTickets}
                         disabled={filteredTickets.length === 0}
                         aria-label={`Export ${filteredTickets.length} filtered tickets as CSV`}
                         className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 rounded-2xl text-[11px] font-black uppercase tracking-widest text-slate-600 hover:bg-emerald-50 hover:border-emerald-200 hover:text-emerald-700 disabled:opacity-40 disabled:cursor-not-allowed transition-all shadow-sm"

--- a/Frontend/src/utils/exportUtils.js
+++ b/Frontend/src/utils/exportUtils.js
@@ -9,35 +9,54 @@
  * @param {string} filename - Output filename (without extension)
  */
 export function downloadCSV(tickets, filename = 'tickets-export') {
-  if (!tickets?.length) return;
+  if (!tickets?.length) {
+    throw new Error('No tickets available to export');
+  }
 
   const headers = [
     'Ticket ID',
-    'Title',
+    'Subject',
+    'Summary',
+    'Description',
     'Category',
     'Priority',
     'Status',
-    'Assigned To',
+    'Assigned Team',
+    'Assigned Agent',
+    'Requester Name',
+    'Requester Email',
+    'SLA Status',
+    'Confidence',
     'Created At',
+    'Updated At',
     'Resolved At',
     'Company',
   ];
 
   const rows = tickets.map((t) => [
     t.ticket_id || t.id || '',
-    t.title || t.subject || '',
+    t.title || t.subject || t.summary || '',
+    t.summary || '',
+    t.description || '',
     t.category || '',
     t.priority || '',
     t.status || '',
-    t.assigned_to || t.assigned_agent || t.agent_name || '',
-    t.created_at || t.createdAt || '',
-    t.resolved_at || t.resolvedAt || '',
+    t.assigned_team || '',
+    getAssignedAgentName(t),
+    t.creator?.full_name || t.profiles?.full_name || t.requester_name || '',
+    t.creator?.email || t.profiles?.email || t.user_email || '',
+    t.sla_status || (t.sla_breach ? 'breached' : ''),
+    formatConfidence(t.confidence),
+    formatExportDate(t.created_at || t.createdAt),
+    formatExportDate(t.updated_at || t.updatedAt),
+    formatExportDate(t.resolved_at || t.resolvedAt),
     t.company_name || t.company || '',
   ]);
 
   // Build CSV content
   const escape = (v) => {
-    const s = String(v ?? '');
+    const raw = String(v ?? '');
+    const s = /^[=+\-@]/.test(raw) ? `'${raw}` : raw;
     return /[,"\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
   };
 
@@ -47,7 +66,7 @@ export function downloadCSV(tickets, filename = 'tickets-export') {
   ].join('\n');
 
   // Trigger download
-  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const blob = new Blob(['\ufeff' + csvContent], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const el = document.createElement('a');
   el.href = url;
@@ -56,6 +75,30 @@ export function downloadCSV(tickets, filename = 'tickets-export') {
   el.click();
   document.body.removeChild(el);
   URL.revokeObjectURL(url);
+}
+
+function getAssignedAgentName(ticket) {
+  return (
+    ticket.assignee?.full_name ||
+    ticket.assigned_to ||
+    ticket.assigned_agent ||
+    ticket.agent_name ||
+    ''
+  );
+}
+
+function formatConfidence(confidence) {
+  if (confidence === null || confidence === undefined || confidence === '') return '';
+  const numericConfidence = Number(confidence);
+  if (Number.isNaN(numericConfidence)) return String(confidence);
+  return `${Math.round(numericConfidence * 100)}%`;
+}
+
+function formatExportDate(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toISOString();
 }
 
 /**


### PR DESCRIPTION
## Summary
- expands the admin ticket CSV export into a fuller ticket history download
- includes requester, assignee, SLA, confidence, description, summary, and normalized timestamps
- adds success/error feedback when admins export the filtered ticket list
- hardens CSV cells against formula injection and keeps values CSV-escaped

Closes #2173

## Verification
- `git diff --check`
- `node --check Frontend/src/utils/exportUtils.js`

Note: the `gssoc` branch currently does not include a `package.json`, so I could not run the full frontend package scripts locally.
