### PR TITLE
Fix React version in .eslintrc.cjs (18.2 -> 19.2)

### DIFF
--- a/Frontend/.eslintrc.cjs
+++ b/Frontend/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     'prettier', 
   ],
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
-  settings: { react: { version: '18.2' } },
+  settings: { react: { version: '19.2' } },
   plugins: ['react-refresh'],
   rules: {
     'react-refresh/only-export-components': [


### PR DESCRIPTION
The legacy .eslintrc.cjs specified React version 18.2 but the project uses React ^19.2.0.

Closes #2683