### PR TITLE
perf(backend): share sentence-transformer model via ModelRegistry singleton

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -5,7 +5,7 @@ Uses sentence-transformers all-MiniLM-L6-v2 to detect similar tickets.
 
 import uuid
 import os
-from sentence_transformers import SentenceTransformer, util
+from sentence_transformers import util
 
 SIMILARITY_THRESHOLD = 0.70
 
@@ -31,14 +31,8 @@ class DuplicateService:
         
         print("[DuplicateService] Loading model...")
         try:
-            # Check if a local model path is provided
-            model_path = os.environ.get("SENTENCE_TRANSFORMER_MODEL_PATH")
-            if model_path and os.path.exists(model_path):
-                print(f"[DuplicateService] Loading from local path: {model_path}")
-                self.model = SentenceTransformer(model_path)
-            else:
-                # Download from HuggingFace
-                self.model = SentenceTransformer("all-MiniLM-L6-v2")
+            from backend.services.model_registry import get_sentence_transformer
+            self.model = get_sentence_transformer()
             self._loaded = True
             
             if os.path.exists(self.storage_file):

--- a/backend/services/model_registry.py
+++ b/backend/services/model_registry.py
@@ -1,0 +1,35 @@
+"""
+Shared Model Registry
+Ensures expensive models (sentence-transformers, etc.) are loaded only once
+and shared across all consuming services. Eliminates redundant memory from
+DuplicateService and RagService each loading their own copy of all-MiniLM-L6-v2.
+"""
+
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+_sentence_transformer_model = None
+_sentence_transformer_loaded = False
+
+
+def get_sentence_transformer():
+    """Return the shared SentenceTransformer instance, loading it on first call."""
+    global _sentence_transformer_model, _sentence_transformer_loaded
+
+    if _sentence_transformer_loaded:
+        return _sentence_transformer_model
+
+    from sentence_transformers import SentenceTransformer
+
+    model_path = os.environ.get("SENTENCE_TRANSFORMER_MODEL_PATH")
+    if model_path and os.path.exists(model_path):
+        logger.info("[ModelRegistry] Loading SentenceTransformer from %s", model_path)
+        _sentence_transformer_model = SentenceTransformer(model_path)
+    else:
+        logger.info("[ModelRegistry] Loading SentenceTransformer all-MiniLM-L6-v2 from HuggingFace")
+        _sentence_transformer_model = SentenceTransformer("all-MiniLM-L6-v2")
+
+    _sentence_transformer_loaded = True
+    return _sentence_transformer_model

--- a/backend/services/rag_service.py
+++ b/backend/services/rag_service.py
@@ -1,5 +1,4 @@
 import os
-from sentence_transformers import SentenceTransformer
 from supabase import create_client, Client
 from dotenv import load_dotenv
 
@@ -28,14 +27,8 @@ class RagService:
         
         print("[RAG] Loading SentenceTransformer for Knowledge Base...")
         try:
-            # Check if a local model path is provided
-            model_path = os.environ.get("SENTENCE_TRANSFORMER_MODEL_PATH")
-            if model_path and os.path.exists(model_path):
-                print(f"[RAG] Loading from local path: {model_path}")
-                self.model = SentenceTransformer(model_path)
-            else:
-                # Download from HuggingFace
-                self.model = SentenceTransformer('all-MiniLM-L6-v2')
+            from backend.services.model_registry import get_sentence_transformer
+            self.model = get_sentence_transformer()
             self._loaded = True
             print("[RAG] Model loaded successfully.")
         except Exception as e:


### PR DESCRIPTION
Closes #2516

## Problem
DuplicateService and RagService each independently loaded all-MiniLM-L6-v2 (~90MB), doubling memory for the same sentence-transformer model. Combined with 4 other transformer models (classifier V1, V3, NER), the total memory footprint reached ~1.5GB, regularly triggering OOM kills on the 2GB Hugging Face Space.

## Fix
Introduces a shared ModelRegistry singleton that loads the sentence-transformer model exactly once. Both services request the model from the registry, receiving the same cached instance.

### Files changed
- \ackend/services/model_registry.py\ (new) — get_sentence_transformer() singleton with env-aware path resolution
- \ackend/services/duplicate_service.py\ — use registry instead of direct SentenceTransformer() call
- \ackend/services/rag_service.py\ — use registry instead of direct SentenceTransformer() call

### Savings
- Eliminates ~90MB of duplicate model RAM
- No change to service interfaces or behavior
- Registry supports SENTENCE_TRANSFORMER_MODEL_PATH env var (same as before)