### PR TITLE
perf: Optimize semantic duplicate reindexing with process pool

### DIFF
--- a/backend/services/semantic_duplicate_service.py
+++ b/backend/services/semantic_duplicate_service.py
@@ -234,35 +234,72 @@ class SemanticDuplicateService:
         Re-generate embeddings for all tickets that don't have them.
         Useful for initial migration or after model update.
         """
-        if not self.supabase:
+        if not self.supabase or not self.model:
             return {"indexed": 0, "errors": 0}
 
         total_indexed = 0
         total_errors = 0
         offset = 0
 
-        while True:
-            res = self.supabase.table("tickets") \
-                .select("id, subject, description, summary") \
-                .is_("description_vector", "null") \
-                .range(offset, offset + batch_size - 1) \
-                .execute()
+        # Start multi-process pool outside the loop to avoid overhead per batch
+        try:
+            pool = self.model.start_multi_process_pool()
+        except Exception as e:
+            logger.error(f"[SemanticDuplicate] Could not start multi_process_pool: {e}")
+            pool = None
 
-            batch = res.data or []
-            if not batch:
-                break
+        try:
+            while True:
+                res = self.supabase.table("tickets") \
+                    .select("id, subject, description, summary") \
+                    .is_("description_vector", "null") \
+                    .range(offset, offset + batch_size - 1) \
+                    .execute()
 
-            for ticket in batch:
-                text = (ticket.get("description") or ticket.get("subject") or ticket.get("summary") or "").strip()
-                if not text:
+                batch = res.data or []
+                if not batch:
+                    break
+
+                texts = []
+                ticket_ids = []
+                for ticket in batch:
+                    text = (ticket.get("description") or ticket.get("subject") or ticket.get("summary") or "").strip()
+                    if text:
+                        texts.append(text)
+                        ticket_ids.append(ticket["id"])
+
+                if not texts:
+                    offset += batch_size
                     continue
-                success = await self.index_ticket(ticket["id"], text)
-                if success:
-                    total_indexed += 1
-                else:
-                    total_errors += 1
 
-            offset += batch_size
+                try:
+                    # Parallel inference
+                    if pool:
+                        embeddings = self.model.encode_multi_process(texts, pool)
+                    else:
+                        embeddings = self.model.encode(texts)
+
+                    # Update each ticket in the database
+                    for ticket_id, embedding in zip(ticket_ids, embeddings):
+                        emb_list = embedding.tolist() if hasattr(embedding, "tolist") else list(embedding)
+                        try:
+                            self.supabase.table("tickets") \
+                                .update({"description_vector": emb_list}) \
+                                .eq("id", ticket_id) \
+                                .execute()
+                            total_indexed += 1
+                        except Exception as e:
+                            logger.error(f"[SemanticDuplicate] Index error for {ticket_id}: {e}")
+                            total_errors += 1
+                            
+                except Exception as e:
+                    logger.error(f"[SemanticDuplicate] Batch encoding error: {e}")
+                    total_errors += len(texts)
+
+                offset += batch_size
+        finally:
+            if pool:
+                self.model.stop_multi_process_pool(pool)
 
         logger.info(f"[SemanticDuplicate] Re-index complete: {total_indexed} indexed, {total_errors} errors")
         return {"indexed": total_indexed, "errors": total_errors}

--- a/backend/tests/test_semantic_duplicates.py
+++ b/backend/tests/test_semantic_duplicates.py
@@ -227,3 +227,45 @@ async def test_embeddings_use_stub_without_loading_sentence_transformer():
 
     assert result["is_duplicate"] is False
     service._model.encode.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reindex_all_parallel_processing():
+    service = SemanticDuplicateService(supabase_client=MagicMock())
+    service._loaded = True
+    service._model = MagicMock()
+    
+    mock_pool = MagicMock()
+    service._model.start_multi_process_pool.return_value = mock_pool
+    
+    class FakeNumpyArray:
+        def __init__(self, vals):
+            self.vals = vals
+        def tolist(self):
+            return self.vals
+
+    service._model.encode_multi_process.return_value = [
+        FakeNumpyArray([0.1]*384),
+        FakeNumpyArray([0.2]*384)
+    ]
+    
+    mock_query = service.supabase.table.return_value.select.return_value.is_.return_value.range.return_value
+    mock_query.execute.side_effect = [
+        MagicMock(data=[
+            {"id": "t1", "subject": "subj1"},
+            {"id": "t2", "subject": "subj2"}
+        ]),
+        MagicMock(data=[])
+    ]
+    
+    result = await service.reindex_all(batch_size=2)
+    
+    assert result["indexed"] == 2
+    assert result["errors"] == 0
+    
+    service._model.start_multi_process_pool.assert_called_once()
+    service._model.encode_multi_process.assert_called_once_with(["subj1", "subj2"], mock_pool)
+    service._model.stop_multi_process_pool.assert_called_once_with(mock_pool)
+    
+    update_mock = service.supabase.table.return_value.update
+    assert update_mock.call_count == 2


### PR DESCRIPTION
### Description:
 Resolves #2949. This PR optimizes the sentence embeddings retrieval pipeline by offloading inference batches to a process pool during the semantic duplicate detection reindex flow.

### Changes Included:

- Process Pool Offloading: Modified the reindex_all method in SemanticDuplicateService to extract ticket text data in batches and process them in parallel using sentence-transformers built-in start_multi_process_pool() and encode_multi_process().
- Performance: Bypasses the synchronous and sequential bottlenecks associated with standard text encoding, allowing thousands of tickets to be embedded rapidly.
- Safety Measures: Included finally blocks to explicitly destroy the spawned inference child processes via stop_multi_process_pool, preventing memory leaks on error.
- Testing: Added test_reindex_all_parallel_processing to the test_semantic_duplicates test suite to ensure the mocked pool functions are evaluated seamlessly with standard execution pipelines.