### PR TITLE
test: add coverage for auto-close and notification routing services

### DIFF
--- a/backend/tests/test_auto_close_service.py
+++ b/backend/tests/test_auto_close_service.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock, patch
+from backend.services.auto_close_service import AutoCloseService, load
+
+
+@patch("backend.services.auto_close_service.create_client")
+def test_service_disabled(mock_create_client):
+    """Verify the service exits early when auto-close is disabled."""
+    
+    service = AutoCloseService()
+    service.enabled = False
+
+    result = service.run()
+
+    assert result == {"status": "disabled"}
+
+
+@patch("backend.services.auto_close_service.create_client")
+def test_default_settings_returned_on_failure(mock_create_client):
+    """Verify default settings are returned when the database query fails."""
+
+    mock_supabase = MagicMock()
+    mock_create_client.return_value = mock_supabase
+
+    # Simulate a database failure while fetching settings
+    mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.side_effect = Exception(
+        "DB Error"
+    )
+
+    service = AutoCloseService()
+
+    settings = service.get_system_settings("company-1")
+
+    assert settings["auto_close_days"] == service.default_auto_close_days
+    assert settings["auto_close_enabled"] is True
+
+
+@patch("backend.services.auto_close_service.create_client")
+def test_close_ticket_updates_stats(mock_create_client):
+    """Verify successful ticket closure updates statistics correctly."""
+
+    mock_supabase = MagicMock()
+    mock_create_client.return_value = mock_supabase
+
+    service = AutoCloseService()
+
+    stats = {
+        "closed_count": 0,
+        "error_count": 0,
+    }
+
+    result = service._close_ticket(
+        "ticket-1",
+        "company-1",
+        stats,
+    )
+
+    assert result is True
+    assert stats["closed_count"] == 1
+
+
+@patch("backend.services.auto_close_service.create_client")
+def test_test_query_returns_empty_list_on_failure(mock_create_client):
+    """Verify test_query returns an empty list when database access fails."""
+
+    mock_supabase = MagicMock()
+    mock_create_client.return_value = mock_supabase
+
+    # Simulate database failure during sample query execution
+    mock_supabase.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.side_effect = Exception(
+        "DB Error"
+    )
+
+    service = AutoCloseService()
+
+    result = service.test_query()
+
+    assert result == []
+
+
+@patch("backend.services.auto_close_service.create_client")
+def test_load_returns_singleton(mock_create_client):
+    """Verify load() returns the same singleton instance."""
+
+    first = load()
+    second = load()
+
+    assert first is second

--- a/backend/tests/test_notification_routing.py
+++ b/backend/tests/test_notification_routing.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for NotificationRoutingMiddleware.
+
+These tests validate notification gating behavior,
+fallback handling, cache invalidation, and singleton loading.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from backend.services.notification_routing import (
+    NotificationRoutingMiddleware,
+    NotificationType,
+    load,
+)
+
+
+@patch("backend.services.notification_routing.create_client")
+def test_email_notifications_disabled(mock_create_client):
+    """Verify email notifications are blocked when disabled."""
+
+    mock_create_client.return_value = MagicMock()
+
+    middleware = NotificationRoutingMiddleware()
+    middleware._settings_cache["company-1"] = {
+        "email_notifications": False,
+        "admin_alerts": True,
+        "digest_frequency": "daily",
+    }
+
+    result = middleware.should_send_email_notification(
+        "company-1",
+        NotificationType.TICKET_ALERT,
+    )
+
+    assert result is False
+
+
+@patch("backend.services.notification_routing.create_client")
+def test_admin_alerts_disabled(mock_create_client):
+    """Verify admin alerts are blocked when disabled."""
+
+    mock_create_client.return_value = MagicMock()
+
+    middleware = NotificationRoutingMiddleware()
+    middleware._settings_cache["company-1"] = {
+        "email_notifications": True,
+        "admin_alerts": False,
+        "digest_frequency": "daily",
+    }
+
+    result = middleware.should_send_admin_alert("company-1")
+
+    assert result is False
+
+
+@patch("backend.services.notification_routing.create_client")
+def test_default_settings_returned_on_failure(mock_create_client):
+    """Verify fail-open behavior when settings lookup fails."""
+
+    mock_supabase = MagicMock()
+    mock_create_client.return_value = mock_supabase
+
+    mock_supabase.table.return_value.select.return_value.eq.return_value.single.return_value.execute.side_effect = Exception(
+        "DB Error"
+    )
+
+    middleware = NotificationRoutingMiddleware()
+
+    settings = middleware.get_system_settings("company-1")
+
+    assert settings["email_notifications"] is True
+    assert settings["admin_alerts"] is True
+    assert settings["digest_frequency"] == "daily"
+
+
+@patch("backend.services.notification_routing.create_client")
+def test_cache_invalidation(mock_create_client):
+    """Verify cached company settings can be invalidated."""
+
+    mock_create_client.return_value = MagicMock()
+
+    middleware = NotificationRoutingMiddleware()
+
+    middleware._settings_cache["company-1"] = {
+        "email_notifications": True,
+        "admin_alerts": True,
+        "digest_frequency": "daily",
+    }
+
+    middleware.invalidate_cache("company-1")
+
+    assert "company-1" not in middleware._settings_cache
+
+
+@patch("backend.services.notification_routing.create_client")
+def test_load_returns_singleton(mock_create_client):
+    """Verify load() returns the same singleton instance."""
+
+    first = load()
+    second = load()
+
+    assert first is second


### PR DESCRIPTION
## What does this PR do?

This PR adds an automated unit test suite for the newly introduced backend services:

* AutoCloseService
* NotificationRoutingMiddleware

The tests validate core functionality, fallback behavior, cache handling, singleton loading, and notification gating logic without requiring a live Supabase instance.

## Related Issue

Closes #2649 

## Changes Made

### AutoCloseService Tests

* Verify service exits correctly when disabled
* Verify default settings are returned when database access fails
* Verify ticket closure updates statistics correctly
* Verify test query returns an empty list on failure
* Verify singleton loading behavior

### NotificationRoutingMiddleware Tests

* Verify email notifications are blocked when disabled
* Verify admin alerts are blocked when disabled
* Verify fail-open behavior when settings retrieval fails
* Verify cache invalidation functionality
* Verify singleton loading behavior

## Testing

```bash
python -m pytest backend/tests -v
```

All tests pass successfully.

## Checklist

* [x] Tests added
* [x] Existing functionality unchanged
* [x] No live database dependency required
* [x] Code follows project guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for auto-close service, including disabled state handling, system settings, ticket closing functionality, and singleton initialization.
  * Added comprehensive test coverage for notification routing, covering notification gating, default settings fallback, cache invalidation, and singleton pattern verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->