### PR TITLE
feat: implement pull-to-refresh on mobile tickets & dashboard screens…

### DIFF
--- a/MobileApp/src/screens/admin/AdminSettingsScreen.js
+++ b/MobileApp/src/screens/admin/AdminSettingsScreen.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
   StyleSheet, View, Text, TouchableOpacity, ScrollView,
-  ActivityIndicator, Switch, StatusBar, Alert
+  ActivityIndicator, RefreshControl, Switch, StatusBar, Alert
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
@@ -63,6 +63,7 @@ const AdminSettingsScreen = () => {
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   // Settings states
   const [confidenceThreshold, setConfidenceThreshold] = useState(0.80);
@@ -113,8 +114,14 @@ const AdminSettingsScreen = () => {
       console.error('Fetch settings error:', e);
     } finally {
       setLoading(false);
+      setRefreshing(false);
     }
   }, []);
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    fetchSettings();
+  };
 
   useEffect(() => {
     fetchSettings();
@@ -190,7 +197,11 @@ const AdminSettingsScreen = () => {
         <Text style={styles.title}>System Settings</Text>
       </View>
 
-      <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} tintColor={COLORS.primary} />}
+      >
         {/* Section 1: AI Engine Benchmarks */}
         <View style={styles.sectionCard}>
           <View style={styles.sectionHeader}>

--- a/MobileApp/src/screens/admin/AdminTicketsScreen.js
+++ b/MobileApp/src/screens/admin/AdminTicketsScreen.js
@@ -260,7 +260,7 @@ const AdminTicketsScreen = () => {
           renderItem={renderTicketItem}
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
-          RefreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} />}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} tintColor={COLORS.primary} />}
           ListEmptyComponent={
             <View style={styles.emptyContainer}>
               <AlertCircle size={48} color={COLORS.textMuted} strokeWidth={1} />

--- a/MobileApp/src/screens/admin/AdminUsersScreen.js
+++ b/MobileApp/src/screens/admin/AdminUsersScreen.js
@@ -387,7 +387,7 @@ const AdminUsersScreen = () => {
           renderItem={renderUserItem}
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
-          RefreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} />}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} colors={[COLORS.primary]} tintColor={COLORS.primary} />}
           ListEmptyComponent={
             <View style={styles.empty}>
               <Users size={48} color={COLORS.textMuted} strokeWidth={1} />


### PR DESCRIPTION
Fixes #2957
fixes pull-to-refresh on mobile ticket and user list screens where RefreshControl= (wrong casing) was silently ignored by React Native. Corrected to refreshControl= on all FlatList/ScrollView components. Also adds pull-to-refresh to AdminSettingsScreen which was missing it entirely.