### PR TITLE
feat: add frontend CI with vitest and fix backend CI duplicate permissions and silent failures

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - gssoc      
       - "fix/**"
       - "feat/**"
       - "test/**"
@@ -20,16 +21,25 @@ on:
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
-permissions:
-  contents: read
 
 jobs:
+  backend-lint:
+    name: Backend Lint (ruff)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff linter
+        run: ruff check backend/ --output-format=github
   smoke-test:
     name: Smoke Test & Unit Tests
     runs-on: ubuntu-latest
+    needs: backend-lint
     env:
       ALLOW_DEGRADED_STARTUP: "1"
       SUPABASE_URL: "https://placeholder.supabase.co"
@@ -68,8 +78,7 @@ jobs:
             --cov-report=term-missing \
             --cov-fail-under=60 \
             -v \
-            --ignore=backend/tests/test_import_smoke.py \
-            2>&1 || true
+            --ignore=backend/tests/test_import_smoke.py
 
       - name: Run import smoke tests
-        run: pytest backend/tests/test_import_smoke.py -v 2>&1 || true
+        run: pytest backend/tests/test_import_smoke.py -v

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,77 @@
+name: Frontend CI
+
+on:
+  push:
+    branches:
+      - main
+      - gssoc
+      - "fix/**"
+      - "feat/**"
+      - "test/**"
+      - "perf/**"
+      - "security/**"
+      - "docs/**"
+      - "devops/**"
+  pull_request:
+    branches:
+      - main
+      - gssoc
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-lint:
+    name: Frontend Lint (ESLint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: Frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npx eslint src/ --max-warnings=0
+
+  frontend-test:
+    name: Frontend Unit Tests (Vitest)
+    runs-on: ubuntu-latest
+    needs: frontend-lint
+    defaults:
+      run:
+        working-directory: Frontend
+    env:
+      VITE_SUPABASE_URL: "https://placeholder.supabase.co"
+      VITE_SUPABASE_ANON_KEY: "placeholder_key"
+      VITE_API_URL: "http://localhost:7860"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: Frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest
+        run: npx vitest run --reporter=verbose
+
+      - name: Build check (ensure production build succeeds)
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: "https://placeholder.supabase.co"
+          VITE_SUPABASE_ANON_KEY: "placeholder_key"
+          VITE_API_URL: "http://localhost:7860"


### PR DESCRIPTION
## 🎯 Summary

Resolves #2965 by adding a complete frontend CI workflow with ESLint + Vitest, and fixing existing issues in the backend CI workflow.

---

## 🛠️ Changes Made

### 1. `.github/workflows/frontend-ci.yml` — New File
- Runs on every push/PR to `main` and `gssoc`
- **Job 1: `frontend-lint`** — runs ESLint on `src/` with `--max-warnings=0`
- **Job 2: `frontend-test`** — runs Vitest unit tests + production build check
- Uses `needs: frontend-lint` to enforce lint-before-test order
- Injects placeholder Supabase env vars for CI compatibility
- Caches npm dependencies via `actions/setup-node@v4`

### 2. `.github/workflows/backend-ci.yml` — Fixed
- Removed duplicate `permissions:` block (was repeated 3 times)
- Added `gssoc` to push branch triggers
- Added `backend-lint` job running `ruff check backend/`
- Added `needs: backend-lint` to `smoke-test` job
- Removed `2>&1 || true` from pytest commands — failures now correctly fail the CI
- Removed trailing backslash from pytest ignore flag

---

## CI Coverage Added
- 🧪 Frontend: ESLint + Vitest + build check on every PR
- 🧪 Backend: ruff lint + pytest with coverage on every PR
- 🔒 Silent test failures no longer masked by `|| true`
- ⚡ Dependency caching for both npm and pip

---

Closes #2965