### PR TITLE
feat: AES-256-GCM encryption + PII redaction for Supabase DB backups (#1402)

### DIFF
--- a/backend/services/db_backup.py
+++ b/backend/services/db_backup.py
@@ -1,0 +1,339 @@
+"""
+Supabase Database Backup Pipeline with AES-256-GCM Encryption & PII Redaction.
+
+Automated backup utility that:
+  1. Exports all tables from Supabase (configurable table list).
+  2. Redacts PII (emails, phones, SSNs, credit cards, IPs, API keys) from
+     sensitive fields using the existing pii_redaction engine.
+  3. Encrypts the entire backup payload with AES-256-GCM.
+  4. Produces an encrypted, auditable backup envelope.
+
+Usage:
+    python -m backend.services.db_backup \
+        --passphrase "your-secure-passphrase" \
+        --output backups/helpdesk_backup_2026.enc.json
+
+Or from code:
+    from backend.services.db_backup import BackupPipeline
+    pipeline = BackupPipeline(supabase_client)
+    envelope = pipeline.run_full()
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+from backend.services.pii_redaction import (
+    redact_all,
+    set_pii_redaction_enabled,
+)
+from backend.services.encryption import encrypt_payload, decrypt_payload
+
+# ── Default tables to back up ─────────────────────────────────────────────
+
+DEFAULT_TABLES: list[str] = [
+    "tickets",
+    "ticket_messages",
+    "profiles",
+    "system_settings",
+    "companies",
+    "company_settings",
+    "knowledge_base",
+    "csat_responses",
+]
+
+
+class BackupPipeline:
+    """Orchestrates backup + redaction + encryption for Supabase."""
+
+    def __init__(self, supabase_client: Any):
+        self.supabase = supabase_client
+
+    def run_full(
+        self,
+        *,
+        passphrase: str | None = None,
+        tables: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Run the complete backup pipeline.
+
+        Args:
+            passphrase: Encryption passphrase.
+            tables: Tables to back up (defaults to DEFAULT_TABLES).
+
+        Returns:
+            Encrypted backup envelope.
+        """
+        if passphrase is None:
+            passphrase = os.environ.get("BACKUP_ENCRYPTION_KEY", "")
+            if not passphrase:
+                raise ValueError(
+                    "passphrase required — set BACKUP_ENCRYPTION_KEY env var "
+                    "or pass explicitly"
+                )
+
+        tables = tables or DEFAULT_TABLES
+
+        # Enable PII redaction during backup
+        set_pii_redaction_enabled(True)
+
+        # 1. Export data from Supabase
+        exported: dict[str, list[dict[str, Any]]] = {}
+        export_errors: list[dict[str, Any]] = []
+        total_rows = 0
+
+        for table_name in tables:
+            try:
+                response = (
+                    self.supabase.table(table_name)
+                    .select("*", count="exact")
+                    .execute()
+                )
+                rows = response.data if response.data else []
+                exported[table_name] = rows
+                total_rows += len(rows)
+            except Exception as e:
+                export_errors.append(
+                    {"table": table_name, "error": str(e)}
+                )
+                exported[table_name] = []
+
+        # 2. Redact PII from each table (row-level + field-level)
+        redacted: dict[str, Any] = {}
+        total_pii_redacted = 0
+
+        for table_name, records in exported.items():
+            if not records:
+                redacted[table_name] = []
+                continue
+
+            redacted_rows = []
+            for record in records:
+                row = dict(record)
+                # Apply redact_all to every string field
+                for key, value in row.items():
+                    if isinstance(value, str) and value:
+                        redacted_val = redact_all(value)
+                        if redacted_val != value:
+                            total_pii_redacted += 1
+                        row[key] = redacted_val
+                redacted_rows.append(row)
+            redacted[table_name] = redacted_rows
+
+        # 3. Build backup payload
+        backup_payload = {
+            "metadata": {
+                "backup_id": f"bkp_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "total_tables": len(tables),
+                "total_rows": total_rows,
+                "tables_exported": list(exported.keys()),
+                "pii_redaction_applied": True,
+                "pii_fields_redacted": total_pii_redacted,
+            },
+            "export_errors": export_errors if export_errors else None,
+            "data": redacted,
+        }
+
+        # 4. Encrypt the payload
+        envelope = encrypt_payload(backup_payload, passphrase=passphrase)
+
+        # 5. Add backup-specific metadata to envelope
+        envelope["backup_id"] = backup_payload["metadata"]["backup_id"]
+        envelope["backup_metadata"] = {
+            "total_rows": total_rows,
+            "tables": list(exported.keys()),
+            "errors": len(export_errors),
+        }
+
+        # Disable PII redaction after backup
+        set_pii_redaction_enabled(False)
+
+        return envelope
+
+    def restore(
+        self,
+        envelope: dict[str, Any],
+        passphrase: str,
+        *,
+        dry_run: bool = True,
+    ) -> dict[str, Any]:
+        """Restore data from an encrypted backup envelope.
+
+        Args:
+            envelope: The encrypted backup envelope from run_full().
+            passphrase: Passphrase to decrypt.
+            dry_run: If True, only validate and return the data without
+                writing to Supabase.
+
+        Returns:
+            {
+                "ok": bool,
+                "tables_restored": list[str],
+                "rows_restored": int,
+                "errors": list[dict],
+            }
+        """
+        # Decrypt
+        try:
+            data = decrypt_payload(envelope, passphrase=passphrase)
+        except Exception as e:
+            return {"ok": False, "error": str(e)}
+
+        tables = data.get("data", {})
+        result: dict[str, Any] = {
+            "ok": True,
+            "tables_restored": [],
+            "rows_restored": 0,
+            "errors": [],
+        }
+
+        for table_name, rows in tables.items():
+            if not rows or dry_run:
+                if not dry_run:
+                    result["errors"].append(
+                        {"table": table_name, "error": "empty table"}
+                    )
+                continue
+
+            if dry_run:
+                result["tables_restored"].append(table_name)
+                result["rows_restored"] += len(rows)
+                continue
+
+            # Actual restore: upsert rows
+            try:
+                for row in rows:
+                    self.supabase.table(table_name).upsert(row).execute()
+                result["tables_restored"].append(table_name)
+                result["rows_restored"] += len(rows)
+            except Exception as e:
+                result["errors"].append(
+                    {"table": table_name, "error": str(e)}
+                )
+
+        return result
+
+
+# ── CLI entry point ───────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Supabase DB Backup with AES-256-GCM + PII Redaction"
+    )
+    parser.add_argument(
+        "--passphrase",
+        help="Encryption passphrase (or set BACKUP_ENCRYPTION_KEY env var)",
+    )
+    parser.add_argument(
+        "--output",
+        default="backup.enc.json",
+        help="Output file path (default: backup.enc.json)",
+    )
+    parser.add_argument(
+        "--tables",
+        nargs="*",
+        help="Tables to back up (default: all DEFAULT_TABLES)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Export and redact but skip encryption",
+    )
+
+    args = parser.parse_args()
+
+    passphrase = args.passphrase or os.environ.get("BACKUP_ENCRYPTION_KEY", "")
+
+    # Initialize Supabase client
+    from dotenv import load_dotenv
+    from pathlib import Path
+
+    env_path = Path(__file__).parent.parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    try:
+        from supabase import create_client
+
+        url = os.environ.get("SUPABASE_URL")
+        key = os.environ.get("SUPABASE_SERVICE_KEY")
+        if not url or not key:
+            print("[ERROR] SUPABASE_URL and SUPABASE_SERVICE_KEY must be set")
+            sys.exit(1)
+
+        supabase = create_client(url, key)
+    except Exception as e:
+        print(f"[ERROR] Failed to initialize Supabase: {e}")
+        sys.exit(1)
+
+    pipeline = BackupPipeline(supabase)
+
+    tables = args.tables if args.tables else DEFAULT_TABLES
+
+    if args.dry_run:
+        set_pii_redaction_enabled(True)
+
+        exported = {}
+        for table_name in tables:
+            try:
+                response = (
+                    supabase.table(table_name)
+                    .select("*", count="exact")
+                    .execute()
+                )
+                exported[table_name] = response.data if response.data else []
+            except Exception as e:
+                exported[table_name] = []
+                print(f"[WARN] Failed to export {table_name}: {e}")
+
+        redacted = {}
+        for table_name, rows in exported.items():
+            r = []
+            for record in rows:
+                row = dict(record)
+                for k, v in row.items():
+                    if isinstance(v, str) and v:
+                        row[k] = redact_all(v)
+                r.append(row)
+            redacted[table_name] = r
+
+        dry_run_output = {
+            "dry_run": True,
+            "tables": list(redacted.keys()),
+            "data": {t: rows[:2] for t, rows in redacted.items()},
+            "sample_only": True,
+        }
+        with open(args.output, "w") as f:
+            json.dump(dry_run_output, f, indent=2, ensure_ascii=False)
+        print(f"[OK] Dry run complete → {args.output}")
+
+        set_pii_redaction_enabled(False)
+    else:
+        if not passphrase:
+            print(
+                "[ERROR] Passphrase required for encryption. "
+                "Use --passphrase or set BACKUP_ENCRYPTION_KEY."
+            )
+            sys.exit(1)
+
+        envelope = pipeline.run_full(
+            passphrase=passphrase,
+            tables=tables,
+        )
+
+        with open(args.output, "w") as f:
+            json.dump(envelope, f, indent=2, ensure_ascii=False)
+
+        print(f"[OK] Encrypted backup saved → {args.output}")
+        print(
+            f"     Tables: {envelope['backup_metadata']['tables']}"
+        )
+        print(
+            f"     Rows: {envelope['backup_metadata']['total_rows']}"
+        )

--- a/backend/services/encryption.py
+++ b/backend/services/encryption.py
@@ -1,0 +1,263 @@
+"""
+AES-256-GCM Payload Encryption for Database Backups.
+
+Provides authenticated encryption (AES-256-GCM) with key derivation
+from passphrase (PBKDF2-HMAC-SHA256) and secure key management.
+
+Follows industry best practices:
+  - AES-256 in GCM mode (authenticated encryption with integrity check)
+  - PBKDF2 key derivation with 600,000 iterations
+  - Random 96-bit nonce per encryption (never reused)
+  - Base64-encoded output with metadata envelope
+
+FROZEN — Industrial-grade encryption for Supabase backup pipelines.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# ── Constants ────────────────────────────────────────────────────────────
+
+KEY_LENGTH = 32  # 256 bits
+NONCE_LENGTH = 12  # 96 bits (GCM standard)
+TAG_LENGTH = 16  # 128 bits (GCM authentication tag)
+PBKDF2_ITERATIONS = 600_000
+PBKDF2_HASH = "sha256"
+KDF_SALT_LENGTH = 32
+
+
+# ── Key derivation ────────────────────────────────────────────────────────
+
+def derive_key(
+    passphrase: str,
+    salt: bytes | None = None,
+    *,
+    iterations: int = PBKDF2_ITERATIONS,
+) -> tuple[bytes, bytes]:
+    """Derive a 256-bit AES key from a passphrase using PBKDF2-HMAC-SHA256.
+
+    Args:
+        passphrase: User-provided passphrase or secret.
+        salt: Optional salt (generated if None).
+        iterations: PBKDF2 iteration count (default 600,000).
+
+    Returns:
+        (key: bytes[32], salt: bytes[32])
+    """
+    if salt is None:
+        salt = secrets.token_bytes(KDF_SALT_LENGTH)
+
+    key = hashlib.pbkdf2_hmac(
+        PBKDF2_HASH,
+        passphrase.encode("utf-8"),
+        salt,
+        iterations,
+        dklen=KEY_LENGTH,
+    )
+    return key, salt
+
+
+def generate_key() -> bytes:
+    """Generate a random 256-bit key (no passphrase needed)."""
+    return secrets.token_bytes(KEY_LENGTH)
+
+
+# ── Encryption / Decryption ───────────────────────────────────────────────
+
+def encrypt(
+    plaintext: str | bytes,
+    key: bytes,
+    *,
+    associated_data: bytes = b"",
+) -> dict[str, Any]:
+    """Encrypt data with AES-256-GCM.
+
+    Args:
+        plaintext: Data to encrypt (str or bytes).
+        key: 256-bit encryption key (32 bytes).
+        associated_data: Optional authenticated associated data (not encrypted
+            but integrity-checked).
+
+    Returns:
+        {
+            "ciphertext_b64": str,
+            "nonce_b64": str,
+            "tag_b64": str,
+            "associated_data_b64": str,
+        }
+    """
+    # Crypto imports here to avoid startup penalty when not in use
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    if isinstance(plaintext, str):
+        plaintext = plaintext.encode("utf-8")
+
+    key = _validate_key(key)
+    nonce = secrets.token_bytes(NONCE_LENGTH)
+
+    aesgcm = AESGCM(key)
+    ciphertext = aesgcm.encrypt(nonce, plaintext, associated_data)
+
+    # AESGCM.encrypt appends the 16-byte tag to ciphertext
+    # Split for explicit metadata
+    tag = ciphertext[-TAG_LENGTH:]
+    ct = ciphertext[:-TAG_LENGTH]
+
+    return {
+        "ciphertext_b64": base64.b64encode(ct).decode(),
+        "nonce_b64": base64.b64encode(nonce).decode(),
+        "tag_b64": base64.b64encode(tag).decode(),
+        "associated_data_b64": base64.b64encode(associated_data).decode()
+        if associated_data
+        else "",
+    }
+
+
+def decrypt(
+    encrypted: dict[str, Any],
+    key: bytes,
+) -> bytes:
+    """Decrypt data encrypted with AES-256-GCM.
+
+    Args:
+        encrypted: Dict from encrypt() with ciphertext_b64, nonce_b64, tag_b64.
+        key: 256-bit encryption key (32 bytes).
+
+    Returns:
+        Decrypted plaintext bytes.
+
+    Raises:
+        ValueError: If decryption/authentication fails.
+    """
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    key = _validate_key(key)
+
+    ct = base64.b64decode(encrypted["ciphertext_b64"])
+    nonce = base64.b64decode(encrypted["nonce_b64"])
+    tag = base64.b64decode(encrypted["tag_b64"])
+    associated_data = (
+        base64.b64decode(encrypted.get("associated_data_b64", ""))
+        if encrypted.get("associated_data_b64")
+        else b""
+    )
+
+    # Reconstruct ciphertext + tag as expected by AESGCM.decrypt
+    ciphertext_with_tag = ct + tag
+
+    aesgcm = AESGCM(key)
+    try:
+        plaintext = aesgcm.decrypt(nonce, ciphertext_with_tag, associated_data)
+        return plaintext
+    except Exception as e:
+        raise ValueError("Decryption failed: authentication check failed") from e
+
+
+# ── High-level encrypt_payload / decrypt_payload ──────────────────────────
+
+def encrypt_payload(
+    data: Any,
+    passphrase: str | None = None,
+    *,
+    key: bytes | None = None,
+) -> dict[str, Any]:
+    """Encrypt any JSON-serializable payload.
+
+    Args:
+        data: JSON-serializable data (dict, list, str, etc.).
+        passphrase: Passphrase for key derivation (or use key directly).
+        key: Pre-derived key (takes precedence over passphrase).
+
+    Returns:
+        Envelope with encrypted payload and metadata.
+    """
+    if key is not None:
+        enc_key = _validate_key(key)
+        kdf_salt_b64 = None
+    elif passphrase is not None:
+        kdf_salt = secrets.token_bytes(KDF_SALT_LENGTH)
+        enc_key, _ = derive_key(passphrase, salt=kdf_salt)
+        kdf_salt_b64 = base64.b64encode(kdf_salt).decode()
+    else:
+        raise ValueError("Either passphrase or key must be provided")
+
+    plaintext = json.dumps(data, ensure_ascii=False, sort_keys=True)
+    encrypted = encrypt(plaintext, enc_key)
+
+    return {
+        "version": 1,
+        "algorithm": "AES-256-GCM",
+        "kdf": {
+            "algorithm": f"PBKDF2-HMAC-{PBKDF2_HASH.upper()}",
+            "iterations": PBKDF2_ITERATIONS,
+            "salt_b64": kdf_salt_b64,
+        },
+        "encrypted": encrypted,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def decrypt_payload(
+    envelope: dict[str, Any],
+    passphrase: str | None = None,
+    *,
+    key: bytes | None = None,
+) -> Any:
+    """Decrypt a payload encrypted with encrypt_payload().
+
+    Args:
+        envelope: The envelope dict from encrypt_payload().
+        passphrase: Passphrase to derive the key.
+        key: Pre-derived key (takes precedence).
+
+    Returns:
+        Original JSON-deserialized data.
+    """
+    if key is not None:
+        enc_key = _validate_key(key)
+    elif passphrase is not None:
+        kdf = envelope.get("kdf", {})
+        kdf_salt = base64.b64decode(kdf.get("salt_b64", "")) if kdf.get("salt_b64") else None
+        if kdf_salt is None:
+            raise ValueError("KDF salt not found in envelope")
+        enc_key, _ = derive_key(
+            passphrase,
+            salt=kdf_salt,
+            iterations=kdf.get("iterations", PBKDF2_ITERATIONS),
+        )
+    else:
+        raise ValueError("Either passphrase or key must be provided")
+
+    plaintext_bytes = decrypt(envelope["encrypted"], enc_key)
+    return json.loads(plaintext_bytes.decode("utf-8"))
+
+
+# ── Key rotation helper ───────────────────────────────────────────────────
+
+def re_encrypt(
+    envelope: dict[str, Any],
+    old_passphrase: str,
+    new_passphrase: str,
+) -> dict[str, Any]:
+    """Re-encrypt a payload with a new passphrase (key rotation)."""
+    data = decrypt_payload(envelope, passphrase=old_passphrase)
+    return encrypt_payload(data, passphrase=new_passphrase)
+
+
+# ── Validation ────────────────────────────────────────────────────────────
+
+def _validate_key(key: bytes) -> bytes:
+    if len(key) != KEY_LENGTH:
+        raise ValueError(
+            f"Key must be exactly {KEY_LENGTH} bytes (got {len(key)})"
+        )
+    return key

--- a/backend/services/test_backup_security.py
+++ b/backend/services/test_backup_security.py
@@ -1,0 +1,434 @@
+"""
+Unit tests for AES-256-GCM Encryption + PII Redaction + DB Backup Pipeline.
+
+Tests the encryption.py and db_backup.py modules against the existing
+pii_redaction.py engine on the gssoc branch.
+
+Run: python -m pytest backend/services/test_backup_security.py -v
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+
+import pytest
+
+# Ensure backend is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from backend.services.pii_redaction import (
+    IP_PATTERN,
+    CREDIT_CARD_PATTERN,
+    EMAIL_PATTERN,
+    PHONE_PATTERN,
+    SSN_PATTERN,
+    redact_all,
+    redact_emails,
+    redact_phones,
+    redact_ssns,
+    redact_credit_cards,
+    redact_ip_addresses,
+    redact_api_keys,
+    redact_row,
+    set_pii_redaction_enabled,
+    is_pii_redaction_enabled,
+    _luhn_check,
+)
+from backend.services.encryption import (
+    decrypt,
+    decrypt_payload,
+    derive_key,
+    encrypt,
+    encrypt_payload,
+    generate_key,
+    re_encrypt,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PII Redaction Tests (against existing gssoc pii_redaction.py)
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestPIIDetection:
+    """Test PII pattern detection via redaction functions."""
+
+    def test_detect_email(self):
+        text = "Contact john.doe@example.com for help"
+        result = redact_emails(text)
+        assert "john.doe@example.com" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_phone_country_code(self):
+        text = "Call +1-555-123-4567 for support"
+        result = redact_phones(text)
+        assert "555" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_phone_parenthesized(self):
+        text = "Phone: (555) 123-4567"
+        result = redact_phones(text)
+        assert "555" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_phone_dot_separated(self):
+        text = "Call 555.123.4567"
+        result = redact_phones(text)
+        assert "555.123.4567" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_ssn(self):
+        text = "SSN: 123-45-6789 was used"
+        result = redact_ssns(text)
+        assert "123-45-6789" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_credit_card(self):
+        # 4111111111111111 is a valid Luhn test card
+        text = "Card: 4111-1111-1111-1111"
+        result = redact_credit_cards(text)
+        assert "4111-1111-1111-1111" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_ip_public(self):
+        text = "Connected from 8.8.8.8"
+        result = redact_ip_addresses(text)
+        assert "8.8.8.8" not in result
+        assert "[REDACTED]" in result
+
+    def test_skip_private_ip(self):
+        text = "Internal IP 192.168.1.100"
+        result = redact_ip_addresses(text)
+        assert "192.168.1.100" in result  # Not redacted (private IP)
+
+    def test_detect_api_key_aws(self):
+        text = "Access key: AKIA0123456789ABCDEF"
+        result = redact_api_keys(text)
+        assert "AKIA" not in result
+        assert "[REDACTED]" in result
+
+    def test_detect_api_key_github(self):
+        text = "Token: ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+        result = redact_api_keys(text)
+        assert "ghp_" not in result
+        assert "[REDACTED]" in result
+
+    def test_redact_all_multiple(self):
+        text = "Email alice@test.com and phone (555) 123-4567"
+        result = redact_all(text)
+        assert "alice@test.com" not in result
+        assert "555" not in result
+        assert result.count("[REDACTED]") >= 2
+
+
+class TestPIIRedactionEdgeCases:
+    """Test edge cases for PII redaction."""
+
+    def test_redact_non_string(self):
+        assert redact_all(None) is None  # type: ignore
+        assert redact_all(42) == 42  # type: ignore
+
+    def test_redact_empty_string(self):
+        assert redact_all("") == ""
+
+    def test_redact_preserves_non_pii(self):
+        text = "The server is running on port 8080"
+        result = redact_all(text)
+        assert "8080" in result  # Not a phone number pattern
+        assert "server" in result
+
+    def test_phone_not_false_positive_port(self):
+        """Port numbers like 8080 should not be redacted."""
+        result = redact_phones("Port 8080 is open")
+        assert "8080" in result
+
+    def test_luhn_check_valid(self):
+        assert _luhn_check("4111111111111111") is True
+
+    def test_luhn_check_invalid(self):
+        assert _luhn_check("1234567890123456") is False
+
+
+class TestRedactRow:
+    """Test row-level redaction."""
+
+    def test_redact_row_email_field(self):
+        set_pii_redaction_enabled(True)
+        row = {
+            "id": 1,
+            "contact_email": "alice@test.com",
+            "description": "Fix login bug",
+            "status": "open",
+        }
+        result = redact_row(row)
+        assert "alice@test.com" not in result.get("contact_email", "")
+        assert "Fix login bug" in result.get("description", "")
+        assert result["id"] == 1
+        set_pii_redaction_enabled(False)
+
+    def test_redact_row_disabled(self):
+        set_pii_redaction_enabled(False)
+        row = {"contact_email": "alice@test.com"}
+        result = redact_row(row)
+        assert "alice@test.com" in result.get("contact_email", "")
+        set_pii_redaction_enabled(False)
+
+    def test_redact_row_nested(self):
+        set_pii_redaction_enabled(True)
+        row = {
+            "id": 1,
+            "metadata": {"original_text": "Email user@nest.com for help"},
+        }
+        result = redact_row(row)
+        assert "user@nest.com" not in str(result)
+        set_pii_redaction_enabled(False)
+
+    def test_is_pii_redaction_enabled(self):
+        set_pii_redaction_enabled(True)
+        assert is_pii_redaction_enabled() is True
+        set_pii_redaction_enabled(False)
+        assert is_pii_redaction_enabled() is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# AES-256-GCM Encryption Tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestKeyDerivation:
+    """Test key derivation functions."""
+
+    def test_derive_key_length(self):
+        key, salt = derive_key("my-secure-passphrase")
+        assert len(key) == 32  # 256 bits
+        assert len(salt) == 32
+
+    def test_derive_key_deterministic(self):
+        key1, _ = derive_key("pass", salt=b"x" * 32)
+        key2, _ = derive_key("pass", salt=b"x" * 32)
+        assert key1 == key2
+
+    def test_derive_key_different_passphrase(self):
+        key1, _ = derive_key("pass1", salt=b"x" * 32)
+        key2, _ = derive_key("pass2", salt=b"x" * 32)
+        assert key1 != key2
+
+    def test_generate_key_length(self):
+        key = generate_key()
+        assert len(key) == 32
+
+    def test_generate_key_random(self):
+        key1 = generate_key()
+        key2 = generate_key()
+        assert key1 != key2
+
+
+class TestEncryptionRoundTrip:
+    """Test encrypt/decrypt round-trip."""
+
+    def test_encrypt_decrypt_string(self):
+        key = generate_key()
+        plaintext = "Hello, secure world!"
+        encrypted = encrypt(plaintext, key)
+        decrypted = decrypt(encrypted, key)
+        assert decrypted.decode() == plaintext
+
+    def test_encrypt_decrypt_bytes(self):
+        key = generate_key()
+        plaintext = b"\x00\x01\x02\x03" * 10
+        encrypted = encrypt(plaintext, key)
+        decrypted = decrypt(encrypted, key)
+        assert decrypted == plaintext
+
+    def test_encrypt_decrypt_empty(self):
+        key = generate_key()
+        encrypted = encrypt("", key)
+        decrypted = decrypt(encrypted, key)
+        assert decrypted == b""
+
+    def test_encrypt_decrypt_unicode(self):
+        key = generate_key()
+        plaintext = "你好世界 🚀 émojis work too"
+        encrypted = encrypt(plaintext, key)
+        decrypted = decrypt(encrypted, key)
+        assert decrypted.decode() == plaintext
+
+    def test_encrypt_decrypt_large(self):
+        key = generate_key()
+        plaintext = "A" * 10000
+        encrypted = encrypt(plaintext, key)
+        decrypted = decrypt(encrypted, key)
+        assert decrypted.decode() == plaintext
+
+    def test_wrong_key_fails(self):
+        key = generate_key()
+        wrong_key = generate_key()
+        encrypted = encrypt("secret", key)
+        with pytest.raises(ValueError, match="authentication check failed"):
+            decrypt(encrypted, wrong_key)
+
+    def test_tampered_ciphertext_fails(self):
+        key = generate_key()
+        encrypted = encrypt("secret", key)
+        # Tamper with ciphertext
+        encrypted["ciphertext_b64"] = "AAAA" + encrypted["ciphertext_b64"][4:]
+        with pytest.raises(ValueError):
+            decrypt(encrypted, key)
+
+    def test_invalid_key_length_raises(self):
+        with pytest.raises(ValueError, match="exactly 32"):
+            encrypt("test", b"short")
+
+    def test_nonce_is_unique(self):
+        key = generate_key()
+        e1 = encrypt("data", key)
+        e2 = encrypt("data", key)
+        assert e1["nonce_b64"] != e2["nonce_b64"]
+        assert e1["ciphertext_b64"] != e2["ciphertext_b64"]
+
+    def test_associated_data(self):
+        key = generate_key()
+        ad = b"metadata-for-auth"
+        encrypted = encrypt("payload", key, associated_data=ad)
+        decrypted = decrypt(encrypted, key)
+        assert decrypted == b"payload"
+
+
+class TestPayloadEncryption:
+    """Test high-level encrypt_payload / decrypt_payload."""
+
+    def test_encrypt_decrypt_payload_passphrase(self):
+        data = {"users": [{"name": "Alice"}]}
+        envelope = encrypt_payload(data, passphrase="strong-passphrase")
+        assert envelope["version"] == 1
+        assert envelope["algorithm"] == "AES-256-GCM"
+        assert "encrypted" in envelope
+        assert envelope["kdf"]["algorithm"] == "PBKDF2-HMAC-SHA256"
+        assert envelope["kdf"]["iterations"] == 600_000
+
+        decrypted = decrypt_payload(envelope, passphrase="strong-passphrase")
+        assert decrypted == data
+
+    def test_encrypt_decrypt_payload_key(self):
+        key = generate_key()
+        data = [1, 2, 3, {"nested": True}]
+        envelope = encrypt_payload(data, key=key)
+        decrypted = decrypt_payload(envelope, key=key)
+        assert decrypted == data
+
+    def test_wrong_passphrase_fails(self):
+        data = {"secret": "top"}
+        envelope = encrypt_payload(data, passphrase="correct")
+        with pytest.raises(ValueError, match="authentication check failed"):
+            decrypt_payload(envelope, passphrase="wrong")
+
+    def test_missing_passphrase_raises(self):
+        with pytest.raises(ValueError, match="passphrase or key"):
+            encrypt_payload({"data": 1})
+
+
+class TestReEncryption:
+    """Test key rotation."""
+
+    def test_re_encrypt(self):
+        data = {"secret": "rotate-me"}
+        envelope = encrypt_payload(data, passphrase="old-key")
+        re_encrypted = re_encrypt(envelope, "old-key", "new-key")
+        decrypted = decrypt_payload(re_encrypted, passphrase="new-key")
+        assert decrypted == data
+
+    def test_re_encrypt_old_key_fails(self):
+        data = {"secret": "rotate-me"}
+        envelope = encrypt_payload(data, passphrase="old-key")
+        re_encrypted = re_encrypt(envelope, "old-key", "new-key")
+        with pytest.raises(ValueError):
+            decrypt_payload(re_encrypted, passphrase="old-key")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Integration: Redaction → Encryption pipeline
+# ═══════════════════════════════════════════════════════════════════════════
+
+class TestRedactAndEncrypt:
+    """Test full redaction + encryption pipeline."""
+
+    def test_redact_then_encrypt_roundtrip(self):
+        set_pii_redaction_enabled(True)
+
+        records = [
+            {
+                "id": 1,
+                "contact_email": "user@acme.com",
+                "phone": "(555) 123-4567",
+                "description": "regular note",
+            },
+            {
+                "id": 2,
+                "contact_email": "admin@acme.com",
+                "phone": "(555) 987-6543",
+                "description": "no PII content",
+            },
+        ]
+
+        # Redact each record
+        redacted_rows = [redact_row(r) for r in records]
+
+        # Verify redaction
+        assert "user@acme.com" not in redacted_rows[0].get("contact_email", "")
+        assert "(555) 123-4567" not in redacted_rows[0].get("phone", "")
+        assert redacted_rows[0]["description"] == "regular note"
+
+        # Encrypt the redacted data
+        envelope = encrypt_payload(
+            {"data": redacted_rows, "summary": "redacted backup"},
+            passphrase="backup-key",
+        )
+
+        # Decrypt and verify
+        restored = decrypt_payload(envelope, passphrase="backup-key")
+        assert len(restored["data"]) == 2
+        assert restored["data"][0]["id"] == 1
+        assert "user@acme.com" not in restored["data"][0].get("contact_email", "")
+
+        set_pii_redaction_enabled(False)
+
+    def test_redact_then_encrypt_key_rotation(self):
+        set_pii_redaction_enabled(True)
+
+        data = {"contact_email": "a@b.com", "description": "test"}
+        envelope = encrypt_payload(data, passphrase="v1")
+        re_encrypted = re_encrypt(envelope, "v1", "v2")
+        restored = decrypt_payload(re_encrypted, passphrase="v2")
+        assert restored == data
+
+        set_pii_redaction_enabled(False)
+
+    def test_full_pipeline_unredacted_fields(self):
+        """Non-PII fields should survive redaction unchanged."""
+        set_pii_redaction_enabled(True)
+
+        row = {
+            "id": 42,
+            "subject": "Login page timeout",
+            "description": "Users on Chrome 120 see 504 timeout at login",
+            "contact_email": "dev@company.io",
+            "status": "open",
+            "priority": "high",
+            "created_at": "2026-06-15T10:00:00Z",
+        }
+        result = redact_row(row)
+
+        assert result["id"] == 42
+        assert result["subject"] == "Login page timeout"
+        assert result["status"] == "open"
+        assert result["priority"] == "high"
+        assert "dev@company.io" not in result.get("contact_email", "")
+        assert "Chrome 120" in result.get("description", "")  # Not PII
+
+        # Encrypt and verify full roundtrip
+        envelope = encrypt_payload(result, passphrase="test-key")
+        restored = decrypt_payload(envelope, passphrase="test-key")
+        assert restored["id"] == 42
+        assert restored["subject"] == "Login page timeout"
+
+        set_pii_redaction_enabled(False)


### PR DESCRIPTION
## Summary

Implements **AES-256-GCM Payload Encryption** and **PII Redaction integration** for Supabase Database Backups as requested in #1402.

## Changes

### 1. `backend/services/encryption.py` (new)
- AES-256-GCM authenticated encryption
- PBKDF2-HMAC-SHA256 key derivation (600,000 iterations)
- Random 96-bit nonce per encryption (never reused)
- Base64-encoded output with structured metadata envelope
- Key rotation support (`re_encrypt`)
- `encrypt_payload` / `decrypt_payload` high-level API

### 2. `backend/services/db_backup.py` (new)
- Automated Supabase backup pipeline
- Table-level export with error handling
- PII redaction via existing `pii_redaction.py` engine
- AES-256-GCM encryption of complete backup payload
- Dry-run and restore modes
- CLI entry point with `--passphrase`, `--output`, `--tables` flags

### 3. `backend/services/test_backup_security.py` (new)
- **45 unit tests, all passing**
- PII detection tests (email, phone, SSN, credit card, IP, API keys)
- Edge cases (private IP skip, Luhn check, false positive prevention)
- Encryption round-trip tests (string, bytes, unicode, large payload, empty)
- Security tests (wrong key, tampered ciphertext, nonce uniqueness, associated data)
- Payload envelope tests (passphrase and key-based)
- Key rotation tests
- Full redaction-to-encryption integration pipeline

## Test Plan
- [x] All 45 tests pass (`pytest backend/services/test_backup_security.py -v`)
- [x] No existing files modified
- [x] Targets `gssoc` branch per CONTRIBUTING.md

Closes #1402