### PR TITLE
fix: safely load classifier v3 weights

### DIFF
--- a/backend/services/classifier_v3.py
+++ b/backend/services/classifier_v3.py
@@ -48,7 +48,12 @@ class ClassifierServiceV3:
             self.label_encoders = pickle.load(f)
 
         self.model = MultiOutputClassifierV3(self.num_labels).to(self.device)
-        self.model.load_state_dict(torch.load(os.path.join(MODEL_DIR, "model.pt"), map_location=self.device))
+        state_dict = torch.load(
+            os.path.join(MODEL_DIR, "model.pt"),
+            map_location=self.device,
+            weights_only=True,
+        )
+        self.model.load_state_dict(state_dict)
         self.model.eval()
 
         self.tokenizer = BertTokenizerFast.from_pretrained(MODEL_DIR)


### PR DESCRIPTION
## Summary
Use PyTorch `weights_only=True` when loading classifier V3 model weights.

## Impact
Prevents arbitrary pickle object deserialization from compromised model artifacts.

## Testing
- Python syntax compilation passed

## Risk
Low