### PR TITLE
fix: make supabase service key env var consistent

### DIFF
--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -47,7 +47,7 @@ def seed_company_settings():
     # Initialize Supabase client
     supabase = create_client(
         os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     )
     
     logger.info("Starting company settings seed script...")
@@ -141,7 +141,7 @@ def verify_seed():
     
     supabase = create_client(
         os.getenv("SUPABASE_URL"),
-        os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+        os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     )
     
     try:

--- a/backend/services/auto_close_service.py
+++ b/backend/services/auto_close_service.py
@@ -36,7 +36,7 @@ class AutoCloseService:
         """Initialize the auto-close service with Supabase client."""
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self.enabled = os.getenv("AUTO_CLOSE_ENABLED", "true").lower() == "true"
         self.default_auto_close_days = int(os.getenv("AUTO_CLOSE_DAYS", "7"))

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -53,7 +53,7 @@ class NotificationRoutingMiddleware:
         """Initialize the notification routing middleware."""
         self.supabase = create_client(
             os.getenv("SUPABASE_URL"),
-            os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            os.getenv("SUPABASE_SERVICE_KEY") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
         )
         self._settings_cache: Dict[str, Dict] = {}
         self.log_level = os.getenv("NOTIFICATION_ROUTING_LOG_LEVEL", "info").lower()


### PR DESCRIPTION
Fix: Make Supabase service key environment variable consistent This PR fixes the inconsistent environment variable naming for the Supabase service key:

1. Updated all files using SUPABASE_SERVICE_ROLE_KEY to use SUPABASE_SERVICE_KEY (matching .env.example)
2. Added backward compatibility by falling back to SUPABASE_SERVICE_ROLE_KEY if SUPABASE_SERVICE_KEY isn't available
3. Updated files: auto_close_service.py , notification_routing.py , and seed_company_settings.py

closes #2823 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend service authentication configuration for improved system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->