### PR TITLE
[CRITICAL] fix: prevent self-assigned role privilege escalation on signup (#2673)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1143,6 +1143,8 @@ class LoginBody(BaseModel):
     email: str
     password: str
 
+ALLOWED_SELF_SIGNUP_ROLES = frozenset({"user"})
+
 class SignupBody(BaseModel):
     email: str
     password: str
@@ -1177,8 +1179,13 @@ async def auth_signup(body: SignupBody, response: Response):
     metadata = {}
     if body.full_name:
         metadata["full_name"] = body.full_name
-    if body.role:
-        metadata["role"] = body.role
+    safe_role = body.role or "user"
+    if safe_role not in ALLOWED_SELF_SIGNUP_ROLES:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Invalid role '{safe_role}'. Self-signup only allows: {', '.join(sorted(ALLOWED_SELF_SIGNUP_ROLES))}"
+        )
+    metadata["role"] = safe_role
     if body.company:
         metadata["company"] = body.company
 


### PR DESCRIPTION
## Description

Fixes a **critical privilege escalation** vulnerability (CVSS 9.8) in the `/auth/signup` endpoint.

**Vulnerability:** The `SignupBody` model accepted a `role` field with no server-side validation. An attacker could sign up with `role="admin"` or `role="master_admin"` and immediately gain elevated privileges.

**Root Cause:** `backend/main.py` line 1180-1181 passed `body.role` directly into Supabase `user_metadata` without checking if the requested role was permitted for self-signup.

## Fix

- Added `ALLOWED_SELF_SIGNUP_ROLES = frozenset({"user"})` constant
- Added server-side validation that rejects signup attempts with roles outside the allowed set
- Returns HTTP 403 with a descriptive error message for invalid role attempts

## Impact

- **Before:** Any unauthenticated attacker could create an admin account
- **After:** Self-signup is restricted to the `"user"` role only
- Admin/master_admin roles can only be assigned server-side by authorized operators

## Testing

- Signup with no role ??? defaults to "user" (allowed)
- Signup with `role="user"` ??? allowed
- Signup with `role="admin"`, `role="master_admin"`, `role="superuser"` ??? HTTP 403 Forbidden

Closes #2673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Signup endpoint now validates user roles against an allowlist and rejects requests with unauthorized roles, returning a 403 error response. Only pre-approved roles can be assigned during signup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->