### PR TITLE
fix: capture Supabase API errors silently bypassing exception handlers (#2659)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -76,6 +76,8 @@ def get_system_settings(company_id: str) -> dict:
         res = supabase.table("system_settings").select(
             "ai_confidence_threshold, duplicate_sensitivity, enable_auto_resolve"
         ).eq("company_id", company_id).single().execute()
+        if getattr(res, 'error', None):
+            print(f"[WARNING] Supabase API error fetching system_settings for company_id={company_id}: {res.error}")
         if res.data:
             return {**defaults, **res.data}
     except Exception as e:

--- a/backend/services/auto_close_service.py
+++ b/backend/services/auto_close_service.py
@@ -57,7 +57,10 @@ class AutoCloseService:
             response = self.supabase.table("system_settings").select(
                 "auto_close_days, auto_close_enabled"
             ).eq("company_id", company_id).single().execute()
-            
+
+            if response.error:
+                logger.warning(f"Supabase API error fetching settings for company {company_id}: {response.error}")
+
             if response.data:
                 return {
                     "auto_close_days": response.data.get("auto_close_days", self.default_auto_close_days),

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -73,6 +73,9 @@ class NotificationRoutingMiddleware:
                 "email_notifications, admin_alerts, digest_frequency"
             ).eq("company_id", company_id).single().execute()
 
+            if response.error:
+                logger.warning(f"Supabase API error fetching company settings for {company_id}: {response.error}")
+
             if response.data:
                 return {
                     "email_notifications": response.data.get("email_notifications", True),


### PR DESCRIPTION
## Description

Fixes the bug described in #2659 where Supabase client API errors bypass exception handling blocks.

## Root Cause

The `_fetch_system_settings` / `get_system_settings` methods in three files relied solely on `try/except` blocks to detect database failures. However, the Supabase/Postgrest Python client does **not** raise exceptions for API-level errors (bad syntax, schema drift, missing permissions) ??? instead, it populates `response.error`. When this happened:

1. `response.data` returned `None` (falsy)
2. The `if response.data:` check evaluated to `False`
3. No exception was raised, so the `except` block never executed
4. The code silently fell back to default values **without logging the actual error**

## Files Changed

### `backend/services/notification_routing.py`
- Added `response.error` check before `response.data` check in `_fetch_system_settings`
- Logs a warning with the actual API error message when present

### `backend/services/auto_close_service.py`
- Added `response.error` check before `response.data` check in `get_system_settings`
- Logs a warning with the actual API error message when present

### `backend/main.py`
- Added `response.error` check before `response.data` check in `get_system_settings`
- Logs a warning with the actual API error message when present

## Impact

- **Before:** API errors silently swallowed, making debugging impossible
- **After:** All Supabase API errors are explicitly logged with the error details
- Fail-open behavior preserved (defaults still returned on error)

Closes #2659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling and logging for system settings retrieval to improve system reliability and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->