### PR TITLE
feat: add visible scrollbar with custom styling

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -93,12 +93,25 @@
 
 html{
   overflow-y: scroll;
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: #618975 #f6f8f7; /* Firefox: thumb, track */
 }
 
 html::-webkit-scrollbar{
-  width: 0;
-  height: 0;
+  width: 8px;
+}
+
+html::-webkit-scrollbar-track{
+  background: #f6f8f7;
+}
+
+html::-webkit-scrollbar-thumb{
+  background: #618975;
+  border-radius: 10px;
+}
+
+html::-webkit-scrollbar-thumb:hover{
+  background: #4a6a5a;
 }
 
 body{


### PR DESCRIPTION
# Feature: Add Visible Custom Scrollbar
## Problem
The website had a hidden scrollbar, making it hard for users to navigate pages.

## Solution
This PR makes the scrollbar visible with custom styling that matches the website's design:

### Key Changes
- Updated index.css to show scrollbar instead of hiding it
- Custom scrollbar styling:
  - Thumb color: #618975 (matches muted text color)
  - Track color: #f6f8f7 (matches site background)
  - Hover state: #4a6a5a (darker version of thumb)
  - Thumb border-radius: 10px for a rounded look
  - Scrollbar width: 8px (thin but visible)
  - Firefox support: scrollbar-width: thin and scrollbar-color properties
Closes #2645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the application's visual appearance with updated global scrollbar styling. Scrollbars now display with custom colors and width settings throughout the interface, replacing the previously hidden state. This styling improvement ensures consistent scrollbar appearance across all browsers and devices, contributing to a more polished and cohesive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->