### PR TITLE
fix: preserve local OCR text in request_body when analyzing ticket

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from contextlib import asynccontextmanager
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, Response
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
@@ -725,6 +725,8 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
         local_ocr_text = ocr_service.extract_text(request_body.image_base64)
         if local_ocr_text:
             text = f"{text} {local_ocr_text}".strip()
+            request_body.text = text
+            request_body.image_text = local_ocr_text
             print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
 
     # Initalize Timeline


### PR DESCRIPTION
Fixes #2572

Changes Made
main.py
Added the missing import for Response from fastapi at the top:
python

from fastapi import FastAPI, Depends, HTTPException, Request, Response
Assigned local OCR results back to the Pydantic request body attributes inside the analyze_ticket endpoint:
python

        if local_ocr_text:
            text = f"{text} {local_ocr_text}".strip()
            request_body.text = text
            request_body.image_text = local_ocr_text
            print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
Verification & Testing
Ran automated tests in 
test_local_ocr.py
 mocking ocr_service and other services to verify that the extracted local OCR text is correctly set on request_body and utilized in downstream classification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing import that was preventing cookie and session helper methods from functioning correctly within API endpoints.

* **Refactor**
  * Improved OCR text handling in ticket analysis by separating extracted OCR content into a dedicated field, enabling more effective OCR-aware analysis and enhancing downstream processing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->