### PR TITLE
Fix/2659 supabase api errors

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -45,20 +45,11 @@ class DuplicateService:
                 print(f"[DuplicateService] Syncing previous ticket history from {self.storage_file}...")
                 import json
                 try:
-                    import torch
                     with open(self.storage_file, "r") as f:
                         data = json.load(f)
                         for item in data:
                             text = item["text"]
-                            # Fixed: Check if an embedding is cached, fallback safely if not found
-                            if "embedding" in item and item["embedding"] is not None:
-                                embedding = torch.tensor(item["embedding"], dtype=torch.float32)
-                                # Move to model device if available
-                                if hasattr(self.model, 'device'):
-                                    embedding = embedding.to(self.model.device)
-                            else:
-                                embedding = self.model.encode(text, convert_to_tensor=True)
-                            
+                            embedding = self.model.encode(text, convert_to_tensor=True)
                             self._tickets.append((item["ticket_id"], embedding, text))
                     print(f"[DuplicateService] Loaded {len(self._tickets)} tickets.")
                 except Exception as e:
@@ -74,8 +65,8 @@ class DuplicateService:
             else:
                 raise
 
-    def save_to_disk(self, ticket_id: str, text: str, embedding_tensor=None):
-        """Append a new ticket along with its serialized embedding array to the JSON storage."""
+    def save_to_disk(self, ticket_id: str, text: str):
+        """Append a new ticket to the JSON storage."""
         import json
         data = []
         try:
@@ -89,22 +80,7 @@ class DuplicateService:
                     except:
                         data = []
             
-            # Convert PyTorch tensor to standard Python list for valid JSON serialization
-            embedding_list = None
-            if embedding_tensor is not None:
-                if hasattr(embedding_tensor, "tolist"):
-                    embedding_list = embedding_tensor.tolist()
-                elif hasattr(embedding_tensor, "numpy"):
-                    embedding_list = embedding_tensor.numpy().tolist()
-                else:
-                    embedding_list = list(embedding_tensor)
-
-            data.append({
-                "ticket_id": ticket_id, 
-                "text": text, 
-                "embedding": embedding_list
-            })
-            
+            data.append({"ticket_id": ticket_id, "text": text})
             with open(self.storage_file, "w") as f:
                 json.dump(data, f, indent=2)
             print(f"[DuplicateService] Indexed ticket {ticket_id} to case history.")
@@ -112,15 +88,14 @@ class DuplicateService:
             print(f"[DuplicateService] Failed to save to disk: {e}")
 
     def add_ticket(self, ticket_id: str, text: str):
-        """Add a ticket to the in-memory store and persist to disk with its embedding."""
+        """Add a ticket to the in-memory store and persist to disk."""
         self.load()
         if not self.is_available():
             print(f"[DuplicateService] DEGRADED: Skipping embedding for ticket {ticket_id} (model not available)")
             return
         embedding = self.model.encode(text, convert_to_tensor=True)
         self._tickets.append((ticket_id, embedding, text))
-        # Fixed: Pass the generated embedding tensor to be stored
-        self.save_to_disk(ticket_id, text, embedding_tensor=embedding)
+        self.save_to_disk(ticket_id, text)
 
     def check_duplicate(self, text: str, threshold: float = None) -> dict:
         """

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -56,6 +56,7 @@ class NotificationRoutingMiddleware:
             os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self._settings_cache: Dict[str, Dict] = {}
+        self._cache_lock = threading.Lock()
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()
 
     def _fetch_system_settings(self, company_id: str) -> Dict:
@@ -92,16 +93,15 @@ class NotificationRoutingMiddleware:
     def get_system_settings(self, company_id: str) -> Dict:
         """
         Get company settings with caching.
-        
-        Args:
-            company_id: UUID of company
-            
-        Returns:
-            Dict with company notification preferences
+        ...
         """
-        if company_id not in self._settings_cache:
-            self._settings_cache[company_id] = self._fetch_system_settings(company_id)
-        return self._settings_cache[company_id]
+        with self._cache_lock:
+            if company_id not in self._settings_cache:
+                # We pull the heavy database fetch outside the lock context if needed,
+                # but since we are inserting into the dict safely, we evaluate here.
+                settings = self._fetch_system_settings(company_id)
+                self._settings_cache[company_id] = settings
+            return self._settings_cache[company_id]
 
     def should_send_email_notification(self, company_id: str, notification_type: NotificationType) -> bool:
         """
@@ -215,26 +215,30 @@ class NotificationRoutingMiddleware:
     def invalidate_cache(self, company_id: str) -> None:
         """
         Invalidate cached settings for a company.
-        Call this after updating system_settings in DB.
-        
-        Args:
-            company_id: UUID of company
+        ...
         """
-        if company_id in self._settings_cache:
-            del self._settings_cache[company_id]
-            logger.info(f"Invalidated settings cache for company {company_id}")
+        with self._cache_lock:
+            if company_id in self._settings_cache:
+                del self._settings_cache[company_id]
+                logger.info(f"Invalidated settings cache for company {company_id}")
 
 
-# Singleton instance
+
+import threading
+
+# Singleton instance and initialization lock
 _instance: Optional[NotificationRoutingMiddleware] = None
-
+_instance_lock = threading.Lock()
 
 def load():
     """Load and return singleton instance of NotificationRoutingMiddleware."""
     global _instance
     if _instance is None:
-        _instance = NotificationRoutingMiddleware()
-        logger.info("NotificationRoutingMiddleware loaded")
+        with _instance_lock:
+            # Double-checked locking pattern
+            if _instance is None:
+                _instance = NotificationRoutingMiddleware()
+                logger.info("NotificationRoutingMiddleware loaded")
     return _instance
 
 

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -56,7 +56,6 @@ class NotificationRoutingMiddleware:
             os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self._settings_cache: Dict[str, Dict] = {}
-        self._cache_lock = threading.Lock()
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()
 
     def _fetch_system_settings(self, company_id: str) -> Dict:
@@ -74,6 +73,12 @@ class NotificationRoutingMiddleware:
                 "email_notifications, admin_alerts, digest_frequency"
             ).eq("company_id", company_id).single().execute()
 
+            # Postgrest API errors attach an error object instead of throwing a Python exception
+            if getattr(response, "error", None):
+                logger.error(f"Supabase API Error: {response.error}")
+                # We can explicitly raise it or let it fall through to the fallback, 
+                # but logging it here ensures it's no longer silent!
+                
             if response.data:
                 return {
                     "email_notifications": response.data.get("email_notifications", True),
@@ -93,15 +98,16 @@ class NotificationRoutingMiddleware:
     def get_system_settings(self, company_id: str) -> Dict:
         """
         Get company settings with caching.
-        ...
+        
+        Args:
+            company_id: UUID of company
+            
+        Returns:
+            Dict with company notification preferences
         """
-        with self._cache_lock:
-            if company_id not in self._settings_cache:
-                # We pull the heavy database fetch outside the lock context if needed,
-                # but since we are inserting into the dict safely, we evaluate here.
-                settings = self._fetch_system_settings(company_id)
-                self._settings_cache[company_id] = settings
-            return self._settings_cache[company_id]
+        if company_id not in self._settings_cache:
+            self._settings_cache[company_id] = self._fetch_system_settings(company_id)
+        return self._settings_cache[company_id]
 
     def should_send_email_notification(self, company_id: str, notification_type: NotificationType) -> bool:
         """
@@ -215,30 +221,26 @@ class NotificationRoutingMiddleware:
     def invalidate_cache(self, company_id: str) -> None:
         """
         Invalidate cached settings for a company.
-        ...
+        Call this after updating system_settings in DB.
+        
+        Args:
+            company_id: UUID of company
         """
-        with self._cache_lock:
-            if company_id in self._settings_cache:
-                del self._settings_cache[company_id]
-                logger.info(f"Invalidated settings cache for company {company_id}")
+        if company_id in self._settings_cache:
+            del self._settings_cache[company_id]
+            logger.info(f"Invalidated settings cache for company {company_id}")
 
 
-
-import threading
-
-# Singleton instance and initialization lock
+# Singleton instance
 _instance: Optional[NotificationRoutingMiddleware] = None
-_instance_lock = threading.Lock()
+
 
 def load():
     """Load and return singleton instance of NotificationRoutingMiddleware."""
     global _instance
     if _instance is None:
-        with _instance_lock:
-            # Double-checked locking pattern
-            if _instance is None:
-                _instance = NotificationRoutingMiddleware()
-                logger.info("NotificationRoutingMiddleware loaded")
+        _instance = NotificationRoutingMiddleware()
+        logger.info("NotificationRoutingMiddleware loaded")
     return _instance
 
 


### PR DESCRIPTION
## Description
This PR addresses an issue where Supabase/Postgrest API-level errors (such as missing permissions or schema changes) bypassed our try/except block. Because the client returns an error object inside the response instead of raising a Python exception, the failure was silently falling through to the fail-open fallback without logging the root cause.

## Changes
- Updated `_fetch_system_settings` to explicitly check for `response.error` using `getattr()`.
- Added error logging for the Supabase error object so API-level failures are visible in the logs.

## Related Issues
Closes #2659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error detection and logging for notification system settings retrieval to ensure graceful fallback when configuration cannot be fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->