### PR TITLE
[CRITICAL] Information disclosure — exception details leaked in auth responses (Fixes #2893)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -63,11 +63,11 @@ async def get_current_user(request: Request) -> dict:
         raise HTTPException(status_code=503, detail="Database connection offline")
     try:
         result = supabase.auth.get_user(token)
-    except Exception as exc:
+    except Exception:
         raise HTTPException(
             status_code=401,
-            detail=f"Invalid session: {exc}",
-        ) from exc
+            detail="Invalid session",
+        )
     user = getattr(result, "user", None) or (result.get("user") if isinstance(result, dict) else None)
     if not user:
         raise HTTPException(status_code=401, detail="Invalid session")


### PR DESCRIPTION
## Description

The `get_current_user` dependency in `backend/routers/auth.py:68` was leaking the raw exception message to clients:

```python
detail=f"Invalid session: {exc}"
```

This exposed internal Supabase/JWT error details (expiry times, parsing errors, internal paths) to attackers, enabling token crafting probes and backend fingerprinting.

### Fix

Replaced with a generic message:
```python
detail="Invalid session"
```

Closes #2893
