### PR TITLE
fix: remove hardcoded secrets and add .env to gitignore

### DIFF
--- a/Frontend/.gitignore
+++ b/Frontend/.gitignore
@@ -24,3 +24,8 @@ dist-ssr
 *.sw?
 
 .vercel
+
+# Environment variables
+.env
+.env.local
+.env.*.local

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,16 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+venv/
+env/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Logs and data
+*.log
+data/low_confidence_log.json
+user_feedback_rows.csv

--- a/supabase/migrations/20260331000000_resolve_vault_sync.sql
+++ b/supabase/migrations/20260331000000_resolve_vault_sync.sql
@@ -10,10 +10,8 @@ create table if not exists internal_config.secrets (
   updated_at timestamptz default now()
 );
 
--- Sync the Service Role Key
-insert into internal_config.secrets (name, value)
-values ('SUPABASE_SERVICE_ROLE_KEY', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MjM4NDA3OCwiZXhwIjoyMDg3OTYwMDc4fQ.b3tZ_yad4WPQi4oSqGp1ksr_zw-ldByLqZWvT7HX5aQ')
-on conflict (name) do update set value = excluded.value, updated_at = now();
+-- NOTE: The Service Role Key should be stored as an environment variable
+-- and set via a secure deployment process, NOT hardcoded in migrations
 
 -- Ensure only the database owner can see this
 revoke all on internal_config.secrets from public;


### PR DESCRIPTION
Okay, issue #2906 is now fixed! Here's what we did:

## Summary of Fixes:
1. Removed hardcoded secret : Removed Supabase service role key from supabase/migrations/20260331000000_resolve_vault_sync.sql line 15 and replaced it with a note to use environment variables instead.
2. Updated Frontend/.gitignore : Added .env , .env.local , and .env.*.local to gitignore.
3. Created backend/.gitignore : Added a proper gitignore for the backend directory that ignores venv, pycache , logs, and environment variables.
## Next Steps (IMPORTANT):
As per the SECURITY_ADVISORY.md, you must rotate all three keys:

1. Rotate Supabase service_role key
2. Rotate Google API Key
3. Rotate GitHub PAT
4. Consider using git-filter-repo to clean secrets from git history

Closes #2906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude environment variable files and build artifacts from version control.
  * Enhanced security handling for deployment credentials through environment variable management rather than hardcoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->