### PR TITLE
fix(frontend): gate USE_MOCK behind VITE_USE_MOCK_API env var, default false

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -15,8 +15,8 @@ VITE_WS_URL=ws://localhost:8000/ws
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 
-# Set to 'false' to disable mock data and use real API
-VITE_USE_MOCK=false
+# Set to 'true' only for local demo/development. Defaults to false (real API).
+VITE_USE_MOCK_API=false
 
 # Support email address
 VITE_SUPPORT_EMAIL=support@example.com

--- a/Frontend/src/config.ts
+++ b/Frontend/src/config.ts
@@ -1,0 +1,29 @@
+/**
+ * Global configuration for the AI Helpdesk frontend.
+ * All values are derived from environment variables at build time.
+ */
+
+const getBackendUrl = (): string => {
+    const envUrl = import.meta.env.VITE_BACKEND_URL as string | undefined;
+    if (envUrl) return envUrl.trim().replace(/\/$/, '');
+
+    if (
+        window.location.hostname === 'localhost' ||
+        window.location.hostname === '127.0.0.1'
+    ) {
+        return 'http://localhost:8000';
+    }
+
+    return 'https://ritesh19180-ai-helpdesk-api.hf.space';
+};
+
+export const API_CONFIG = {
+    BACKEND_URL: getBackendUrl(),
+    FRONTEND_URL: window.location.origin,
+    IS_PROD: import.meta.env.PROD,
+    /**
+     * Set VITE_USE_MOCK_API=true in .env to enable local mock mode.
+     * Defaults to false — production always uses real persistence.
+     */
+    USE_MOCK: import.meta.env.VITE_USE_MOCK_API === 'true',
+};


### PR DESCRIPTION
## Summary

Closes #2788

`Frontend/src/services/api.js` (now `api.ts` on the `gssoc` branch) read `USE_MOCK` from `API_CONFIG.USE_MOCK`, but the `config` module did not exist on this branch, meaning `USE_MOCK` was always `undefined` (falsy) — a silent accident rather than intentional behaviour. On `main`, the value was hardcoded to `true`, so all ticket reads/writes went to `localStorage` instead of the real backend.

## Changes

- **`Frontend/src/config.ts`** — new TypeScript port of `config.js`; adds `USE_MOCK: import.meta.env.VITE_USE_MOCK_API === 'true'` which defaults to `false`, ensuring production builds always use real backend persistence.
- **`Frontend/.env.example`** — replaces the unused `VITE_USE_MOCK=false` entry with the correct `VITE_USE_MOCK_API=false` so contributors know how to enable mock mode locally.

No changes to `api.ts` itself — it already reads `API_CONFIG.USE_MOCK` correctly.

## Behaviour after this change

| Environment | `VITE_USE_MOCK_API` | Result |
|---|---|---|
| Production build | unset (default) | Real backend / Supabase |
| Local dev (demo) | `true` | In-memory mock data |
| Local dev (real) | `false` or unset | Real backend / Supabase |

## Test Plan

- [ ] Run `npm run build` — confirm no TypeScript errors from the new `config.ts`.
- [ ] Start the dev server without setting `VITE_USE_MOCK_API` — submit a ticket and confirm it is sent to the backend, not stored in the browser.
- [ ] Add `VITE_USE_MOCK_API=true` to `.env.local`, restart — confirm mock tickets appear and no network requests are made to the backend for `getTickets`/`createTicket`.