### PR TITLE
fix: resolve TypeError in /ai/analyze endpoint due to analyze_image method signature mismatch

### DIFF
--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -27,9 +27,13 @@ class GeminiService:
         else:
             print("[GeminiService] WARNING: GEMINI_API_KEY not found in environment.")
 
-    def analyze_image(self, image_base64: str) -> dict:
+    def analyze_image(self, image_base64: str, ticket_text: str = "") -> dict:
         """
         Perform OCR and image analysis using Gemini logic.
+
+        Args:
+            image_base64: Base64-encoded image string.
+            ticket_text: Optional ticket description text for additional context.
         """
         if not self._initialized:
             return {
@@ -44,8 +48,13 @@ class GeminiService:
             image_bytes = base64.b64decode(image_base64)
             img = Image.open(io.BytesIO(image_bytes))
 
+            context_line = (
+                f"The user described the issue as: '{ticket_text}'. "
+                if ticket_text else ""
+            )
             prompt = (
                 "Analyze this screenshot from a user reporting a technical issue. "
+                f"{context_line}"
                 "1. Provide a concise description of what is shown in the image. "
                 "2. Perform OCR and extract any error messages or key text. "
                 "3. Identify the main technical problem depicted. "


### PR DESCRIPTION
## Problem

The `/ai/analyze` endpoint crashes with a `TypeError` when a user submits a ticket with an attached image.

**Root cause:** In `main.py:L669`, `gemini_service.analyze_image()` is called with two arguments (`image_base64`, `text`), but the method in `gemini_service.py` only accepted one positional parameter (`image_base64`). Python counts `self` implicitly, so the call passes 3 positional args to a method expecting 2 — causing a runtime crash.

```python
# main.py:669 — caller passes two args
vision_result = gemini_service.analyze_image(request_body.image_base64, text)

# gemini_service.py:30 — method only accepted one
def analyze_image(self, image_base64: str) -> dict:  # ← TypeError
```

## Fix

- Added an optional `ticket_text: str = ""` parameter to `GeminiService.analyze_image()`
- When provided, the user's ticket description is injected into the Gemini vision prompt for richer contextual analysis
- Backward-compatible: existing callers that don't pass `ticket_text` are unaffected

## Impact

- **Before:** Every image-attached ticket submission crashed the AI analysis pipeline
- **After:** Image analysis works correctly and benefits from the user's text description for improved accuracy

## Changes

- `backend/services/gemini_service.py`: Updated `analyze_image()` method signature and prompt construction
closes #3040 