### PR TITLE
[CRITICAL] Enforce password complexity requirements by default

### DIFF
--- a/Frontend/src/utils/passwordValidation.js
+++ b/Frontend/src/utils/passwordValidation.js
@@ -28,9 +28,9 @@ export function hasSequentialCharacters(password, span = 3) {
 export function getPasswordValidation(password, options = {}) {
   const {
     minLength = 8,
-    requireUppercase = false,
-    requireNumber = false,
-    requireSpecial = false,
+    requireUppercase = true,
+    requireNumber = true,
+    requireSpecial = true,
   } = options;
 
   return {


### PR DESCRIPTION
## Summary

Changes default password validation to require uppercase, number, and special characters. Previously all complexity checks defaulted to false, allowing trivially weak passwords.

## Changes

- **Frontend/src/utils/passwordValidation.js** — Changed defaults from \alse\ to \	rue\ for \equireUppercase\, \equireNumber\, \equireSpecial\

## Impact

- Severity: CRITICAL
- Prevents users from setting all-lowercase passwords like \aaaaaaa\
- Aligns with OWASP password security guidelines
- Significantly increases resistance to brute-force attacks

Fixes #2489