### PR TITLE
fix: resolve Supabase service key naming mismatch

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,7 +39,7 @@ load_dotenv(dotenv_path=env_path)
 try:
     from supabase import create_client, Client
     url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
     if not url or not key:
         print("[ERROR] SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
         supabase = None

--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -47,7 +47,7 @@ def seed_company_settings():
     # Initialize Supabase client
     supabase = create_client(
         os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     )
     
     logger.info("Starting company settings seed script...")
@@ -141,7 +141,7 @@ def verify_seed():
     
     supabase = create_client(
         os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     )
     
     try:

--- a/backend/services/auto_close_service.py
+++ b/backend/services/auto_close_service.py
@@ -36,7 +36,7 @@ class AutoCloseService:
         """Initialize the auto-close service with Supabase client."""
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self.enabled = os.getenv("AUTO_CLOSE_ENABLED", "true").lower() == "true"
         self.default_auto_close_days = int(os.getenv("AUTO_CLOSE_DAYS", "7"))

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -53,7 +53,7 @@ class NotificationRoutingMiddleware:
         """Initialize the notification routing middleware."""
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self._settings_cache: Dict[str, Dict] = {}
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -11,7 +11,7 @@ class RagService:
         
         load_dotenv()
         url = os.environ.get("SUPABASE_URL")
-        key = os.environ.get("SUPABASE_SERVICE_KEY")
+        key = os.environ.get("SUPABASE_SERVICE_KEY") or os.environ.get("SUPABASE_SERVICE_ROLE_KEY")
         if url and key:
             self.supabase: Client = create_client(url, key)
         else:


### PR DESCRIPTION
Fixes #2472 

Resolves the naming mismatch of the Supabase service key environment variable between the API backend, seeding scripts, and background services.

All affected modules now check for both `SUPABASE_SERVICE_KEY` and `SUPABASE_SERVICE_ROLE_KEY`, ensuring background jobs, seeding scripts, and routing middlewares successfully initialize.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend credential configuration to support flexible environment variable handling for improved deployment flexibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->