### PR TITLE
[HIGH] Wire SecurityHeadersMiddleware into main.py — app missing CSP, HSTS, X-Frame-Options (Fixes #2892)

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse, PlainTextResponse
 from supabase import create_client
 
 from backend.csrf import CSRFTokenMiddleware, set_csrf_cookie, CSRF_COOKIE_NAME
+from backend.security_middleware import SecurityHeadersMiddleware
 
 from backend.routers import tickets, ai, admin, health, auth
 from backend.routes import translation, estimator, voice, privacy, active_learning, weekly_digest
@@ -17,12 +18,8 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 app.add_middleware(CSRFTokenMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
 
-# Initialize Supabase client
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
-
-# Initialize Supabase client
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
 


### PR DESCRIPTION
## Description

The fully-implemented \SecurityHeadersMiddleware\ in \ackend/security_middleware.py\ was never wired into the FastAPI application. This meant the app served all responses without:

- **Content-Security-Policy** (XSS mitigation)
- **Strict-Transport-Security** (HTTPS enforcement)  
- **X-Frame-Options: DENY** (clickjacking prevention)
- **X-Content-Type-Options: nosniff** (MIME sniffing prevention)
- **Referrer-Policy**
- **Permissions-Policy**
- **Cross-Origin-Opener-Policy**

### Changes
1. Added \rom backend.security_middleware import SecurityHeadersMiddleware\
2. Added \pp.add_middleware(SecurityHeadersMiddleware)\ after \CSRFTokenMiddleware\
3. Removed duplicate \SUPABASE_URL\ / \SUPABASE_SERVICE_KEY\ environment variable reads

Closes #2892