### PR TITLE
fix: prevent mass assignment in updateProfile

### DIFF
--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -245,17 +245,24 @@ const useAuthStore = create(
 
 
             updateProfile: async (updates) => {
-                const { profile } = get();
-                if (!profile?.id) return;
+    const { profile } = get();
+    if (!profile?.id) return;
 
-                set({ loading: true });
-                try {
-                    const { data, error } = await supabase
-                        .from('profiles')
-                        .update(updates)
-                        .eq('id', profile.id)
-                        .select()
-                        .single();
+    // Whitelist: only permit safe, user-editable fields
+    const ALLOWED_FIELDS = ['full_name', 'avatar_url', 'phone', 'company'];
+    const safeUpdates = Object.fromEntries(
+        Object.entries(updates).filter(([key]) => ALLOWED_FIELDS.includes(key))
+    );
+    if (Object.keys(safeUpdates).length === 0) return;
+
+    set({ loading: true });
+    try {
+        const { data, error } = await supabase
+            .from('profiles')
+            .update(safeUpdates)
+            .eq('id', profile.id)
+            .select()
+            .single();
 
                     if (error) throw error;
                     if (data) {


### PR DESCRIPTION
Whitelist only safe fields (full_name, avatar_url, phone, company) before passing updates to Supabase. Prevents privilege escalation via role/status/company_id injection.

Fixes #2894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile updates now only allow changes to authorized fields: full name, avatar, phone, and company. Updates attempting to modify other profile fields are filtered out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->