### PR TITLE
[CRITICAL] Add missing router includes to main.py - all API endpoints currently return 404

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,12 +6,27 @@ from fastapi.responses import JSONResponse
 
 from backend.csrf import CSRFTokenMiddleware, set_csrf_cookie, CSRF_COOKIE_NAME
 
+from backend.routers import tickets, ai, admin, health, auth
+from backend.routes import translation, estimator, voice, privacy, active_learning, weekly_digest
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
 app.add_middleware(CSRFTokenMiddleware)
+
+app.include_router(tickets.router)
+app.include_router(ai.router)
+app.include_router(admin.router)
+app.include_router(health.router)
+app.include_router(auth.router)
+app.include_router(translation.router)
+app.include_router(estimator.router)
+app.include_router(voice.router)
+app.include_router(privacy.router)
+app.include_router(active_learning.router)
+app.include_router(weekly_digest.router)
 
 
 @app.get("/auth/csrf-token")


### PR DESCRIPTION
## Summary

The FastAPI application entry point (\main.py\) created the app and added CSRF middleware but **never included any routers**. Every single API endpoint returned 404 because none of the 11 router modules were registered.

## Changes

- **main.py** — Added \pp.include_router()\ calls for all 11 router modules:
  - \ackend/routers/tickets.py\ — Ticket CRUD
  - \ackend/routers/ai.py\ — AI analysis, troubleshooting
  - \ackend/routers/admin.py\ — Admin profile/company management
  - \ackend/routers/health.py\ — Health check endpoints
  - \ackend/routers/auth.py\ — Authentication
  - \ackend/routes/translation.py\ — Translation API
  - \ackend/routes/estimator.py\ — SLA estimation
  - \ackend/routes/voice.py\ — Voice-to-ticket
  - \ackend/routes/privacy.py\ — Privacy/GDPR operations
  - \ackend/routes/active_learning.py\ — Active learning
  - \ackend/routes/weekly_digest.py\ — Weekly digest

## Impact

- Severity: CRITICAL
- All API endpoints now work instead of returning 404
- Without this fix, the entire backend application was non-functional despite booting successfully

## Verification

- Only 1 file changed, 15 insertions
- Based directly on upstream/gssoc — no merge conflicts

Fixes #2494