### PR TITLE
[HIGH] Prevent mass assignment and add role-based auth to admin endpoints (Fixes #2894)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,8 +1,23 @@
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException
-from backend.database import supabase
+from pydantic import BaseModel
+
 from backend.auth_cookie import get_current_user
+from backend.database import supabase
 
 router = APIRouter(prefix="/api", tags=["Admin"])
+
+
+class ProfileUpdate(BaseModel):
+    full_name: Optional[str] = None
+    avatar_url: Optional[str] = None
+    timezone: Optional[str] = None
+    locale: Optional[str] = None
+    notification_preferences: Optional[dict] = None
+
+
+ALLOWED_ADMIN_ROLES = ("admin", "master_admin")
 
 @router.get("/profiles")
 async def api_get_profiles(
@@ -12,7 +27,10 @@ async def api_get_profiles(
     offset: int = 0,
     current_user: dict = Depends(get_current_user),
 ):
-    if not supabase: return []
+    if current_user.get("role") not in ALLOWED_ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    if not supabase:
+        return []
     query = supabase.table("profiles").select("*")
     if role: query = query.eq("role", role)
     if status: query = query.eq("status", status)
@@ -22,11 +40,19 @@ async def api_get_profiles(
 @router.patch("/profiles/{user_id}")
 async def api_update_profile(
     user_id: str,
-    updates: dict,
+    updates: ProfileUpdate,
     current_user: dict = Depends(get_current_user),
 ):
-    if not supabase: return {}
-    res = supabase.table("profiles").update(updates).eq("id", user_id).execute()
+    if not supabase:
+        return {}
+    caller_id = current_user.get("id")
+    caller_role = current_user.get("role")
+    if caller_id != user_id and caller_role not in ALLOWED_ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Not authorized to update this profile")
+    filtered = updates.model_dump(exclude_none=True)
+    if not filtered:
+        raise HTTPException(status_code=400, detail="No valid fields to update")
+    res = supabase.table("profiles").update(filtered).eq("id", user_id).execute()
     return res.data[0] if res.data else {}
 
 @router.delete("/profiles/{user_id}")
@@ -34,7 +60,10 @@ async def api_delete_profile(
     user_id: str,
     current_user: dict = Depends(get_current_user),
 ):
-    if not supabase: return {"success": False}
+    if current_user.get("role") not in ALLOWED_ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    if not supabase:
+        return {"success": False}
     supabase.table("profiles").delete().eq("id", user_id).execute()
     try:
         supabase.rpc('delete_user').execute()
@@ -45,7 +74,10 @@ async def api_delete_profile(
 async def api_get_companies(
     current_user: dict = Depends(get_current_user),
 ):
-    if not supabase: return []
+    if current_user.get("role") not in ALLOWED_ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    if not supabase:
+        return []
     res = supabase.table("companies").select("*").execute()
     return res.data
 
@@ -56,7 +88,10 @@ async def api_get_admin_requests(
     offset: int = 0,
     current_user: dict = Depends(get_current_user),
 ):
-    if not supabase: return []
+    if current_user.get("role") not in ALLOWED_ADMIN_ROLES:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    if not supabase:
+        return []
     query = supabase.table("admin_requests").select("*")
     if status: query = query.eq("status", status)
     res = query.range(offset, offset + limit - 1).execute()


### PR DESCRIPTION
## Mass Assignment Vulnerability — Any Authenticated User Can Modify Any Profile Field (Privilege Escalation)

### Severity: **HIGH** (CVSS 8.0)

### Location: `backend/routers/admin.py:17`

### Description

The `PATCH /profiles/{user_id}` endpoint accepts a raw `updates: dict` parameter without a Pydantic schema or field allowlist. Any authenticated user can update ANY field on ANY user's profile, including:

- `role` — escalate to admin/master_admin
- `status` — bypass email verification, suspend other users
- `company_id` — change tenant assignment
- `email` — take over other accounts

```python
@router.patch("/profiles/{user_id}")
async def api_update_profile(
    user_id: str,
    updates: dict,           # <-- No schema validation — ANY field accepted
    current_user: dict = Depends(get_current_user),
):
    if not supabase: return {}
    res = supabase.table("profiles").update(updates).eq("id", user_id).execute()
    return res.data[0] if res.data else {}
```

There is NO:
1. Authorization check (is the user an admin?)
2. Schema validation (what fields are allowed?)
3. Ownership check (is the user updating their own profile?)
4. Field allowlist/blocklist

### Impact

- **Privilege escalation**: Any authenticated user can set `role: "admin"` or `role: "master_admin"` on their own profile
- **Account takeover**: Change another user's email or status
- **Tenant escape**: Change `company_id` to access other organizations' data
- **Data integrity**: Delete or corrupt critical profile fields

### Proof of Concept

```python
# Any authenticated user can escalate to admin:
PATCH /profiles/{their_user_id}
{"role": "admin"}
```

### Fix

Use a Pydantic model to restrict updatable fields:

```python
class ProfileUpdate(BaseModel):
    full_name: Optional[str] = None
    avatar_url: Optional[str] = None
    # role and status should NOT be user-updatable
```

And add role-based authorization:

```python
async def api_update_profile(
    user_id: str,
    updates: ProfileUpdate,
    current_user: dict = Depends(get_current_user),
):
    if current_user.get("id") != user_id and current_user.get("role") not in ("admin", "master_admin"):
        raise HTTPException(status_code=403, detail="Not authorized")
    ...
```

### References
- `backend/routers/admin.py:17` — `updates: dict` without schema
- OWASP: Mass Assignment (A05:2021)
