### PR TITLE
fix: add type="tel" to phone input in Profile.jsx

### DIFF
--- a/Frontend/src/user/pages/Profile.jsx
+++ b/Frontend/src/user/pages/Profile.jsx
@@ -315,6 +315,7 @@ const Profile = () => {
                                             <div className="space-y-1 md:col-span-2">
                                                 <label className="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em] ml-2">Comms Channel</label>
                                                 <input
+                                                    type="tel"
                                                     value={formData.phone}
                                                     onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
                                                     className="w-full bg-slate-50 border-2 border-transparent focus:border-emerald-500 px-4 py-2.5 rounded-2xl text-sm font-bold outline-none transition-all"


### PR DESCRIPTION
Closes #2757

Adds type="tel" to the phone number input so mobile devices show a numeric dialpad instead of a full QWERTY keyboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone number input field to use the appropriate keyboard type on mobile devices for better user input experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->