### PR TITLE
fix: reject invalid IP entities

### DIFF
--- a/backend/services/ner_service.py
+++ b/backend/services/ner_service.py
@@ -14,6 +14,7 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 MAX_LEN = 128
 
 import re
+import ipaddress
 
 # Regex patterns for high-fidelity extraction
 REGEX_PATTERNS = {
@@ -26,6 +27,16 @@ REGEX_PATTERNS = {
     "SYSTEM": r"\bProduction\b|\bStaging\b|\bInstance\b|\bMainframe\b",
     "BROWSER": r"Chrome|Edge|Firefox|Safari|Browser"
 }
+
+
+def _is_valid_regex_entity(label: str, value: str) -> bool:
+    if label != "IP_ADDRESS" or value.lower().startswith("ip"):
+        return True
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
 
 
 class NERService:
@@ -187,6 +198,8 @@ class NERService:
             for match in matches:
                 # Add to entities, avoiding duplicates (check if text already extracted)
                 match_text = match.group()
+                if not _is_valid_regex_entity(label, match_text):
+                    continue
                 if not any(e["text"].lower() == match_text.lower() for e in entities):
                     entities.append({
                         "text": match_text,
@@ -204,6 +217,8 @@ class NERService:
             matches = re.finditer(pattern, text, re.IGNORECASE)
             for match in matches:
                 match_text = match.group()
+                if not _is_valid_regex_entity(label, match_text):
+                    continue
                 if not any(e["text"].lower() == match_text.lower() for e in entities):
                     entities.append({
                         "text": match_text,


### PR DESCRIPTION
## Summary
Validate regex-extracted IP addresses with Python's `ipaddress` parser.

## Impact
Prevents invalid addresses such as `999.999.999.999` from being treated as high-confidence entities.

## Testing
- Python syntax compilation passed

## Risk
Low

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ticket retrieval by ID endpoint
  * Added authentication endpoints: signup, logout, and current user info

* **Bug Fixes**
  * Fixed mutable default values in data models
  * Improved startup error handling and strict mode enforcement
  * Added fallback classification and entity extraction when ML models are unavailable
  * Enhanced ticket persistence with tenant authorization checks

* **Changes**
  * Refactored AI analysis to consistently use OCR-enriched text
  * Improved ticket filtering with company ID support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->