### PR TITLE
chore: add .prettierrc configuration file (closes #225) [clean]

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
## Summary

This is a **clean recreation** of PR #492 (which was closed due to GitGuardian detecting a Supabase secret in a different file within the same commit history).

This PR contains **only** a `.prettierrc` configuration file with zero secrets or sensitive data.

## What Changed

- **New:** `.prettierrc` — standard Prettier configuration with:
  - `semi: true` — semicolons for statement termination
  - `singleQuote: true` — consistent quote style
  - `tabWidth: 2` — standard indentation
  - `trailingComma: es5` — trailing commas in arrays/objects
  - `printWidth: 80` — line length limit
  - `bracketSpacing: true` — spaces inside object braces
  - `arrowParens: always` — consistent arrow function parens
  - `endOfLine: lf` — Unix-style line endings

## Why

Without an explicit Prettier config, different developers' editors may format files differently, causing style drift and noisy diffs in PRs. This provides a single source of truth for formatting rules.

## Security Self-Check

- ✅ No keys, tokens, passwords, or secrets in file content
- ✅ No `supabase`, `secret`, `password`, or `token` keywords
- ✅ Clean single commit — no polluted git history

## Related Issue

Closes #225