### PR TITLE
fix(translation): remove duplicate limiter import (closes #2898)

### DIFF
--- a/backend/routes/translation.py
+++ b/backend/routes/translation.py
@@ -12,9 +12,6 @@ from fastapi import APIRouter, Depends, HTTPException, status, Request
 from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Optional, Any
 from backend.auth_cookie import get_current_user
-from backend.services.rate_limit_config import limiter
-
-
 
 from backend.limiter import limiter
 from backend.services.translation_service import (


### PR DESCRIPTION
Closes #2898

## Summary
Removes the duplicate `limiter` import in `backend/routes/translation.py`. The first import (`from backend.services.rate_limit_config import limiter`) was silently overridden by the second (`from backend.limiter import limiter`) on the very next line, so the canonical `backend.limiter` instance is the one actually used at runtime — making the `rate_limit_config` import dead code.

## Changes
- `backend/routes/translation.py:15` — Removed `from backend.services.rate_limit_config import limiter` and the two blank lines that followed it

## Why this is safe
- `backend.limiter` (line 19, now line 16 after removal) is the canonical, app-wide limiter instance used across the codebase
- `rate_limit_config.limiter` is silently shadowed on the next line, so removing it has zero runtime impact
- No call sites in this file reference the `rate_limit_config` instance — verified by full-file read

## Testing
- `python -c "import ast; ast.parse(open('backend/routes/translation.py').read())"` → SYNTAX OK
- `git diff` confirms only the intended import is removed (3 lines deleted total: 1 import + 2 blank)

## Risk
Trivial. One-line removal, no behavior change, no test fixtures to update, no call site changes needed.