### PR TITLE
fix(security): enforce schema + role gate on PATCH /api/profiles/{user_id} (closes #2894)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from backend.database import supabase
 from backend.auth_cookie import get_current_user
+from backend.schemas import ProfileUpdate
 
 router = APIRouter(prefix="/api", tags=["Admin"])
 
@@ -22,11 +23,23 @@ async def api_get_profiles(
 @router.patch("/profiles/{user_id}")
 async def api_update_profile(
     user_id: str,
-    updates: dict,
+    updates: ProfileUpdate,
     current_user: dict = Depends(get_current_user),
 ):
+    # Authorization: only the user themselves, or admin/master_admin, may update.
+    caller_id = current_user.get("id") or current_user.get("user_id")
+    caller_role = current_user.get("role")
+    if caller_id != user_id and caller_role not in ("admin", "master_admin"):
+        raise HTTPException(status_code=403, detail="Not authorized to update this profile")
+
     if not supabase: return {}
-    res = supabase.table("profiles").update(updates).eq("id", user_id).execute()
+    # Schema validation in ProfileUpdate (extra="forbid") already blocks
+    # any field outside the allowlist, so a Pydantic .model_dump() with
+    # exclude_unset=True gives us only what the client actually sent.
+    payload = updates.model_dump(exclude_unset=True)
+    if not payload:
+        return {}
+    res = supabase.table("profiles").update(payload).eq("id", user_id).execute()
     return res.data[0] if res.data else {}
 
 @router.delete("/profiles/{user_id}")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, List, Dict, Any
 class TicketRequest(BaseModel):
     text: str
@@ -70,4 +70,31 @@ class TicketResponse(BaseModel):
     sla_breach_at: str | None = None
     version: str = "2.1.0-Neural-Diagnostic"
 
+
+# ─── Profile update schema (closes #2894) ──────────────────────────────────
+# `extra="forbid"` rejects unknown fields, so a client cannot smuggle
+# `role`, `status`, `company_id`, `email`, etc. into the PATCH body.
+# Fields are all Optional so PATCH can update a subset; the handler uses
+# `exclude_unset=True` to only persist what was actually sent.
+class ProfileUpdate(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    full_name: Optional[str] = Field(default=None, max_length=200)
+    avatar_url: Optional[str] = Field(default=None, max_length=2048)
+    bio: Optional[str] = Field(default=None, max_length=1000)
+    phone: Optional[str] = Field(default=None, max_length=32)
+    timezone: Optional[str] = Field(default=None, max_length=64)
+    locale: Optional[str] = Field(default=None, max_length=16)
+
+    @field_validator("avatar_url")
+    @classmethod
+    def _validate_avatar_url(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            return None
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("avatar_url must be an http(s) URL")
+        return v
 

--- a/backend/tests/test_admin_mass_assignment_2894.py
+++ b/backend/tests/test_admin_mass_assignment_2894.py
@@ -1,0 +1,185 @@
+"""
+Regression tests for PATCH /api/profiles/{user_id} — closes #2894.
+
+Original vulnerability: the endpoint accepted `updates: dict`, so any
+authenticated user could PATCH any profile field on any user, including
+`role` (privilege escalation), `status`, `company_id`, and `email`
+(account takeover / tenant escape).
+
+These tests pin the new behavior:
+  1. Schema rejects unknown fields (extra="forbid") with 422.
+  2. Caller may only update their own profile, unless admin/master_admin.
+  3. Allowed fields round-trip through to supabase unchanged.
+  4. PATCH with empty body returns 200 (no-op) without calling supabase.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make the project importable regardless of cwd.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+# Mock heavy ML deps so importing the app is cheap in CI.
+for _m in ("torch", "torch.nn", "torch.nn.functional", "transformers", "sentence_transformers"):
+    sys.modules.setdefault(_m, MagicMock())
+
+from fastapi.testclient import TestClient
+import main  # noqa: E402
+
+client = TestClient(main.app)
+
+
+# ─── Fixtures ───────────────────────────────────────────────────────────────
+
+USER_SELF = {"id": "user-1", "email": "self@example.com", "role": "user"}
+USER_OTHER = {"id": "user-2", "email": "other@example.com", "role": "user"}
+USER_ADMIN = {"id": "admin-1", "email": "admin@example.com", "role": "admin"}
+USER_MASTER = {"id": "master-1", "email": "m@example.com", "role": "master_admin"}
+
+
+@pytest.fixture
+def mock_supabase():
+    """Replace main.supabase with a MagicMock for the duration of the test."""
+    original = getattr(main, "supabase", None)
+    sb = MagicMock()
+    # chain: supabase.table(...).update(payload).eq("id", x).execute() -> .data
+    sb.table.return_value.update.return_value.eq.return_value.execute.return_value = MagicMock(
+        data=[{"id": "user-1", "full_name": "Updated"}]
+    )
+    main.supabase = sb
+    yield sb
+    main.supabase = original
+
+
+def _as(user: dict):
+    """Override the auth dependency to return the given user dict."""
+    from backend.auth_cookie import get_current_user
+    main.app.dependency_overrides[get_current_user] = lambda: user
+    return user
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    main.app.dependency_overrides.clear()
+    yield
+    main.app.dependency_overrides.clear()
+
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+def test_rejects_unknown_field_role_escalation(mock_supabase):
+    """#2894 primary PoC: any user tries to set role=admin. Must 422."""
+    _as(USER_SELF)
+    r = client.patch(
+        "/api/profiles/user-1",
+        json={"role": "admin"},
+    )
+    assert r.status_code == 422, r.text
+    # Pydantic v2 extra=forbid messages mention "Extra inputs"
+    body = r.text
+    assert "role" in body or "Extra" in body, body
+    # supabase must NOT be called.
+    mock_supabase.table.assert_not_called()
+
+
+def test_rejects_status_field(mock_supabase):
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-1", json={"status": "verified"})
+    assert r.status_code == 422, r.text
+    mock_supabase.table.assert_not_called()
+
+
+def test_rejects_company_id_field(mock_supabase):
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-1", json={"company_id": "other-tenant"})
+    assert r.status_code == 422, r.text
+    mock_supabase.table.assert_not_called()
+
+
+def test_rejects_email_field(mock_supabase):
+    """Email is auth-controlled; users must not be able to PATCH it."""
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-1", json={"email": "attacker@evil.com"})
+    assert r.status_code == 422, r.text
+    mock_supabase.table.assert_not_called()
+
+
+def test_user_cannot_update_other_profile(mock_supabase):
+    """Authorization: user-1 cannot PATCH user-2's profile."""
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-2", json={"full_name": "Hacked"})
+    assert r.status_code == 403, r.text
+    assert "Not authorized" in r.json()["detail"]
+    mock_supabase.table.assert_not_called()
+
+
+def test_user_can_update_own_profile(mock_supabase):
+    """Authorization: user-1 can update their own profile with allowed fields."""
+    _as(USER_SELF)
+    r = client.patch(
+        "/api/profiles/user-1",
+        json={"full_name": "New Name", "bio": "Hello", "avatar_url": "https://x/y.png"},
+    )
+    assert r.status_code == 200, r.text
+    # update() must be called with the exact allowlist payload
+    mock_supabase.table.return_value.update.assert_called_once()
+    payload = mock_supabase.table.return_value.update.call_args.args[0]
+    assert payload == {
+        "full_name": "New Name",
+        "bio": "Hello",
+        "avatar_url": "https://x/y.png",
+    }
+    # forbidden fields not present in payload
+    for forbidden in ("role", "status", "company_id", "email"):
+        assert forbidden not in payload
+
+
+def test_admin_can_update_other_profile(mock_supabase):
+    _as(USER_ADMIN)
+    r = client.patch("/api/profiles/user-2", json={"full_name": "Admin Renamed"})
+    assert r.status_code == 200, r.text
+    payload = mock_supabase.table.return_value.update.call_args.args[0]
+    assert payload == {"full_name": "Admin Renamed"}
+
+
+def test_master_admin_can_update_other_profile(mock_supabase):
+    _as(USER_MASTER)
+    r = client.patch("/api/profiles/user-2", json={"full_name": "Master Renamed"})
+    assert r.status_code == 200, r.text
+
+
+def test_non_admin_role_cannot_update_other(mock_supabase):
+    """A 'manager' or any other non-allowlisted role must NOT bypass."""
+    _as({"id": "mgr-1", "email": "m@x.com", "role": "manager"})
+    r = client.patch("/api/profiles/user-2", json={"full_name": "Bypass attempt"})
+    assert r.status_code == 403, r.text
+    mock_supabase.table.assert_not_called()
+
+
+def test_avatar_url_must_be_http(mock_supabase):
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-1", json={"avatar_url": "javascript:alert(1)"})
+    assert r.status_code == 422, r.text
+    mock_supabase.table.assert_not_called()
+
+
+def test_empty_body_is_noop(mock_supabase):
+    """An empty PATCH should be a 200 with no DB write."""
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-1", json={})
+    assert r.status_code == 200, r.text
+    mock_supabase.table.assert_not_called()
+
+
+def test_exclude_unset_only_persists_sent_fields(mock_supabase):
+    """If client only sends full_name, the DB write must only contain full_name."""
+    _as(USER_SELF)
+    r = client.patch("/api/profiles/user-1", json={"full_name": "Only Name"})
+    assert r.status_code == 200, r.text
+    payload = mock_supabase.table.return_value.update.call_args.args[0]
+    assert payload == {"full_name": "Only Name"}
+    assert "avatar_url" not in payload
+    assert "bio" not in payload


### PR DESCRIPTION
Closes #2894

## Summary

Fixes a **HIGH** mass-assignment privilege-escalation vulnerability in `PATCH /api/profiles/{user_id}` (CVSS 8.0). The endpoint accepted a raw `dict` body and had no authorization check, so any authenticated user could:

- Set `role: "admin"` or `role: "master_admin"` on their own profile (privilege escalation)
- Change `email` of any user (account takeover)
- Modify `status` to bypass email verification or suspend other users
- Change `company_id` (tenant escape)

## Changes

### `backend/schemas.py`
- New `ProfileUpdate` Pydantic model with `extra="forbid"` and a 6-field allowlist:
  `full_name`, `avatar_url`, `bio`, `phone`, `timezone`, `locale`
- All `Optional` so PATCH can update a subset
- `field_validator` on `avatar_url` enforces http(s) scheme (rejects `javascript:`, `data:`, etc.)
- Length caps on every string field

### `backend/routers/admin.py`
- Handler now accepts `ProfileUpdate` instead of `dict`
- New auth check: caller must be the user themselves, OR have role in `("admin", "master_admin")`, else **403**
- Uses `updates.model_dump(exclude_unset=True)` so partial PATCHes don't null out fields the client didn't send
- Empty-body PATCH is a no-op (returns `{}` without touching the DB)

### `backend/tests/test_admin_mass_assignment_2894.py` (new)
12 regression tests covering:
1. Schema rejects `role`, `status`, `company_id`, `email` (all → 422, no DB call)
2. User cannot PATCH another user's profile (→ 403)
3. User CAN PATCH their own profile with allowlisted fields
4. Admin / master_admin can PATCH any profile
5. Non-allowlisted roles (e.g. "manager") cannot bypass
6. `avatar_url` rejects non-http(s) schemes
7. Empty body is a 200 no-op
8. `exclude_unset` ensures only sent fields hit the DB

## Why this is the right fix

- The existing handler used `updates: dict` → Pydantic couldn't enforce shape
- Now the schema is the single source of truth for what's user-updatable
- A future maintainer adding a new field to `ProfileUpdate` is a deliberate, reviewable change — not a silent privilege expansion
- The auth check uses `current_user.get("id") or current_user.get("user_id")` to be defensive against either user-dict shape (auth_cookie returns one or the other depending on the user object)

## Testing

- Syntax check on both modified files: PASS
- ProfileUpdate validated in isolation:
  - `ProfileUpdate(role="admin")` → ValidationError ✓
  - `ProfileUpdate(avatar_url="javascript:alert(1)")` → ValidationError ✓
  - `ProfileUpdate(full_name="X").model_dump(exclude_unset=True)` → `{"full_name": "X"}` ✓
  - `ProfileUpdate().model_dump(exclude_unset=True)` → `{}` ✓
- Handler logic simulated in-process: 6 scenarios all pass
- Full pytest suite in `test_admin_mass_assignment_2894.py` (12 cases) runs in CI

## Risk

Low. The new `ProfileUpdate` is a strict superset of the *intended* use — any well-formed PATCH the project was already doing will keep working. The auth check is the only behavior change for the happy path: a user trying to PATCH another user's profile will now correctly get 403.
