### PR TITLE
feat: optimize multi-stage Dockerfiles with non-root users, build args and prod resource limits

### DIFF
--- a/Frontend/Dockerfile
+++ b/Frontend/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Multi-stage Dockerfile for HELPDESK.AI Frontend (Vite + nginx)
 # Stage 1 (builder): Build the Vite/React application
-# Stage 2 (production): Serve via nginx:alpine
+# Stage 2 (production): Serve via nginx:alpine with non-root user
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -11,15 +11,24 @@ FROM node:20-alpine AS builder
 
 WORKDIR /build
 
+ARG VITE_API_URL=http://localhost:7860
+ARG VITE_WS_URL=ws://localhost:7860/ws/metrics
+ARG VITE_SUPABASE_URL
+ARG VITE_SUPABASE_ANON_KEY
+
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_WS_URL=$VITE_WS_URL
+ENV VITE_SUPABASE_URL=$VITE_SUPABASE_URL
+ENV VITE_SUPABASE_ANON_KEY=$VITE_SUPABASE_ANON_KEY
+
 COPY package.json package-lock.json* ./
-RUN npm ci
+RUN npm ci --prefer-offline
 
 COPY . .
 RUN npm run build
 
-
 # ---------------------------------------------------------------------------
-# Stage 2: production — serve static files via nginx
+# Stage 2: production — serve static files via nginx with non-root user
 # ---------------------------------------------------------------------------
 FROM nginx:stable-alpine AS production
 
@@ -27,12 +36,23 @@ LABEL maintainer="HELPDESK.AI Team" \
       version="2.0.0" \
       description="AI Helpdesk — frontend production image"
 
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup
+
 COPY --from=builder /build/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+RUN chown -R appuser:appgroup /usr/share/nginx/html && \
+    chown -R appuser:appgroup /var/cache/nginx && \
+    chown -R appuser:appgroup /var/log/nginx && \
+    touch /var/run/nginx.pid && \
+    chown appuser:appgroup /var/run/nginx.pid
+
+USER appuser
 
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["wget", "--spider", "-q", "http://localhost:80/"]
+    CMD wget --spider -q http://localhost:80/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,22 @@
+# =============================================================================
+# Multi-stage Dockerfile for HELPDESK.AI Backend (FastAPI + uvicorn)
+# Stage 1 (builder): Install Python dependencies
+# Stage 2 (production): Minimal runtime image with non-root user
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Stage 1: builder — install dependencies into user space
+# ---------------------------------------------------------------------------
 FROM python:3.12-slim AS builder
 
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install --user --no-cache-dirs -r requirements.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
 
+# ---------------------------------------------------------------------------
+# Stage 2: production — minimal runtime image
+# ---------------------------------------------------------------------------
 FROM python:3.12-slim AS production
 
 LABEL maintainer="HELPDESK.AI Team" \
@@ -14,19 +26,28 @@ LABEL maintainer="HELPDESK.AI Team" \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tesseract-ocr \
     tesseract-ocr-eng \
+    wget \
     && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd --gid 1001 appgroup && \
+    useradd --uid 1001 --gid appgroup --shell /bin/bash --create-home appuser
 
 WORKDIR /app
 
-COPY --from=builder /root/.local /root/.local
-COPY . .
+COPY --from=builder /root/.local /home/appuser/.local
+COPY --chown=appuser:appgroup . .
 
-ENV PATH=/root/.local/bin:$PATH
+ENV PATH=/home/appuser/.local/bin:$PATH
 ENV PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+USER appuser
 
 EXPOSE 7860
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD python /app/backend/healthcheck.py
+    CMD wget --spider -q http://localhost:7860/health || exit 1
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "7860"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "7860", "--workers", "2"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 # ============================================================
 # HELPDESK.AI — Docker Compose (production override)
 # ============================================================
-# Usage (always combine with base docker-compose.yml):
+# Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 # ============================================================
 
@@ -14,6 +14,7 @@ services:
     image: helpdesk-ai-backend:latest
     environment:
       - ENVIRONMENT=production
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-https://helpdeskaiv1.vercel.app}
     volumes: []
     deploy:
       resources:
@@ -26,7 +27,32 @@ services:
     restart: always
 
   frontend:
+    build:
+      args:
+        - VITE_API_URL=${VITE_API_URL:-https://api.helpdeskai.com}
+        - VITE_WS_URL=${VITE_WS_URL:-wss://api.helpdeskai.com/ws/metrics}
+        - VITE_SUPABASE_URL=${VITE_SUPABASE_URL}
+        - VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}
     environment:
       - NODE_ENV=production
     volumes: []
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+        reservations:
+          cpus: "0.1"
+          memory: 64M
+    restart: always
+
+  redis:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 256M
+        reservations:
+          cpus: "0.05"
+          memory: 64M
     restart: always


### PR DESCRIPTION
## 🎯 Summary

Resolves #2967 by optimizing the multi-stage production Dockerfiles for both frontend and backend, reducing image weight, adding non-root user security, fixing a pip typo, and adding build args for Vite env vars.

---

## 🛠️ Changes Made

### 1. `backend/Dockerfile`
- Fixed typo: `--no-cache-dirs` → `--no-cache-dir`
- Added non-root user (`appuser`) for security — containers no longer run as root
- Added `wget` for HTTP-based healthcheck (replaced Python script dependency)
- Healthcheck now uses `wget http://localhost:7860/health` instead of running a Python script
- Fixed CMD: `main:app` → `backend.main:app` (correct module path)
- Added `PYTHONDONTWRITEBYTECODE=1` and `PYTHONUNBUFFERED=1`
- Added `--workers 2` for production throughput

### 2. `Frontend/Dockerfile`
- Added `ARG`/`ENV` for Vite build-time env vars (`VITE_API_URL`, `VITE_WS_URL`, `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`)
- Added non-root user (`appuser`) in nginx stage
- Fixed nginx temp dir permissions for non-root execution
- Added `--prefer-offline` to `npm ci` for faster CI builds

### 3. `docker-compose.prod.yml`
- Added `ALLOWED_ORIGINS` env var for backend CORS in production
- Added frontend `build.args` to pass Vite env vars at build time
- Added resource limits and reservations for frontend and redis services

---

## ✅ Security Improvements
- 🔒 Both containers now run as non-root users
- 🔒 Fixed pip typo that could cause silent dependency install failures
- 🔒 Backend healthcheck no longer depends on internal Python script

---

Closes #2967