### PR TITLE
Fix/2660 thread safe middleware

### DIFF
--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -56,6 +56,7 @@ class NotificationRoutingMiddleware:
             os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self._settings_cache: Dict[str, Dict] = {}
+        self._cache_lock = threading.Lock()
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()
 
     def _fetch_system_settings(self, company_id: str) -> Dict:
@@ -92,16 +93,15 @@ class NotificationRoutingMiddleware:
     def get_system_settings(self, company_id: str) -> Dict:
         """
         Get company settings with caching.
-        
-        Args:
-            company_id: UUID of company
-            
-        Returns:
-            Dict with company notification preferences
+        ...
         """
-        if company_id not in self._settings_cache:
-            self._settings_cache[company_id] = self._fetch_system_settings(company_id)
-        return self._settings_cache[company_id]
+        with self._cache_lock:
+            if company_id not in self._settings_cache:
+                # We pull the heavy database fetch outside the lock context if needed,
+                # but since we are inserting into the dict safely, we evaluate here.
+                settings = self._fetch_system_settings(company_id)
+                self._settings_cache[company_id] = settings
+            return self._settings_cache[company_id]
 
     def should_send_email_notification(self, company_id: str, notification_type: NotificationType) -> bool:
         """
@@ -215,26 +215,30 @@ class NotificationRoutingMiddleware:
     def invalidate_cache(self, company_id: str) -> None:
         """
         Invalidate cached settings for a company.
-        Call this after updating system_settings in DB.
-        
-        Args:
-            company_id: UUID of company
+        ...
         """
-        if company_id in self._settings_cache:
-            del self._settings_cache[company_id]
-            logger.info(f"Invalidated settings cache for company {company_id}")
+        with self._cache_lock:
+            if company_id in self._settings_cache:
+                del self._settings_cache[company_id]
+                logger.info(f"Invalidated settings cache for company {company_id}")
 
 
-# Singleton instance
+
+import threading
+
+# Singleton instance and initialization lock
 _instance: Optional[NotificationRoutingMiddleware] = None
-
+_instance_lock = threading.Lock()
 
 def load():
     """Load and return singleton instance of NotificationRoutingMiddleware."""
     global _instance
     if _instance is None:
-        _instance = NotificationRoutingMiddleware()
-        logger.info("NotificationRoutingMiddleware loaded")
+        with _instance_lock:
+            # Double-checked locking pattern
+            if _instance is None:
+                _instance = NotificationRoutingMiddleware()
+                logger.info("NotificationRoutingMiddleware loaded")
     return _instance
 
 


### PR DESCRIPTION
## Description
This PR resolves a multi-threading race condition in the `NotificationRoutingMiddleware` where concurrent operations under threaded workers (e.g., Gunicorn/Uvicorn) could trigger duplicate instantiations of the global singleton or throw a `RuntimeError: dictionary changed size during iteration` during cache mutations.

## Changes
- **Thread-safe Singleton Initialization**: Implemented a Double-Checked Locking pattern using `threading.Lock()` inside the global `load()` function to ensure safe instantiation.
- **Thread-safe Cache Mutations**: Added an internal `_cache_lock` to the middleware instance to safely serialize concurrent read, write, and delete operations on `self._settings_cache`.

## Related Issues
Closes #2660

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented thread-safe notification routing to prevent race conditions under concurrent load.

* **Chores**
  * Optimized duplicate ticket detection by caching embeddings to reduce recomputation overhead.
  * Updated model artifacts for improved detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->