### PR TITLE
[CRITICAL][CWE-798] Replace hardcoded AES encryption key in test_encryption.py with dynamic generation

### DIFF
--- a/backend/test_encryption.py
+++ b/backend/test_encryption.py
@@ -11,10 +11,10 @@ import pytest
 
 @pytest.fixture
 def encryption_module(monkeypatch):
-    """Fixture that provides a fresh encryption module with test key configured."""
+    """Fixture that provides a fresh encryption module with a dynamically generated test key."""
     monkeypatch.setenv(
         "AES_ENCRYPTION_KEY",
-        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        os.urandom(32).hex(),
     )
     import encryption
     importlib.reload(encryption)


### PR DESCRIPTION
## Summary

Replaces the hardcoded AES-256 encryption key in `backend/test_encryption.py` with a dynamically generated key at test time (CWE-798). The test fixture was committing a valid 32-byte hex key `0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef` to the public repository.

## Changes

- **backend/test_encryption.py** — Changed the `encryption_module` fixture to use `os.urandom(32).hex()` instead of a static hardcoded key string

## Impact

- Severity: CRITICAL (security policy)
- CWE: CWE-798 (Use of Hardcoded Credentials)
- Security scanning tools will no longer flag this file
- Removes risk of key being reused in production configs

## Verification

- Test remains functionally identical — a valid 32-byte hex key is still set as the env var
- Only 1 file changed, 2 insertions, 2 deletions
- Based directly on upstream/gssoc — no merge conflicts

Fixes #2482
