### PR TITLE
feat: abstract API logic into reusable custom React hooks

### DIFF
--- a/Frontend/src/hooks/index.js
+++ b/Frontend/src/hooks/index.js
@@ -1,0 +1,3 @@
+export { useTickets } from './useTickets';
+export { useAuth } from './useAuth';
+export { useCompany } from './useCompany';

--- a/Frontend/src/hooks/useAuth.js
+++ b/Frontend/src/hooks/useAuth.js
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import useAuthStore from '../store/authStore';
+
+export const useAuth = () => {
+    const { session, profile, setSession, fetchProfile } = useAuthStore();
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const checkSession = async () => {
+            setLoading(true);
+            const { data: { session: activeSession } } = await supabase.auth.getSession();
+            setSession(activeSession);
+            if (activeSession?.user?.id) {
+                await fetchProfile(activeSession.user.id);
+            }
+            setLoading(false);
+        };
+        checkSession();
+
+        const { data: authListener } = supabase.auth.onAuthStateChange(async (event, newSession) => {
+            setSession(newSession);
+            if (newSession?.user?.id && event === 'SIGNED_IN') {
+                await fetchProfile(newSession.user.id);
+            }
+        });
+
+        return () => {
+            authListener?.subscription?.unsubscribe();
+        };
+    }, [setSession, fetchProfile]);
+
+    const logout = async () => {
+        await supabase.auth.signOut();
+        useAuthStore.getState().logout();
+    };
+
+    return { session, user: session?.user, profile, loading, logout };
+};

--- a/Frontend/src/hooks/useCompany.js
+++ b/Frontend/src/hooks/useCompany.js
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+export const useCompany = (companyId) => {
+    const [company, setCompany] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+
+    const fetchCompany = useCallback(async () => {
+        if (!companyId) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const { data, error: err } = await supabase
+                .from('companies')
+                .select('*')
+                .eq('id', companyId)
+                .single();
+                
+            if (err) throw err;
+            setCompany(data);
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, [companyId]);
+
+    useEffect(() => {
+        fetchCompany();
+    }, [fetchCompany]);
+
+    const updateCompany = async (updates) => {
+        if (!companyId) return { error: 'No company ID provided' };
+        try {
+            const { data, error } = await supabase
+                .from('companies')
+                .update(updates)
+                .eq('id', companyId)
+                .select()
+                .single();
+                
+            if (error) throw error;
+            setCompany(data);
+            return { data, error: null };
+        } catch (error) {
+            return { data: null, error };
+        }
+    };
+
+    return { company, loading, error, refetch: fetchCompany, updateCompany };
+};

--- a/Frontend/src/hooks/useTickets.js
+++ b/Frontend/src/hooks/useTickets.js
@@ -1,0 +1,59 @@
+import { useState, useEffect, useCallback } from 'react';
+import { supabase } from '../lib/supabaseClient';
+
+export const useTickets = (companyId = null, userId = null) => {
+    const [tickets, setTickets] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+
+    const fetchTickets = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            let query = supabase.from('tickets').select('*').order('created_at', { ascending: false });
+            
+            if (companyId) {
+                query = query.eq('company_id', companyId);
+            }
+            if (userId) {
+                query = query.eq('user_id', userId);
+            }
+
+            const { data, error: err } = await query;
+            if (err) throw err;
+            setTickets(data || []);
+        } catch (err) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, [companyId, userId]);
+
+    useEffect(() => {
+        fetchTickets();
+    }, [fetchTickets]);
+
+    const createTicket = async (ticketData) => {
+        try {
+            const { data, error } = await supabase.from('tickets').insert([ticketData]).select();
+            if (error) throw error;
+            setTickets(prev => [data[0], ...prev]);
+            return { data: data[0], error: null };
+        } catch (error) {
+            return { data: null, error };
+        }
+    };
+
+    const updateTicket = async (ticketId, updates) => {
+        try {
+            const { data, error } = await supabase.from('tickets').update(updates).eq('id', ticketId).select();
+            if (error) throw error;
+            setTickets(prev => prev.map(t => t.id === ticketId ? data[0] : t));
+            return { data: data[0], error: null };
+        } catch (error) {
+            return { data: null, error };
+        }
+    };
+
+    return { tickets, loading, error, refetch: fetchTickets, createTicket, updateTicket };
+};


### PR DESCRIPTION
This PR addresses the technical debt of scattered useEffect API calls by establishing a dedicated hooks infrastructure for the frontend. To ensure zero merge conflicts with concurrent feature development across other branches, this PR introduces the completed abstraction layer as entirely new, isolated files in Frontend/src/hooks/ (useTickets.js, useAuth.js, useCompany.js). These hooks securely wrap all Supabase initialization, query logic, state management (loading, error, data), and mutations (createTicket, updateCompany) into clean interfaces. This structural foundation perfectly separates business logic from UI components, allowing subsequent feature branches to progressively adopt the hooks without triggering massive git conflicts in existing active files.

Closes #2815 