### PR TITLE
Add multilingual translation fallback

### DIFF
--- a/backend/language_pipeline.py
+++ b/backend/language_pipeline.py
@@ -109,12 +109,21 @@ def translate_to_english(text: str, source_lang: str) -> str:
         return text
 
     model_name = f"Helsinki-NLP/opus-mt-{lang}-en"
+    fallback_model_name = "Helsinki-NLP/opus-mt-mul-en"
     try:
         return _run_translation(text, model_name)
     except Exception as exc:
         logger.warning(
-            "translate_to_english failed (model=%s): %s – returning original text",
+            "translate_to_english failed (model=%s): %s – trying multilingual fallback",
             model_name, exc,
+        )
+
+    try:
+        return _run_translation(text, fallback_model_name)
+    except Exception as exc:
+        logger.warning(
+            "translate_to_english fallback failed (model=%s): %s – returning original text",
+            fallback_model_name, exc,
         )
         return text
 
@@ -183,20 +192,31 @@ def detect_and_translate_ticket_text(text: str) -> dict:
 
     lang = str(detected_lang).lower().split("-")[0][:2]
     model_name = f"Helsinki-NLP/opus-mt-{lang}-en"
+    fallback_model_name = "Helsinki-NLP/opus-mt-mul-en"
     translated_text = original_text
     failure_reason = "translation returned original text"
 
-    try:
-        translated_text = _run_translation(original_text, model_name)
-    except Exception as e:
-        failure_reason = str(e)
-        logger.error(
-            "Translation failed: %s | detected language: %s",
-            str(e),
-            detected_lang,
-        )
+    for candidate_model in (model_name, fallback_model_name):
+        try:
+            translated_text = _run_translation(original_text, candidate_model)
+            if translated_text and translated_text.strip() and translated_text.strip() != original_text:
+                break
+            failure_reason = f"{candidate_model} returned original or empty text"
+        except Exception as e:
+            failure_reason = str(e)
+            logger.error(
+                "Translation failed: %s | detected language: %s | model: %s",
+                str(e),
+                detected_lang,
+                candidate_model,
+            )
 
     if not translated_text or not translated_text.strip() or translated_text.strip() == original_text:
+        logger.error(
+            "Translation attempted but failed: %s | detected language: %s",
+            failure_reason,
+            detected_lang,
+        )
         logger.warning(
             "detect_and_translate_ticket_text: translation returned empty/unchanged text "
             "(lang=%s, original_len=%d). Setting translation_failed=True.",

--- a/backend/tests/test_language_pipeline.py
+++ b/backend/tests/test_language_pipeline.py
@@ -215,6 +215,23 @@ class TestTranslateToEnglish(unittest.TestCase):
             result = translate_to_english("बोलो", "hi")
             self.assertEqual(result, "बोलो")
 
+    def test_direct_model_failure_uses_multilingual_fallback(self):
+        from backend.language_pipeline import translate_to_english
+        with patch(
+            "backend.language_pipeline._run_translation",
+            side_effect=[OSError("model not found"), "Printer is broken"],
+        ) as m:
+            result = translate_to_english("La impresora está rota", "es")
+
+        self.assertEqual(result, "Printer is broken")
+        self.assertEqual(
+            [mock_call.args for mock_call in m.call_args_list],
+            [
+                ("La impresora está rota", "Helsinki-NLP/opus-mt-es-en"),
+                ("La impresora está rota", "Helsinki-NLP/opus-mt-mul-en"),
+            ],
+        )
+
     def test_returns_translation_result(self):
         from backend.language_pipeline import translate_to_english
         with patch("backend.language_pipeline._run_translation", return_value="My computer does not start"):
@@ -303,6 +320,28 @@ class TestDetectAndTranslateTicketText(unittest.TestCase):
         self.assertTrue(result["was_translated"])
         self.assertTrue(result["translation_attempted"])
         self.assertFalse(result["translation_failed"])
+
+    def test_detect_and_translate_uses_multilingual_fallback(self):
+        from backend.language_pipeline import detect_and_translate_ticket_text
+
+        original = "La impresora está rota"
+        with patch("backend.language_pipeline.detect_language", return_value="es"):
+            with patch(
+                "backend.language_pipeline._run_translation",
+                side_effect=[OSError("model not found"), "Printer is broken"],
+            ) as m:
+                result = detect_and_translate_ticket_text(original)
+
+        self.assertEqual(result["text_for_analysis"], "Printer is broken")
+        self.assertTrue(result["was_translated"])
+        self.assertFalse(result["translation_failed"])
+        self.assertEqual(
+            [mock_call.args for mock_call in m.call_args_list],
+            [
+                (original, "Helsinki-NLP/opus-mt-es-en"),
+                (original, "Helsinki-NLP/opus-mt-mul-en"),
+            ],
+        )
 
     def test_translation_returning_original_logs_failure(self):
         from backend.language_pipeline import detect_and_translate_ticket_text


### PR DESCRIPTION
## Summary
- fall back to `Helsinki-NLP/opus-mt-mul-en` when a direct `{lang}-en` model fails
- reuse the fallback in the ticket detect-and-translate pipeline
- add tests for both direct helper and pipeline fallback behavior

## Testing
- `python3 -m unittest backend.tests.test_language_pipeline`
- `python3 -m py_compile backend/language_pipeline.py backend/tests/test_language_pipeline.py`

Refs #2669
