### PR TITLE
fix: replace hardcoded localhost API URL with API_CONFIG.BACKEND_URL

### DIFF
--- a/Frontend/src/user/pages/AutoResolve.jsx
+++ b/Frontend/src/user/pages/AutoResolve.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bot, User, CheckCircle2, XCircle, Send, RefreshCcw, ShieldCheck } from 'lucide-react';
 import useTicketStore from '../../store/ticketStore';
+import { API_CONFIG } from '../../config';
 
 function AutoResolve() {
     const { aiTicket } = useTicketStore();
@@ -15,7 +16,7 @@ function AutoResolve() {
     const fetchNextStep = async (history = []) => {
         setIsThinking(true);
         try {
-            const response = await fetch('http://127.0.0.1:8000/ai/troubleshoot', {
+            const response = await fetch(`${API_CONFIG.BACKEND_URL}/ai/troubleshoot`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({


### PR DESCRIPTION
Hi @ritesh-1918 ,
i have resolved this issue 

## Summary
- Added import for API_CONFIG from ../../config
- Replaced hardcoded http://127.0.0.1:8000/ai/troubleshoot with ${API_CONFIG.BACKEND_URL}/ai/troubleshoot

Closes #2756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the backend URL configuration to use a centralized configuration module instead of a hardcoded value, improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->