### PR TITLE
fix: validate duplicate similarity threshold

### DIFF
--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -125,6 +125,7 @@ class DuplicateService:
         
         # Use provided threshold or default to global constant
         active_threshold = threshold if threshold is not None else SIMILARITY_THRESHOLD
+        active_threshold = min(max(float(active_threshold), 0.0), 1.0)
 
         if not self._tickets:
             return {


### PR DESCRIPTION
## Summary
Clamp duplicate-detection thresholds to the valid cosine-similarity range.

## Impact
Prevents invalid configuration from marking every ticket duplicate or disabling duplicate detection.

## Testing
- Python syntax compilation passed

## Risk
Low