### PR TITLE
fix: guard malformed realtime notification payloads

### DIFF
--- a/Frontend/src/hooks/useTicketsRealtime.js
+++ b/Frontend/src/hooks/useTicketsRealtime.js
@@ -13,6 +13,29 @@ const makeChannelName = (baseName, company) => {
     return `${baseName}_${safeCompany}`;
 };
 
+const REALTIME_EVENTS = new Set(['INSERT', 'UPDATE', 'DELETE']);
+
+const isRecord = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const isValidTicketRealtimePayload = (payload) => {
+    if (!isRecord(payload) || !REALTIME_EVENTS.has(payload.eventType)) {
+        return false;
+    }
+
+    if (payload.eventType === 'DELETE') {
+        return isRecord(payload.old);
+    }
+
+    return isRecord(payload.new);
+};
+
+const warnMalformedRealtimePayload = (payload, error) => {
+    console.warn('useTicketsRealtime: ignored malformed realtime payload', {
+        payload,
+        error: error instanceof Error ? error.message : error,
+    });
+};
+
 const useTicketsRealtime = ({
     company,
     enabled = true,
@@ -42,20 +65,16 @@ const useTicketsRealtime = ({
                     ...(realtimeFilter ? { filter: realtimeFilter } : {}),
                 },
                 (payload) => {
+                    if (!isValidTicketRealtimePayload(payload)) {
+                        warnMalformedRealtimePayload(payload);
+                        return;
+                    }
+
                     try {
-                        if (!payload || typeof payload !== 'object') {
-                            throw new Error('Invalid socket payload format: expected object');
-                        }
-
                         const ticket = payload.new || payload.old;
-                        if (!ticket || typeof ticket !== 'object') {
-                            console.warn('Realtime payload missing ticket data, ignoring.', payload);
-                            return;
-                        }
-
                         const ticketId = getTicketRecordId(ticket);
                         if (!ticketId) {
-                            console.warn('Realtime payload missing ticket ID, ignoring.', payload);
+                            warnMalformedRealtimePayload(payload, 'Missing ticket ID');
                             return;
                         }
 
@@ -91,8 +110,8 @@ const useTicketsRealtime = ({
                                 setLastChangedTicketId(null);
                             }, 3500);
                         }
-                    } catch (err) {
-                        console.error('Caught error processing realtime notification payload:', err);
+                    } catch (error) {
+                        warnMalformedRealtimePayload(payload, error);
                     }
                 },
             )

--- a/Frontend/src/hooks/useTicketsRealtime.structure.test.js
+++ b/Frontend/src/hooks/useTicketsRealtime.structure.test.js
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert';
+import test from 'node:test';
+
+const source = readFileSync('Frontend/src/hooks/useTicketsRealtime.js', 'utf8');
+
+test('validates realtime payload event and record shape before store updates', () => {
+  assert.match(source, /const REALTIME_EVENTS = new Set\(\['INSERT', 'UPDATE', 'DELETE'\]\)/);
+  assert.match(source, /REALTIME_EVENTS\.has\(payload\.eventType\)/);
+  assert.match(source, /return isRecord\(payload\.old\)/);
+  assert.match(source, /return isRecord\(payload\.new\)/);
+});
+
+test('malformed realtime payloads are ignored before reducer updates run', () => {
+  const guardIndex = source.indexOf('if (!isValidTicketRealtimePayload(payload))');
+  const updateIndex = source.indexOf('applyTicketRealtimePayload(currentTickets, payload');
+
+  assert.notStrictEqual(guardIndex, -1);
+  assert.notStrictEqual(updateIndex, -1);
+  assert.ok(guardIndex < updateIndex);
+});
+
+test('unexpected realtime processing errors are caught and logged', () => {
+  assert.match(source, /try \{/);
+  assert.match(source, /catch \(error\) \{/);
+  assert.match(source, /warnMalformedRealtimePayload\(payload, error\)/);
+});


### PR DESCRIPTION
## Summary
- add event-type and record-shape validation before ticket realtime payloads reach reducers or stores
- catch unexpected realtime processing errors so malformed socket payloads are logged and ignored instead of crashing the page
- add a focused structure regression test for the live `useTicketsRealtime` hook

Closes #2174

## Tests
- `node --check Frontend/src/hooks/useTicketsRealtime.js`
- `node --test Frontend/src/hooks/useTicketsRealtime.structure.test.js`
- `git diff --check origin/gssoc..HEAD`
