### PR TITLE
fix: replace Markdown ** syntax with <strong> in Help.jsx

### DIFF
--- a/Frontend/src/user/pages/Help.jsx
+++ b/Frontend/src/user/pages/Help.jsx
@@ -171,7 +171,7 @@ ${fullName}`;
                         How can we help you today?
                     </h1>
                     <p className="text-lg text-emerald-100 max-w-2xl mx-auto font-medium opacity-90 mb-10">
-                        Search our **Solution Library**, watch curated IT tutorials, or connect with a support agent instantly.
+                        Search our <strong>Solution Library</strong>, watch curated IT tutorials, or connect with a support agent instantly.
                     </p>
 
                     {/* Faux Search Bar representing the Hub */}


### PR DESCRIPTION
# Fix: Replace Markdown Bold Syntax with JSX  in Help.jsx ## Problem
The hero subtitle on the /help page contained raw Markdown Solution Library syntax, which JSX doesn't interpret, causing literal asterisks to appear instead of bold text.

## Solution
Replaced the Markdown-style **Solution Library** with JSX <strong>Solution Library</strong> to properly render the text as bold.

## Changes Made
- Updated Frontend/src/user/pages/Help.jsx line 174
Closes #2758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text formatting on the Help page to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->