### PR TITLE
feat: Standardize environment variable loading with validation schemas

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,10 +1,11 @@
 from typing import Optional
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     # Core API Keys
-    SUPABASE_URL: str
-    SUPABASE_SERVICE_KEY: str
+    SUPABASE_URL: Optional[str] = None
+    SUPABASE_SERVICE_KEY: Optional[str] = None
     GEMINI_API_KEY: Optional[str] = None
     RESEND_API_KEY: Optional[str] = None
     
@@ -20,5 +21,12 @@ class Settings(BaseSettings):
         env_file_encoding="utf-8",
         extra="ignore"
     )
+
+    @model_validator(mode='after')
+    def validate_dependencies(self) -> 'Settings':
+        if not self.ALLOW_DEGRADED_STARTUP:
+            if not self.SUPABASE_URL or not self.SUPABASE_SERVICE_KEY:
+                raise ValueError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set unless ALLOW_DEGRADED_STARTUP is True")
+        return self
 
 settings = Settings()

--- a/backend/database.py
+++ b/backend/database.py
@@ -10,8 +10,9 @@ load_dotenv(dotenv_path=env_path)
 
 try:
     from supabase import create_client, Client
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    from backend.config import settings
+    url = settings.SUPABASE_URL
+    key = settings.SUPABASE_SERVICE_KEY
     if not url or not key:
         logger.error("SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
         supabase = None

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -7,8 +7,9 @@ from slowapi.util import get_remote_address
 
 try:
     from supabase import create_client, Client
-    url = os.environ.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    from backend.config import settings
+    url = settings.SUPABASE_URL
+    key = settings.SUPABASE_SERVICE_KEY
     if not url or not key:
         print("[ERROR] SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
         supabase = None

--- a/main.py
+++ b/main.py
@@ -19,18 +19,13 @@ app = FastAPI()
 
 app.add_middleware(CSRFTokenMiddleware)
 
-# Initialize Supabase client
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
+from backend.config import settings
 
 # Initialize Supabase client
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY")
-
 supabase = None
-if SUPABASE_URL and SUPABASE_SERVICE_KEY and os.getenv("ALLOW_DEGRADED_STARTUP") != "1":
+if settings.SUPABASE_URL and settings.SUPABASE_SERVICE_KEY and not settings.ALLOW_DEGRADED_STARTUP:
     try:
-        supabase = create_client(SUPABASE_URL, SUPABASE_SERVICE_KEY)
+        supabase = create_client(settings.SUPABASE_URL, settings.SUPABASE_SERVICE_KEY)
     except Exception as e:
         logger.warning(f"Failed to initialize Supabase client: {e}")
 


### PR DESCRIPTION
## Description
Fixes #2968

### Summary
This PR standardizes environment variable loading during the API server's startup phase using Pydantic Settings models. Rather than relying on scattered `os.getenv` and `os.environ.get` calls, core backend dependencies and the main app lifecycle now strictly validate against the defined schema in `backend.config.Settings`.

### Changes Made
- Updated `Settings` in `backend/config.py` to use a `model_validator` that cleanly enforces `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` presence while fully respecting the `ALLOW_DEGRADED_STARTUP` environment flag.
- Refactored `main.py` to consume the Pydantic settings instance for the initial Supabase client setup instead of manual environment lookups.
- Centralized the initialization routines in `backend/database.py` and `backend/dependencies.py` to defer to the same strongly-typed Pydantic properties.