### PR TITLE
Fix invalid lint-staged config in Frontend/package.json

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -60,5 +60,10 @@
     "tailwindcss": "^3.4.19",
     "vite": "^7.3.1"
   },
-  "lint-staged": "{'*.{js,jsx}': ['eslint --fix', 'prettier --write']}"
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  }
 }


### PR DESCRIPTION
The lint-staged config was a string containing invalid single-quoted JSON instead of a proper JSON object, which breaks lint-staged.

Closes #2679