### PR TITLE
fix: import Response from fastapi in main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from contextlib import asynccontextmanager
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, Response
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded


### PR DESCRIPTION
Fixes #2471 

Imported `Response` from `fastapi` in `backend/main.py` to resolve the `NameError: name 'Response' is not defined` when calling the authentication endpoints `/auth/login`, `/auth/signup`, and `/auth/logout`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend request/response handling infrastructure to support session management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->