### PR TITLE
[MEDIUM] Fix XSS and missing noopener in ticket print/export (fixes #2929)

### DIFF
--- a/Frontend/src/utils/exportUtils.js
+++ b/Frontend/src/utils/exportUtils.js
@@ -139,9 +139,13 @@ export function generateTicketPrintHTML(ticket) {
 }
 
 function escapeHTML(s) {
-  const div = document.createElement('div');
-  div.textContent = s ?? '';
-  return div.innerHTML;
+  if (s == null) return '';
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
 }
 
 /**
@@ -150,7 +154,7 @@ function escapeHTML(s) {
  */
 export function printTicket(ticket) {
   if (!ticket) return;
-  const win = window.open('', '_blank');
+  const win = window.open('', '_blank', 'noopener,noreferrer');
   if (!win) return;
   win.document.write(generateTicketPrintHTML(ticket));
   win.document.close();


### PR DESCRIPTION
## Summary

Fixes #2929 - Two XSS-related issues in ticket print/export.

### Changes

- Replaced DOM-based escapeHTML() (div.textContent + div.innerHTML) with a pure string-replace approach that encodes &, <, >, ", and '
- Added noopener,noreferrer to window.open() in printTicket() to prevent the print window from accessing window.opener
