### PR TITLE
feat: integrate Redis caching for ticket lists and stats queries

### DIFF
--- a/backend/routers/tickets.py
+++ b/backend/routers/tickets.py
@@ -17,12 +17,25 @@ async def get_tickets(company_id: str | None = None, user: dict = Depends(get_cu
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
     
+    from backend.services.redis_cache import redis_cache
+    
+    cache_key = f"helpdesk:tickets:list:{company_id or 'all'}"
+    if redis_cache.available:
+        cached_data = redis_cache.get_json(cache_key)
+        if cached_data is not None:
+            return cached_data
+
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
     if company_id:
         query = query.eq("company_id", company_id)
         
     res = query.execute()
-    return res.data
+    data = res.data
+    
+    if redis_cache.available:
+        redis_cache.set_json(cache_key, data, ttl=300)
+        
+    return data
 
 @router.post("/save")
 async def save_ticket(request_body: TicketSaveRequest, user: dict = Depends(get_current_user)):

--- a/backend/services/digest_service.py
+++ b/backend/services/digest_service.py
@@ -66,6 +66,13 @@ def get_weekly_stats(company_id: str) -> dict:
         logger.warning("[Digest] Supabase connection is offline. Returning mock stats.")
         return stats
 
+    from backend.services.redis_cache import redis_cache
+    cache_key = f"helpdesk:stats:weekly:{company_id}"
+    if redis_cache.available:
+        cached_stats = redis_cache.get_json(cache_key)
+        if cached_stats is not None:
+            return cached_stats
+
     try:
         # Get company name
         company_res = supabase.table("companies").select("name").eq("id", company_id).single().execute()
@@ -218,6 +225,10 @@ def get_weekly_stats(company_id: str) -> dict:
 
     except Exception as e:
         logger.error(f"[Digest] Error building weekly stats: {e}")
+
+    from backend.services.redis_cache import redis_cache
+    if redis_cache.available:
+        redis_cache.set_json(cache_key, stats, ttl=3600)
 
     return stats
 

--- a/backend/services/redis_cache.py
+++ b/backend/services/redis_cache.py
@@ -156,5 +156,29 @@ class RedisInferenceCache:
         except Exception as error:
             logger.warning("[RedisCache] embedding set failed: %s", error)
 
+    def get_json(self, key: str) -> Any | None:
+        """Retrieve a cached generic JSON payload."""
+        if not self.available:
+            return None
+        try:
+            raw = self._client.get(key)
+            return json.loads(raw) if raw else None
+        except Exception as error:
+            logger.warning("[RedisCache] get_json failed for %s: %s", key, error)
+            return None
+
+    def set_json(self, key: str, payload: Any, ttl: int | None = None) -> None:
+        """Cache a generic JSON payload."""
+        if not self.available:
+            return
+        try:
+            self._client.setex(
+                key,
+                ttl or self.ttl_seconds,
+                json.dumps(payload),
+            )
+        except Exception as error:
+            logger.warning("[RedisCache] set_json failed for %s: %s", key, error)
+
 
 redis_cache = RedisInferenceCache()

--- a/main.py
+++ b/main.py
@@ -74,10 +74,23 @@ async def list_tickets(
     """List tickets scoped to the authenticated user's tenant."""
     security_manager.verify_tenant_access(company_id, user)
     if supabase:
+        from backend.services.redis_cache import redis_cache
+        cache_key = f"helpdesk:tickets:list:{company_id or 'all'}"
+        
+        if redis_cache.available:
+            cached = redis_cache.get_json(cache_key)
+            if cached is not None:
+                return cached
+
         query = supabase.table("tickets").select("*").order("created_at", desc=True)
         if company_id:
             query = query.eq("company_id", company_id)
-        return query.execute().data
+        data = query.execute().data
+        
+        if redis_cache.available:
+            redis_cache.set_json(cache_key, data, ttl=300)
+            
+        return data
     return []
 
 


### PR DESCRIPTION
## Description
Fixes #2946

### Summary
This PR integrates Redis caching to optimize database queries for ticket list fetching and weekly stats generation, ensuring the application remains performant under high developer load.

### Changes Made
- Added generic JSON caching methods (`get_json` and `set_json`) to the `RedisInferenceCache` service.
- Cached the `list_tickets` (`main.py`) and `get_tickets` (`backend/routers/tickets.py`) endpoints with tenant-scoped cache keys (`helpdesk:tickets:list:{company_id}`).
- Cached the expensive `get_weekly_stats` DB aggregation in `backend/services/digest_service.py` with a 1-hour TTL.
- Designed the cache layer to fail gracefully (bypassing the cache and querying the DB directly) if the Redis connection goes down.