### PR TITLE
Add auth role guard dependencies

### DIFF
--- a/backend/auth_cookie.py
+++ b/backend/auth_cookie.py
@@ -136,6 +136,29 @@ def _clear_session_cookies(response: Response) -> None:
     response.delete_cookie(REFRESH_COOKIE, path=kwargs["path"])
 
 
+def get_user_role(user: dict | None) -> str:
+    """Return the normalized role from Supabase user metadata or direct payload."""
+    if not user:
+        return "user"
+
+    metadata = user.get("user_metadata") or {}
+    app_metadata = user.get("app_metadata") or {}
+    role = (
+        user.get("role")
+        or metadata.get("role")
+        or app_metadata.get("role")
+        or app_metadata.get("user_role")
+        or "user"
+    )
+    return str(role).strip().lower().replace("-", "_") or "user"
+
+
+ADMIN_ROLES = frozenset({"admin", "company_admin", "super_admin", "master_admin"})
+AGENT_ROLES = frozenset(
+    {"agent", "support_agent", "admin", "company_admin", "super_admin", "master_admin"}
+)
+
+
 async def get_current_user(request: Request) -> dict:
     token = extract_token(request)
     if not token:
@@ -164,6 +187,28 @@ async def get_current_user(request: Request) -> dict:
     if hasattr(user, "dict"):
         return user.dict()
     return dict(user)
+
+
+def require_roles(*allowed_roles: str):
+    """Build a FastAPI dependency that rejects authenticated users without a role."""
+    normalized_roles = {
+        role.strip().lower().replace("-", "_") for role in allowed_roles
+    }
+
+    async def _dependency(user: dict = Depends(get_current_user)) -> dict:
+        role = get_user_role(user)
+        if role not in normalized_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient role permissions",
+            )
+        return user
+
+    return _dependency
+
+
+get_current_active_admin = require_roles(*ADMIN_ROLES)
+get_current_active_agent = require_roles(*AGENT_ROLES)
 
 
 class LoginBody(BaseModel):

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import sys
 import hmac
@@ -12,6 +13,8 @@ from backend.auth_cookie import (
     ACCESS_COOKIE,
     REFRESH_COOKIE,
     extract_token,
+    get_user_role,
+    require_roles,
     _cookie_kwargs,
     _set_session_cookies,
     _clear_session_cookies,
@@ -46,6 +49,47 @@ class _FakeSession:
     def __init__(self, access_token: str = "acc-tok", refresh_token: str = "ref-tok"):
         self.access_token = access_token
         self.refresh_token = refresh_token
+
+
+# ---------------------------------------------------------------------------
+# RBAC role helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_user_role_defaults_to_user():
+    assert get_user_role({}) == "user"
+    assert get_user_role(None) == "user"
+
+
+def test_get_user_role_prefers_direct_role_and_normalizes():
+    assert get_user_role({"role": "Company-Admin"}) == "company_admin"
+
+
+def test_get_user_role_reads_supabase_user_metadata():
+    user = {"user_metadata": {"role": "support-agent"}}
+    assert get_user_role(user) == "support_agent"
+
+
+def test_get_user_role_reads_supabase_app_metadata():
+    user = {"app_metadata": {"user_role": "Master-Admin"}}
+    assert get_user_role(user) == "master_admin"
+
+
+def test_require_roles_allows_matching_role():
+    dependency = require_roles("admin")
+    result = asyncio.run(dependency({"user_metadata": {"role": "admin"}}))
+    assert result == {"user_metadata": {"role": "admin"}}
+
+
+def test_require_roles_rejects_non_matching_role():
+    dependency = require_roles("admin")
+    try:
+        asyncio.run(dependency({"user_metadata": {"role": "user"}}))
+    except Exception as exc:
+        assert exc.status_code == 403
+        assert exc.detail == "Insufficient role permissions"
+    else:
+        raise AssertionError("Expected HTTPException")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- add normalized Supabase role extraction from direct, user_metadata, and app_metadata payloads
- add reusable FastAPI role guard dependency factory
- expose admin and agent role guard dependencies for protected routes
- add focused RBAC helper tests

Refs #2670

Testing:
- python3 -m py_compile backend/auth_cookie.py backend/tests/test_auth_cookie.py

Note:
- I kept this scoped to the FastAPI dependency layer because core RLS migrations already exist in the branch; this gives routes a reusable server-side role guard without changing current route behavior.