### PR TITLE
fix: add missing Response import from fastapi

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,7 +19,7 @@ from contextlib import asynccontextmanager
 warnings.filterwarnings("ignore", message="'pin_memory'")
 
 # HF Rebuild Trigger: 2026-03-08-2030
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException, Request, Response
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded


### PR DESCRIPTION
# ix: Add Missing Response Import from FastAPI
## Problem
Auth cookie endpoints ( /auth/login , /auth/signup , /auth/logout ) specify response: Response in method signatures, but Response wasn't imported from fastapi , causing a NameError at runtime.

## Solution
Added Response to the FastAPI imports:

```
from fastapi import FastAPI, Depends, HTTPException, 
Request, Response
```
Closes #2605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend imports to align with codebase usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->