### PR TITLE
fix: safely load classifier v2 weights

### DIFF
--- a/backend/services/classifier_v2.py
+++ b/backend/services/classifier_v2.py
@@ -48,7 +48,8 @@ class ClassifierServiceV2:
         # 3. Load Model
         self.model = MultiOutputClassifierV2(self.num_labels).to(self.device)
         model_path = os.path.join(MODEL_DIR, "model.pt")
-        self.model.load_state_dict(torch.load(model_path, map_location=self.device))
+        state_dict = torch.load(model_path, map_location=self.device, weights_only=True)
+        self.model.load_state_dict(state_dict)
         self.model.eval()
 
         # 4. Load Tokenizer


### PR DESCRIPTION
## Summary
Use PyTorch `weights_only=True` when loading classifier V2 model weights.

## Impact
Prevents arbitrary pickle object deserialization when loading model artifacts.

## Testing
- Python syntax compilation passed

## Risk
Low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected mutable default values in request and response models.
  * Improved error handling and validation during backend startup.

* **New Features**
  * Added backward-compatible legacy analysis endpoint.
  * Added fallback modes for classification and entity extraction when model files are unavailable.

* **Improvements**
  * Refactored ticket analysis workflow to ensure consistent OCR enrichment.
  * Enhanced startup diagnostics and logging for system dependencies.
  * Improved authentication error messages with detailed exception information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->