### PR TITLE
fix: only accept https:// in isLikelyValidUrl to prevent auth tokens being sent over plain HTTP

### DIFF
--- a/Frontend/src/lib/supabaseClient.js
+++ b/Frontend/src/lib/supabaseClient.js
@@ -14,7 +14,7 @@ const isLikelyValidUrl = (value) => {
 	if (!value || INVALID_MARKERS.has(value)) return false
 	try {
 		const parsed = new URL(value)
-		return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+		return parsed.protocol === 'https:'
 	} catch {
 		return false
 	}


### PR DESCRIPTION
## Summary
Removes http:// acceptance from isLikelyValidUrl in supabaseClient.js
so a misconfigured plain HTTP URL correctly falls back to the safe
disabled client instead of creating a real Supabase connection.

## Problem
isLikelyValidUrl accepted both https:// and http://. A misconfigured
VITE_SUPABASE_URL with http:// passed validation and created a real
Supabase client, transmitting auth tokens over plain HTTP.

## Fix
Removed || parsed.protocol === 'http:' from the protocol check.
Only https:// is now accepted matching Supabase's requirement.

## Changes
- Frontend/src/supabaseClient.js — removed http:// from protocol check

Closes #2910 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated protocol validation to require HTTPS-only URLs. Previously, both HTTP and HTTPS protocols were accepted for configuration. This change enforces stricter validation standards, affecting how the application initializes its client connection based on configuration validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->