### PR TITLE
feat: Add custom scrollbar styling across frontend

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -91,14 +91,28 @@
   }
 }
 
-html{
+html {
   overflow-y: scroll;
-  scrollbar-width: none; /* Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: #618975 #f1f1f1;
 }
 
-html::-webkit-scrollbar{
-  width: 0;
-  height: 0;
+html::-webkit-scrollbar {
+  width: 12px;
+}
+
+html::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 10px;
+}
+
+html::-webkit-scrollbar-thumb {
+  background: #618975;
+  border-radius: 10px;
+}
+
+html::-webkit-scrollbar-thumb:hover {
+  background: #4a6a5a;
 }
 
 body{


### PR DESCRIPTION
## Summary

Adds custom scroll bar styling to the HELPDESK.AI frontend for improved user experience and visual consistency.

## Changes
- Modified `Frontend/src/index.css`
- Replaced hidden scrollbar with visible custom-styled scrollbar
- 12px scrollbar width with rounded corners (10px radius)
- Themed thumb color #618975 (matches design system muted text color)
- Hover state darkens to #4a6a5a
- Track color #f1f1f1 with rounded corners
- Firefox support via scrollbar-width: thin / scrollbar-color properties

Closes #2652