### PR TITLE
fix: close mobile sidebar on route navigation

### DIFF
--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -11,12 +11,13 @@ import NotificationToast from '../../user/components/NotificationToast';
  */
 const AdminLayout = () => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
   const location = useLocation();
 
   useEffect(() => {
     setIsMobileNavOpen(false);
   }, [location.pathname]);
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
   return (
     <div className='flex h-screen bg-[#f8faf9] overflow-hidden font-sans'>

--- a/Frontend/src/admin/layout/AdminLayout.jsx
+++ b/Frontend/src/admin/layout/AdminLayout.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Outlet, useLocation } from 'react-router-dom';
 import AdminSidebar from '../components/AdminSidebar';
 import AdminHeader from '../components/AdminHeader';
 import NotificationToast from '../../user/components/NotificationToast';
@@ -10,56 +10,64 @@ import NotificationToast from '../../user/components/NotificationToast';
  * Enforces a fixed-sidebar architecture with a centered, high-density content terminal.
  */
 const AdminLayout = () => {
-    const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
-    const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const location = useLocation();
 
-    return (
-        <div className="flex h-screen bg-[#f8faf9] overflow-hidden font-sans">
-            {/* Master Navigation Column (Responsive) */}
-            <div 
-                className={`hidden md:block flex-shrink-0 relative z-40 transition-all duration-300`}
-                style={{ width: isSidebarCollapsed ? '80px' : '260px' }}
-            >
-                <AdminSidebar isCollapsed={isSidebarCollapsed} onToggleCollapse={() => setIsSidebarCollapsed(!isSidebarCollapsed)} />
-            </div>
+  useEffect(() => {
+    setIsMobileNavOpen(false);
+  }, [location.pathname]);
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
 
-            {/* Viewport Execution Layer */}
-            <div className="flex-1 flex flex-col min-w-0 relative h-full">
-                {/* Global Command Header */}
-                <AdminHeader 
-                    onMobileNavToggle={() => setIsMobileNavOpen(!isMobileNavOpen)} 
-                    isSidebarCollapsed={isSidebarCollapsed}
-                    onToggleSidebar={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-                />
+  return (
+    <div className='flex h-screen bg-[#f8faf9] overflow-hidden font-sans'>
+      {/* Master Navigation Column (Responsive) */}
+      <div
+        className={`hidden md:block flex-shrink-0 relative z-40 transition-all duration-300`}
+        style={{ width: isSidebarCollapsed ? '80px' : '260px' }}
+      >
+        <AdminSidebar
+          isCollapsed={isSidebarCollapsed}
+          onToggleCollapse={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+        />
+      </div>
 
-                {/* Operational Workspace */}
-                <main className="flex-1 overflow-x-hidden overflow-y-auto custom-scrollbar relative">
-                    {/* Centered Payload Container */}
-                    <div className="max-w-[1280px] w-full mx-auto px-6 md:px-10 py-8 md:py-12 animate-in fade-in slide-in-from-bottom-6 duration-1000">
-                        <Outlet />
-                    </div>
-                </main>
-            </div>
+      {/* Viewport Execution Layer */}
+      <div className='flex-1 flex flex-col min-w-0 relative h-full'>
+        {/* Global Command Header */}
+        <AdminHeader
+          onMobileNavToggle={() => setIsMobileNavOpen(!isMobileNavOpen)}
+          isSidebarCollapsed={isSidebarCollapsed}
+          onToggleSidebar={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+        />
 
-            {/* Real-time System Notifications */}
-            <NotificationToast />
+        {/* Operational Workspace */}
+        <main className='flex-1 overflow-x-hidden overflow-y-auto custom-scrollbar relative'>
+          {/* Centered Payload Container */}
+          <div className='max-w-[1280px] w-full mx-auto px-6 md:px-10 py-8 md:py-12 animate-in fade-in slide-in-from-bottom-6 duration-1000'>
+            <Outlet />
+          </div>
+        </main>
+      </div>
 
-            {/* Mobile Nav Overlay (Emergency protocols) */}
-            {isMobileNavOpen && (
-                <div
-                    className="fixed inset-0 bg-slate-900/80 backdrop-blur-md z-50 lg:hidden flex transition-opacity duration-300"
-                    onClick={() => setIsMobileNavOpen(false)}
-                >
-                    <div
-                        className="w-[85%] max-w-[280px] h-full shadow-2xl animate-in slide-in-from-left duration-300"
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <AdminSidebar isMobile={true} onClose={() => setIsMobileNavOpen(false)} />
-                    </div>
-                </div>
-            )}
+      {/* Real-time System Notifications */}
+      <NotificationToast />
+
+      {/* Mobile Nav Overlay (Emergency protocols) */}
+      {isMobileNavOpen && (
+        <div
+          className='fixed inset-0 bg-slate-900/80 backdrop-blur-md z-50 lg:hidden flex transition-opacity duration-300'
+          onClick={() => setIsMobileNavOpen(false)}
+        >
+          <div
+            className='w-[85%] max-w-[280px] h-full shadow-2xl animate-in slide-in-from-left duration-300'
+            onClick={(e) => e.stopPropagation()}
+          >
+            <AdminSidebar isMobile={true} onClose={() => setIsMobileNavOpen(false)} />
+          </div>
         </div>
-    );
+      )}
+    </div>
+  );
 };
 
 export default AdminLayout;


### PR DESCRIPTION
## What does this PR do?
Fixes the mobile sidebar remaining open when navigating between dashboard pages.

## Related Issue
Closes #2504

## Changes made
- Imported useLocation and useEffect in AdminLayout.jsx
- Added useEffect to call setIsMobileNavOpen(false) on location.pathname change

## How to test
1. Open app in Chrome DevTools mobile view (press F12 → click phone icon)
2. Open the mobile sidebar
3. Click any navigation link
4. Sidebar should now automatically close

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile navigation overlay now automatically closes when navigating between pages.

* **Refactor**
  * Sidebar collapse/expand behavior improved with more consistent state handling between header and sidebar for predictable toggling and responsive layout.

* **Style**
  * JSX markup and component structure reformatted for consistent styling and clearer markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->