### PR TITLE
[CRITICAL][CWE-321] Remove hardcoded fallback encryption key in KMS client

### DIFF
--- a/backend/security/kms_client.py
+++ b/backend/security/kms_client.py
@@ -132,8 +132,14 @@ def get_kms_provider() -> KMSProvider:
         return GoogleCloudKMSProvider(key_name)
         
     else:
-        # Fallback local KMS using local DB_ENCRYPTION_SECRET_KEY
-        secret = os.environ.get("DB_ENCRYPTION_SECRET_KEY") or "default-development-secret-key-32b"
+        # Local KMS requires DB_ENCRYPTION_SECRET_KEY to be explicitly set
+        secret = os.environ.get("DB_ENCRYPTION_SECRET_KEY")
+        if not secret:
+            raise ValueError(
+                "DB_ENCRYPTION_SECRET_KEY environment variable not set. "
+                "Encryption requires a configured key. Generate one with: "
+                "python3 -c \"import secrets; print(secrets.token_hex(32))\""
+            )
         import hashlib
         key_bytes = hashlib.sha256(secret.encode()).digest()
         return LocalKMSProvider(key_bytes)


### PR DESCRIPTION
## Summary

Removes the hardcoded fallback encryption key "default-development-secret-key-32b" in backend/security/kms_client.py:136 (CWE-321). When DB_ENCRYPTION_SECRET_KEY is not set, the function now raises a ValueError instead of silently falling back to a hardcoded key.

## Changes

- **backend/security/kms_client.py** — Replaced `os.environ.get("DB_ENCRYPTION_SECRET_KEY") or "default-development-secret-key-32b"` with a proper check that raises ValueError when the env var is unset

## Impact

- Severity: CRITICAL (CVSS 9.1)
- CWE: CWE-321 (Use of Hardcoded Cryptographic Key)
- Anyone with source access could derive the AES-256-GCM key via SHA-256 and decrypt all encrypted PII/ticket data

## Verification

- Python syntax valid
- Only 1 file changed, 8 insertions, 2 deletions
- Based directly on upstream/gssoc — no merge conflicts

Fixes #2480
