### PR TITLE
feat: add support transcript summarization endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -452,6 +452,9 @@ class BugReportAnalysisRequest(BaseModel):
 class BugReportAnalysisResponse(BaseModel):
     probable_cause: str
 
+class TranscriptSummarizeRequest(BaseModel):
+    messages: list[dict]
+
 @app.post("/ai/analyze_bug", response_model=BugReportAnalysisResponse)
 async def analyze_bug(request: BugReportAnalysisRequest):
     """Analyze a bug report using Gemini to generate a Probable Cause."""
@@ -467,6 +470,31 @@ async def analyze_bug(request: BugReportAnalysisRequest):
         request.console_errors
     )
     return BugReportAnalysisResponse(probable_cause=cause)
+
+@app.post("/ai/summarize_transcript")
+async def summarize_transcript(request: TranscriptSummarizeRequest):
+    """Summarize a support ticket conversation transcript."""
+    if not gemini_service or not gemini_service._initialized:
+        return {
+            "status": "error",
+            "message": "Transcript summarization unavailable (API key missing)",
+            "data": None
+        }
+
+    try:
+        summary_data = gemini_service.summarize_transcript(request.messages)
+        return {
+            "status": "success",
+            "message": "Transcript summarized successfully",
+            "data": summary_data
+        }
+    except Exception as e:
+        print(f"[Transcript Summarization Error]: {e}")
+        return {
+            "status": "error",
+            "message": str(e),
+            "data": None
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -222,3 +222,52 @@ class GeminiService:
         except Exception as e:
             print(f"[GeminiService] Bug Analysis Error: {e}")
             return f"Diagnostic analysis failed: {str(e)}"
+
+    def summarize_transcript(self, messages: list[dict]) -> dict:
+        """
+        Summarize a support ticket conversation/transcript.
+        Returns summary, key issues, resolution status, and next steps.
+        """
+        if not self._initialized:
+            return {
+                "summary": "AI summarization unavailable.",
+                "key_issues": [],
+                "resolution_status": "unknown",
+                "next_steps": []
+            }
+        
+        try:
+            # Format messages for the prompt
+            transcript_str = ""
+            for msg in messages:
+                role = msg.get("sender_name", msg.get("role", "Unknown"))
+                text = msg.get("message", msg.get("text", ""))
+                transcript_str += f"{role}: {text}\n"
+            
+            prompt = (
+                f"You are an expert IT support manager analyzing a support ticket conversation.\n"
+                f"Transcript:\n{transcript_str}\n\n"
+                "Please analyze and return the following in JSON format:\n"
+                "1. 'summary': A concise 2-3 sentence summary of the entire conversation\n"
+                "2. 'key_issues': A list of 2-4 key problems discussed (short bullet points)\n"
+                "3. 'resolution_status': One of: 'resolved', 'in_progress', 'unresolved', 'escalated'\n"
+                "4. 'next_steps': A list of 1-3 recommended next steps for the support team\n"
+                "Return ONLY the JSON, no extra text."
+            )
+            
+            response = self.client.models.generate_content(
+                model=self.model_name,
+                contents=prompt,
+                config={"response_mime_type": "application/json"}
+            )
+            
+            import json
+            return json.loads(response.text)
+        except Exception as e:
+            print(f"[GeminiService] Transcript Summarization Error: {e}")
+            return {
+                "summary": "Error generating summary.",
+                "key_issues": [],
+                "resolution_status": "unknown",
+                "next_steps": []
+            }


### PR DESCRIPTION
Perfect! I've solved issue #2465! Here's what was done:

## Summary
Added support transcript summarization to reduce review time!

### Changes Made:
1. Updated GeminiService ( backend/services/gemini_service.py ) :
   
   - Added summarize_transcript(messages: list[dict]) method
   - Takes a list of conversation messages
   - Returns structured JSON with:
     - summary : 2-3 sentence conversation summary
     - key_issues : List of key problems discussed
     - resolution_status : One of "resolved", "in_progress", "unresolved", "escalated"
     - next_steps : Recommended next steps for support team
2. Added API Endpoint ( backend/main.py ) :
   
   - Added TranscriptSummarizeRequest Pydantic model (takes messages list)
   - Added POST /ai/summarize_transcript endpoint
   - Handles errors gracefully (falls back to default responses if API key missing or error occurs)
### Branch
fix/2465-support-transcript-summarization

### Pull Request
PR is ready here: https://github.com/pranayukey200/HELPDESK.AI/pull/new/fix/2465-support-transcript-summarization

Closes #2465