### PR TITLE
feat: add image compression utility using expo-image-manipulator before Supabase upload

### DIFF
--- a/MobileApp/src/screens/admin/AdminTicketDetailScreen.js
+++ b/MobileApp/src/screens/admin/AdminTicketDetailScreen.js
@@ -15,7 +15,7 @@ import {
   ShieldCheck, X
 } from 'lucide-react-native';
 import * as Haptics from 'expo-haptics';
-
+import { compressAndUpload, QUALITY_PRESETS } from '../../utils/imageCompressor';
 const TEAMS = ['Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
 const STATUSES = ['pending', 'in_progress', 'resolved', 'closed'];
 

--- a/MobileApp/src/utils/imageCompressor.js
+++ b/MobileApp/src/utils/imageCompressor.js
@@ -1,0 +1,93 @@
+/**
+ * imageCompressor.js
+ * Compresses images using expo-image-manipulator before uploading to Supabase storage.
+ * Reduces payload size, speeds up uploads, and lowers storage costs.
+ */
+
+import * as ImageManipulator from 'expo-image-manipulator';
+import { supabase } from '../lib/supabase';
+
+// Compression config
+const COMPRESSION_CONFIG = {
+  maxWidthPx: 1280,
+  maxHeightPx: 1280,
+  quality: 0.75, // 75% JPEG quality — good balance of size vs clarity
+  format: ImageManipulator.SaveFormat.JPEG,
+};
+
+/**
+ * Compresses an image before upload.
+ * @param {string} uri - Local image URI from camera/picker
+ * @param {object} options - Optional overrides for compression config
+ * @returns {Promise<{uri: string, width: number, height: number, base64?: string}>}
+ */
+export async function compressImage(uri, options = {}) {
+  const config = { ...COMPRESSION_CONFIG, ...options };
+
+  const result = await ImageManipulator.manipulateAsync(
+    uri,
+    [
+      {
+        resize: {
+          width: config.maxWidthPx,
+          height: config.maxHeightPx,
+        },
+      },
+    ],
+    {
+      compress: config.quality,
+      format: config.format,
+      base64: options.includeBase64 ?? false,
+    }
+  );
+
+  return result;
+}
+
+/**
+ * Compresses and uploads an image to Supabase storage.
+ * @param {string} uri - Local image URI
+ * @param {string} bucket - Supabase storage bucket name
+ * @param {string} filePath - Destination path in the bucket (e.g. 'tickets/abc123.jpg')
+ * @param {object} options - Optional compression overrides
+ * @returns {Promise<{publicUrl: string, path: string, originalSize?: number, compressedSize?: number}>}
+ */
+export async function compressAndUpload(uri, bucket, filePath, options = {}) {
+  // Step 1: Compress
+  const compressed = await compressImage(uri, options);
+
+  // Step 2: Fetch compressed image as blob
+  const response = await fetch(compressed.uri);
+  const blob = await response.blob();
+
+  // Step 3: Upload to Supabase storage
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .upload(filePath, blob, {
+      contentType: 'image/jpeg',
+      upsert: true,
+    });
+
+  if (error) {
+    throw new Error(`Supabase upload failed: ${error.message}`);
+  }
+
+  // Step 4: Get public URL
+  const { data: urlData } = supabase.storage
+    .from(bucket)
+    .getPublicUrl(data.path);
+
+  return {
+    publicUrl: urlData.publicUrl,
+    path: data.path,
+  };
+}
+
+/**
+ * Helper: pick quality preset by use case
+ */
+export const QUALITY_PRESETS = {
+  thumbnail: { maxWidthPx: 320, maxHeightPx: 320, quality: 0.5 },
+  standard: { maxWidthPx: 1280, maxHeightPx: 1280, quality: 0.75 },
+  high: { maxWidthPx: 1920, maxHeightPx: 1920, quality: 0.9 },
+};

--- a/MobileApp/src/utils/imageCompressor.test.js
+++ b/MobileApp/src/utils/imageCompressor.test.js
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for imageCompressor utility
+ */
+
+import { compressImage, QUALITY_PRESETS } from './imageCompressor';
+
+// Mock expo-image-manipulator
+jest.mock('expo-image-manipulator', () => ({
+  manipulateAsync: jest.fn().mockResolvedValue({
+    uri: 'file://compressed/test.jpg',
+    width: 1280,
+    height: 960,
+  }),
+  SaveFormat: { JPEG: 'jpeg' },
+}));
+
+describe('imageCompressor', () => {
+  it('compressImage returns a compressed uri', async () => {
+    const result = await compressImage('file://test/original.jpg');
+    expect(result.uri).toBe('file://compressed/test.jpg');
+    expect(result.width).toBe(1280);
+  });
+
+  it('QUALITY_PRESETS has thumbnail, standard, high', () => {
+    expect(QUALITY_PRESETS.thumbnail.quality).toBe(0.5);
+    expect(QUALITY_PRESETS.standard.quality).toBe(0.75);
+    expect(QUALITY_PRESETS.high.quality).toBe(0.9);
+  });
+
+  it('compressImage accepts quality override', async () => {
+    const { manipulateAsync } = require('expo-image-manipulator');
+    await compressImage('file://test/original.jpg', { quality: 0.5 });
+    expect(manipulateAsync).toHaveBeenCalledWith(
+      'file://test/original.jpg',
+      expect.any(Array),
+      expect.objectContaining({ compress: 0.5 })
+    );
+  });
+});


### PR DESCRIPTION
## 🎯 Summary

Resolves #2961 by adding a reusable image compression utility using `expo-image-manipulator` that compresses captured photos before sending payloads to the Supabase storage bucket — reducing upload size, speeding up transfers, and lowering storage costs.

---

## 🛠️ Changes Made

### 1. `MobileApp/src/utils/imageCompressor.js` — New Utility
- `compressImage(uri, options)` — compresses any image URI using `expo-image-manipulator`
  - Default: 1280×1280 max resolution, 75% JPEG quality
  - Fully configurable via options override
- `compressAndUpload(uri, bucket, filePath, options)` — compresses then uploads directly to Supabase storage, returns `publicUrl` and `path`
- `QUALITY_PRESETS` — three ready-to-use presets:
  - `thumbnail` → 320px, 50% quality
  - `standard` → 1280px, 75% quality (default)
  - `high` → 1920px, 90% quality

### 2. `MobileApp/src/utils/imageCompressor.test.js` — Unit Tests
- Mocks `expo-image-manipulator` for fast CI testing
- Tests compression output, quality presets, and option overrides

---

## ✅ Benefits
- 📦 Reduces image payload size before Supabase upload
- ⚡ Faster uploads on mobile networks
- 💰 Lower Supabase storage usage
- 🔧 Reusable across all screens via simple import

---

## 📦 Required Dependency

Run the following to install the required package:

expo install expo-image-manipulator

---

Closes #2961