### PR TITLE
fix: update React version in eslint config from 18.2 to 19.2 (#2683)

### DIFF
--- a/Frontend/.eslintrc.cjs
+++ b/Frontend/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
     'prettier', 
   ],
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
-  settings: { react: { version: '18.2' } },
+  settings: { react: { version: '19.2' } },
   plugins: ['react-refresh'],
   rules: {
     'react-refresh/only-export-components': [


### PR DESCRIPTION
## Description

The project uses React `^19.2.0` per `Frontend/package.json`, but `.eslintrc.cjs` still specified `settings.react.version = '18.2'`. This caused eslint-plugin-react to use outdated linting rules and could produce incorrect warnings.

## Fix

Changed `version: '18.2'` to `version: '19.2'` in `Frontend/.eslintrc.cjs` line 11 to match the actual React version used in the project.

Closes #2683