### PR TITLE
feat: add WebSocket server metrics panel with CPU, memory, disk and network stats

### DIFF
--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -38,3 +38,5 @@ VITE_STRIPE_GROWTH_LINK=https://billing.stripe.com/p/mock-link
 #   supabase secrets set OPENROUTER_API_KEY_1=your-key
 #   supabase secrets set GROQ_API_KEY_1=your-key
 # See supabase/functions/ai-proxy/index.ts for the full list of secret names.
+
+VITE_WS_URL=ws://localhost:8000/ws/metrics

--- a/Frontend/src/components/ServerMetricsPanel.jsx
+++ b/Frontend/src/components/ServerMetricsPanel.jsx
@@ -1,0 +1,143 @@
+import { useEffect, useState, useRef } from "react";
+import { Activity, Cpu, HardDrive, Wifi, Server } from "lucide-react";
+
+const BACKEND_WS_URL = import.meta.env.VITE_WS_URL || "ws://localhost:8000/ws/metrics";
+
+function MetricBar({ label, percent, color }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs font-semibold text-slate-500 dark:text-slate-400">
+        <span>{label}</span>
+        <span>{percent}%</span>
+      </div>
+      <div className="w-full bg-slate-100 dark:bg-slate-800 rounded-full h-2">
+        <div
+          className={`h-2 rounded-full transition-all duration-500 ${color}`}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function ServerMetricsPanel() {
+  const [metrics, setMetrics] = useState(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState(null);
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    const connect = () => {
+      const ws = new WebSocket(BACKEND_WS_URL);
+      wsRef.current = ws;
+
+      ws.onopen = () => { setConnected(true); setError(null); };
+      ws.onmessage = (e) => setMetrics(JSON.parse(e.data));
+      ws.onerror = () => setError("WebSocket connection failed");
+      ws.onclose = () => {
+        setConnected(false);
+        setTimeout(connect, 3000); // auto-reconnect after 3s
+      };
+    };
+
+    connect();
+    return () => wsRef.current?.close();
+  }, []);
+
+  const statusColor = metrics?.status === "healthy"
+    ? "text-emerald-500"
+    : "text-red-500";
+
+  return (
+    <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-2xl p-6 shadow-sm space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Server className="w-5 h-5 text-emerald-500" />
+          <h2 className="font-bold text-slate-800 dark:text-slate-100 text-sm">Server Metrics</h2>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className={`w-2 h-2 rounded-full ${connected ? "bg-emerald-500 animate-pulse" : "bg-red-500"}`} />
+          <span className="text-xs font-semibold text-slate-400">
+            {connected ? "Live" : "Reconnecting..."}
+          </span>
+        </div>
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-500 font-medium">{error}</p>
+      )}
+
+      {!metrics ? (
+        <div className="flex items-center justify-center py-8 text-slate-400 text-sm">
+          Connecting to server...
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* Status */}
+          <div className="flex items-center gap-2">
+            <Activity className="w-4 h-4 text-slate-400" />
+            <span className={`text-xs font-bold uppercase tracking-widest ${statusColor}`}>
+              {metrics.status}
+            </span>
+            <span className="text-xs text-slate-400 ml-auto">
+              {new Date(metrics.timestamp).toLocaleTimeString()}
+            </span>
+          </div>
+
+          {/* CPU */}
+          <div className="space-y-1">
+            <div className="flex items-center gap-1 mb-1">
+              <Cpu className="w-3.5 h-3.5 text-slate-400" />
+              <span className="text-xs font-bold text-slate-500">CPU ({metrics.cpu.count} cores)</span>
+            </div>
+            <MetricBar
+              label="Usage"
+              percent={metrics.cpu.percent}
+              color={metrics.cpu.percent > 80 ? "bg-red-500" : "bg-emerald-500"}
+            />
+          </div>
+
+          {/* Memory */}
+          <div className="space-y-1">
+            <div className="flex items-center gap-1 mb-1">
+              <Server className="w-3.5 h-3.5 text-slate-400" />
+              <span className="text-xs font-bold text-slate-500">
+                Memory ({metrics.memory.used_mb} / {metrics.memory.total_mb} MB)
+              </span>
+            </div>
+            <MetricBar
+              label="Usage"
+              percent={metrics.memory.percent}
+              color={metrics.memory.percent > 85 ? "bg-red-500" : "bg-blue-500"}
+            />
+          </div>
+
+          {/* Disk */}
+          <div className="space-y-1">
+            <div className="flex items-center gap-1 mb-1">
+              <HardDrive className="w-3.5 h-3.5 text-slate-400" />
+              <span className="text-xs font-bold text-slate-500">
+                Disk ({metrics.disk.used_gb} / {metrics.disk.total_gb} GB)
+              </span>
+            </div>
+            <MetricBar
+              label="Usage"
+              percent={metrics.disk.percent}
+              color={metrics.disk.percent > 90 ? "bg-red-500" : "bg-purple-500"}
+            />
+          </div>
+
+          {/* Network */}
+          <div className="flex items-center gap-2 pt-1 border-t border-slate-100 dark:border-slate-800">
+            <Wifi className="w-3.5 h-3.5 text-slate-400" />
+            <span className="text-xs text-slate-500">
+              ↑ {metrics.network.bytes_sent_mb} MB &nbsp;
+              ↓ {metrics.network.bytes_recv_mb} MB
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -1,0 +1,49 @@
+import asyncio
+import json
+import datetime
+import psutil
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+from backend.auth_cookie import get_current_user
+
+router = APIRouter(prefix="/ws", tags=["metrics"])
+
+def get_server_metrics() -> dict:
+    cpu = psutil.cpu_percent(interval=None)
+    mem = psutil.virtual_memory()
+    disk = psutil.disk_usage("/")
+    net = psutil.net_io_counters()
+    return {
+        "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        "cpu": {
+            "percent": cpu,
+            "count": psutil.cpu_count(),
+        },
+        "memory": {
+            "total_mb": round(mem.total / 1024 / 1024, 1),
+            "used_mb": round(mem.used / 1024 / 1024, 1),
+            "percent": mem.percent,
+        },
+        "disk": {
+            "total_gb": round(disk.total / 1024 / 1024 / 1024, 1),
+            "used_gb": round(disk.used / 1024 / 1024 / 1024, 1),
+            "percent": disk.percent,
+        },
+        "network": {
+            "bytes_sent_mb": round(net.bytes_sent / 1024 / 1024, 2),
+            "bytes_recv_mb": round(net.bytes_recv / 1024 / 1024, 2),
+        },
+        "status": "healthy" if cpu < 85 and mem.percent < 90 else "degraded",
+    }
+
+@router.websocket("/metrics")
+async def metrics_websocket(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            metrics = get_server_metrics()
+            await websocket.send_text(json.dumps(metrics))
+            await asyncio.sleep(2)  # emit every 2 seconds
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        await websocket.close(code=1011)

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from supabase import create_client
 
 from backend.csrf import CSRFTokenMiddleware, set_csrf_cookie, CSRF_COOKIE_NAME
 from backend.swagger_config import SWAGGER_UI_CUSTOM_CSS, SWAGGER_UI_CUSTOM_JS
+from backend.routers import metrics as metrics_router
 
 from backend.routers import tickets, ai, admin, health, auth
 from backend.routes import translation, estimator, voice, privacy, active_learning, weekly_digest
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI()
 
 app.add_middleware(CSRFTokenMiddleware)
+app.include_router(metrics_router.router)
 
 # Initialize Supabase client
 SUPABASE_URL = os.getenv("SUPABASE_URL")

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ pytest==8.2.2
 pytest-asyncio==0.23.7
 pytest-mock==3.14.0
 pycryptodome==3.21.0
+psutil>=5.9.0


### PR DESCRIPTION
## Summary

Resolves #2970 by building a lightweight real-time server metrics panel using WebSockets, emitting CPU, memory, disk, and network stats every 2 seconds to update dashboard graphics live.

---

## Changes Made

### 1. `backend/routers/metrics.py` — New WebSocket Endpoint
- `GET /ws/metrics` — WebSocket pipeline emitting server stats every 2 seconds
- Collects CPU percent, core count, memory usage, disk usage, and network I/O via `psutil`
- Auto-detects server health status (`healthy` / `degraded`) based on thresholds
- Gracefully handles `WebSocketDisconnect`

### 2. `backend/main.py` — Router Registration
- Registered `metrics.router` with the FastAPI app

### 3. `Frontend/src/components/ServerMetricsPanel.jsx` — React Dashboard Panel
- Live-updating panel with animated progress bars for CPU, memory, and disk
- Network I/O display (bytes sent/received)
- Auto-reconnects on WebSocket disconnect (3s retry)
- Shows live/reconnecting connection status indicator
- Fully dark mode compatible

### 4. `Frontend/.env.example`
- Added `VITE_WS_URL` for configurable WebSocket backend URL

### 5. `backend/requirements.txt`
- Added `psutil>=5.9.0`

---

## Features
- ⚡ Real-time updates every 2 seconds via WebSocket
- 📊 CPU, Memory, Disk progress bars with color-coded thresholds
- 🌐 Network bytes sent/received display
- 🔁 Auto-reconnect on connection loss
- 🌙 Full dark mode support

---

Closes #2970 