### PR TITLE
[CRITICAL] Fix Tenant Isolation Bypass — Weekly Digest Cross-Company Data Leak

### DIFF
--- a/backend/routes/weekly_digest.py
+++ b/backend/routes/weekly_digest.py
@@ -7,9 +7,11 @@ digest email report for admin users.
 
 import datetime
 import logging
+import os
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
+from supabase import create_client
 
 from backend.auth_cookie import get_current_user
 from backend.services.digest_service import (
@@ -17,6 +19,30 @@ from backend.services.digest_service import (
     generate_ai_summary,
     send_digest_email,
 )
+
+
+def _require_tenant(
+    company_id: str,
+    user: dict,
+) -> None:
+    uid = user.get("id") or user.get("sub")
+    if not uid:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required.")
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    if not url or not key:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Server configuration error.")
+    try:
+        client = create_client(url, key)
+        result = client.table("profiles").select("company_id").eq("id", uid).single().execute()
+        data = getattr(result, "data", None) or {}
+        user_company = data.get("company_id")
+        if user_company and user_company != company_id:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Tenant mismatch.")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Tenant verification failed.") from exc
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +85,7 @@ async def preview_weekly_digest(
     team performance metrics, and an AI-generated summary — without
     sending any email.
     """
+    _require_tenant(company_id, user)
     stats = get_weekly_stats(company_id)
     summary = generate_ai_summary(stats)
     return {"stats": stats, "ai_summary": summary}
@@ -78,6 +105,7 @@ async def trigger_weekly_digest(
     - Team performance metrics (per-team resolution rates, avg times)
     - AI-generated summary with recommendations
     """
+    _require_tenant(body.company_id, user)
     from backend.main import supabase
 
     stats = get_weekly_stats(body.company_id)


### PR DESCRIPTION
## Summary
The weekly digest router (backend/routes/weekly_digest.py) authenticates via Depends(get_current_user) but never checks the caller's company_id.

## Affected Endpoints
- GET /api/digest/preview/{company_id} — preview any company's digest
- POST /api/digest/send-now — trigger digest for any company

## Fix
Added _require_tenant() that verifies the caller's company_id matches the requested company_id.

Fixes #3017