### PR TITLE
fix: add user_text parameter to analyze_image() to resolve arg count mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 venv/
+venv_hd/
 env/
 .env
 

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -27,9 +27,12 @@ class GeminiService:
         else:
             print("[GeminiService] WARNING: GEMINI_API_KEY not found in environment.")
 
-    def analyze_image(self, image_base64: str) -> dict:
+    def analyze_image(self, image_base64: str, user_text: str = "") -> dict:
         """
         Perform OCR and image analysis using Gemini logic.
+        Args:
+            image_base64: Base64-encoded image bytes.
+            user_text: Optional user-provided description of the issue to give context.
         """
         if not self._initialized:
             return {
@@ -44,8 +47,10 @@ class GeminiService:
             image_bytes = base64.b64decode(image_base64)
             img = Image.open(io.BytesIO(image_bytes))
 
+            user_context = f"\nThe user reported the following: {user_text}\n" if user_text else ""
             prompt = (
-                "Analyze this screenshot from a user reporting a technical issue. "
+                "Analyze this screenshot from a user reporting a technical issue."
+                f"{user_context}"
                 "1. Provide a concise description of what is shown in the image. "
                 "2. Perform OCR and extract any error messages or key text. "
                 "3. Identify the main technical problem depicted. "


### PR DESCRIPTION
Closes #2571

## Problem
`gemini_service.analyze_image()` was defined with signature `(self, image_base64: str)` but both call sites in `main.py` (lines 769 and 923) invoke it as `analyze_image(request_body.image_base64, text)`, passing a second positional argument `text`. This causes a `TypeError: analyze_image() takes 2 positional arguments but 3 were given` every time a ticket with an image attachment is analyzed.

## Fix
- Updated `analyze_image` signature to accept `user_text: str = ""`
- Incorporated `user_text` into the Gemini prompt as user-reported context when provided
- Both call sites already pass `text` — no changes needed there
- Default value ensures backward compatibility with any other callers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image analysis functionality now supports optional user-provided text input. Users can include custom context, questions, or specific directives when submitting images for analysis to receive significantly more tailored, personalized, and contextually relevant results compared to standard analysis operations.

* **Chores**
  * Updated project configuration to properly exclude additional virtual environment directories from version control tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->