### PR TITLE
fix: add escape key handling for modals

### DIFF
--- a/Frontend/src/admin/pages/AdminProfile.jsx
+++ b/Frontend/src/admin/pages/AdminProfile.jsx
@@ -62,6 +62,23 @@ const AdminProfile = () => {
         fetchActivity();
     }, [adminProfile?.company]);
 
+    // Handle Escape key to close password modal
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape' && showPasswordModal) {
+                setShowPasswordModal(false);
+            }
+        };
+
+        if (showPasswordModal) {
+            document.addEventListener('keydown', handleKeyDown);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [showPasswordModal]);
+
     const handleImageUpload = async (e) => {
         const file = e.target.files?.[0];
         if (!file) return;

--- a/Frontend/src/user/components/CSATModal.jsx
+++ b/Frontend/src/user/components/CSATModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Star, CheckCircle2, X, Loader2, MessageSquare } from 'lucide-react';
 import { supabase } from '../../lib/supabaseClient';
 
@@ -17,6 +17,21 @@ export default function CSATModal({ ticketId, onSubmit, onDismiss }) {
     const [submitted, setSubmitted] = useState(false);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState('');
+
+    // Handle Escape key to close modal
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') {
+                onDismiss();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [onDismiss]);
 
     const ratingLabels = {
         1: 'Very Dissatisfied',

--- a/Frontend/src/user/pages/Profile.jsx
+++ b/Frontend/src/user/pages/Profile.jsx
@@ -66,6 +66,23 @@ const Profile = () => {
         }
     }, [profile]);
 
+    // Handle Escape key to close password modal
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape' && showPasswordModal) {
+                setShowPasswordModal(false);
+            }
+        };
+
+        if (showPasswordModal) {
+            document.addEventListener('keydown', handleKeyDown);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [showPasswordModal]);
+
     useEffect(() => {
         const fetchUserTickets = async () => {
             if (!user?.id) return;


### PR DESCRIPTION
hi @ritesh-1918 
Okay, all fixed! Here are the details:

## PR Description
Fix: Add Escape key handling for modals

This PR adds Escape key closing functionality to all three modals:

- Profile page password modal
- AdminProfile page password modal
- CSATModal
All follow the same pattern using useEffect with a document keydown listener.

## Issue Comment
Hey there! I've fixed the Escape key handling for all three modals (Profile, AdminProfile, and CSATModal)! 🛠️

Changes made:

1. Added useEffect in Profile.jsx to listen for Escape and close password modal
2. Added the same in AdminProfile.jsx for password modal
3. Updated CSATModal.jsx to listen for Escape and call onDismiss
All listeners properly clean up after the modal closes.

Pull request ready for review: https://github.com/pranayukey200/HELPDESK.AI/pull/new/fix/2755-escape-key-modals

Closes #2755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Escape key support to dismiss password modals and feedback forms, enhancing keyboard navigation and user accessibility across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->