### PR TITLE
fix(backend): implement configurable structured JSON logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,9 @@ ALLOWED_ORIGINS=https://helpdeskaiv1.vercel.app,http://localhost:5173,http://loc
 
 # Token for /metrics endpoint authentication
 METRICS_TOKEN=
+
+# --- Logging ---
+# Severity threshold for the backend structured logger (issue #2944).
+# Accepts DEBUG/INFO/WARNING/ERROR/CRITICAL (case-insensitive) or an integer.
+# Defaults to INFO when unset or invalid.
+LOG_LEVEL=INFO

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,13 +7,19 @@ class Settings(BaseSettings):
     SUPABASE_SERVICE_KEY: str
     GEMINI_API_KEY: Optional[str] = None
     RESEND_API_KEY: Optional[str] = None
-    
+
     # Model Configurations
     SENTENCE_TRANSFORMER_MODEL_PATH: str = "all-MiniLM-L6-v2"
-    
+
     # Application State
     ALLOW_DEGRADED_STARTUP: bool = False
     REQUIRE_SUPABASE: bool = True
+
+    # Logging
+    # Severity threshold for the FastAPI backend logger.
+    # Accepts standard stdlib names (DEBUG/INFO/WARNING/ERROR/CRITICAL)
+    # case-insensitively, or an integer level. Defaults to INFO.
+    LOG_LEVEL: str = "INFO"
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/logger.py
+++ b/backend/logger.py
@@ -1,11 +1,82 @@
+"""
+Structured JSON logging for the FastAPI backend (issue #2944).
+
+This module exposes a single public entry point, ``get_logger(name)``, that
+returns a configured ``structlog`` logger emitting one JSON object per record.
+
+Key properties (see ``backend/tests/test_logger.py``):
+
+* **Configurable level.** The effective log level is read once from
+  ``Settings.LOG_LEVEL`` (env var ``LOG_LEVEL``), accepting the stdlib level
+  names case-insensitively or an integer (``"10"``, ``"DEBUG"``, ``"debug"``
+  are all equivalent). Defaults to ``INFO``.
+* **Structured JSON output.** Every record is rendered as a single JSON line
+  carrying ``event``, ``level``, ``logger``, ``timestamp`` and the call's
+  keyword arguments — suitable for ingestion by log aggregators.
+* **Idempotent configuration.** ``configure_logging`` guards against the
+  double-configure / handler-stacking bug the previous implementation had:
+  repeated imports or calls no longer attach duplicate handlers or reset the
+  level inconsistently.
+"""
+from __future__ import annotations
+
 import logging
 import sys
+from typing import Optional, Union
+
 import structlog
 
-def get_logger(name: str = None):
+# Default fallback if settings cannot be resolved (e.g. very early bootstrap).
+_DEFAULT_LEVEL = logging.INFO
+
+
+def _coerce_level(value: Union[str, int, None]) -> int:
+    """Normalise a level spec into a stdlib numeric level.
+
+    Accepts upper/lower/stdlib names ("debug", "WARNING", ...) and integer
+    strings ("10"). Falls back to INFO on anything unrecognised so a typo in
+    configuration never silences production logs unexpectedly.
     """
-    Returns a configured structlog logger.
+    if value is None:
+        return _DEFAULT_LEVEL
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return _DEFAULT_LEVEL
+        # Integer-as-string ("10", "20").
+        if text.isdigit():
+            return int(text)
+        # Named level ("info", "WARNING", "Error").
+        named = logging.getLevelName(text.upper())
+        if isinstance(named, int):
+            return named
+    return _DEFAULT_LEVEL
+
+
+def _resolve_level() -> int:
+    """Resolve the effective level from settings, tolerating import failures."""
+    try:
+        from backend.config import settings
+        return _coerce_level(settings.LOG_LEVEL)
+    except Exception:
+        # During very early bootstrap or in test isolation, settings may not
+        # be importable. Fall back to the env var directly, then to default.
+        import os
+        return _coerce_level(os.getenv("LOG_LEVEL"))
+
+
+def configure_logging(level: Optional[Union[str, int]] = None) -> None:
+    """Configure structlog + stdlib logging once, idempotently.
+
+    Safe to call any number of times: on the first call it wires up the JSON
+    processors and a stdout ``StreamHandler``; subsequent calls only adjust the
+    effective level (no duplicate handlers, no reset of structlog state).
     """
+    resolved = _coerce_level(level) if level is not None else _resolve_level()
+
+    # structlog is configured exactly once per process.
     if not structlog.is_configured():
         structlog.configure(
             processors=[
@@ -14,7 +85,7 @@ def get_logger(name: str = None):
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.processors.StackInfoRenderer(),
                 structlog.processors.format_exc_info,
-                structlog.processors.JSONRenderer()
+                structlog.processors.JSONRenderer(),
             ],
             context_class=dict,
             logger_factory=structlog.stdlib.LoggerFactory(),
@@ -22,11 +93,26 @@ def get_logger(name: str = None):
             cache_logger_on_first_use=True,
         )
 
-        # Set up standard logging to flow into structlog
-        logging.basicConfig(
-            format="%(message)s",
-            stream=sys.stdout,
-            level=logging.INFO,
-        )
-    
+    # Stdlib routing — always (re)apply the level, never stack handlers.
+    root = logging.getLogger()
+    root.setLevel(resolved)
+    if not any(
+        getattr(h, "_helpdesk_structlog_handler", False) for h in root.handlers
+    ):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(resolved)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        # Mark our own handler so re-configuration does not duplicate it.
+        handler._helpdesk_structlog_handler = True  # type: ignore[attr-defined]
+        root.addHandler(handler)
+
+
+def get_logger(name: Optional[str] = None):
+    """Return a configured structlog logger bound to ``name``.
+
+    Guarantees logging is configured (idempotently) before the logger is
+    handed back, so callers can ``from backend.logger import get_logger`` and
+    start logging without a separate bootstrap step.
+    """
+    configure_logging()
     return structlog.get_logger(name)

--- a/backend/tests/test_logger.py
+++ b/backend/tests/test_logger.py
@@ -1,0 +1,142 @@
+"""
+Tests for backend/logger.py — configurable log level + structured JSON output.
+
+Covers issue #2944: "Introduce configurable log levels and structured JSON
+formatting in the FastAPI backend logger to improve trace reliability."
+"""
+import io
+import json
+import logging
+import sys
+from contextlib import redirect_stderr
+
+import pytest
+
+
+def _import_fresh():
+    """Import logger with clean state so each test re-configures from scratch."""
+    for mod in list(sys.modules):
+        if mod in ("backend.logger", "backend.config"):
+            del sys.modules[mod]
+    import structlog
+    structlog.reset_defaults()
+    # Remove handlers that previous runs attached to the root logger.
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    return __import__("backend.logger", fromlist=["get_logger"])
+
+
+def _emit(level, event="hello", **kw):
+    """
+    Re-import logger fresh, attach a capturing handler to the root logger,
+    emit one record, and return the list of captured formatted lines.
+
+    backend/logger.py routes records through stdlib logging (structlog's
+    LoggerFactory), so we capture at the logging layer rather than sys.stdout.
+    """
+    log_module = _import_fresh()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.DEBUG)
+    # structlog's JSONRenderer produces the final JSON string; keep the
+    # formatter transparent so we can parse it.
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        logger = log_module.get_logger("test")
+        getattr(logger, level)(event, **kw)
+    finally:
+        root.removeHandler(handler)
+    return [l for l in buf.getvalue().splitlines() if l.strip()]
+
+
+def _set_env(monkeypatch, **kw):
+    monkeypatch.setenv("SUPABASE_URL", "https://placeholder.supabase.co")
+    monkeypatch.setenv("SUPABASE_SERVICE_KEY", "placeholder_key")
+    for k, v in kw.items():
+        monkeypatch.setenv(k, v)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Structured JSON output
+# --------------------------------------------------------------------------- #
+def test_output_is_valid_json(monkeypatch):
+    _set_env(monkeypatch)
+    lines = _emit("info", key="value")
+    assert lines, "expected at least one log line"
+    payload = json.loads(lines[-1])
+    assert payload["event"] == "hello"
+    assert payload["level"] == "info"
+    assert payload["key"] == "value"
+    assert "timestamp" in payload
+
+
+def test_output_is_valid_json_on_error(monkeypatch):
+    _set_env(monkeypatch)
+    lines = _emit("error", event="boom")
+    payload = json.loads(lines[-1])
+    assert payload["level"] == "error"
+    assert payload["event"] == "boom"
+
+
+# --------------------------------------------------------------------------- #
+# 2. Configurable log level (the core ask of #2944)
+# --------------------------------------------------------------------------- #
+def test_log_level_debug_emits_debug(monkeypatch):
+    _set_env(monkeypatch, LOG_LEVEL="DEBUG")
+    lines = _emit("debug", event="dbg")
+    assert any(json.loads(l)["level"] == "debug" for l in lines), lines
+
+
+def test_log_level_info_suppresses_debug(monkeypatch):
+    _set_env(monkeypatch, LOG_LEVEL="INFO")
+    lines = _emit("debug", event="should_not_appear")
+    matching = [l for l in lines if '"should_not_appear"' in l]
+    assert matching == [], matching
+
+
+def test_log_level_warning_suppresses_info(monkeypatch):
+    _set_env(monkeypatch, LOG_LEVEL="WARNING")
+    lines = _emit("info", event="should_not_appear")
+    assert all('"should_not_appear"' not in l for l in lines), lines
+
+
+# --------------------------------------------------------------------------- #
+# 3. Idempotency / no double-configure
+# --------------------------------------------------------------------------- #
+def test_get_logger_is_idempotent(monkeypatch):
+    _set_env(monkeypatch)
+    log_module = _import_fresh()
+    log_module.get_logger("a")
+    log_module.get_logger("b")
+    log_module.get_logger("c")  # must not raise
+
+
+def test_get_logger_emits_exactly_one_line(monkeypatch):
+    _set_env(monkeypatch, LOG_LEVEL="INFO")
+    log_module = _import_fresh()
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        logger = log_module.get_logger("test")
+        logger.info("once")
+    finally:
+        root.removeHandler(handler)
+    lines = [l for l in buf.getvalue().splitlines() if '"once"' in l]
+    assert len(lines) == 1, lines
+
+
+# --------------------------------------------------------------------------- #
+# 4. Level normalisation: lower/upper/numeric forms
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("level", ["DEBUG", "debug", "10"])
+def test_log_level_normalisation(monkeypatch, level):
+    _set_env(monkeypatch, LOG_LEVEL=level)
+    lines = _emit("debug", event="dbg")
+    assert any('"dbg"' in l for l in lines), (level, lines)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from fastapi import FastAPI, Request, HTTPException, Depends
 from fastapi.openapi.docs import get_swagger_ui_html
@@ -7,13 +6,13 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Res
 from supabase import create_client
 
 from backend.csrf import CSRFTokenMiddleware, set_csrf_cookie, CSRF_COOKIE_NAME
+from backend.logger import get_logger
 from backend.swagger_config import SWAGGER_UI_CUSTOM_CSS, SWAGGER_UI_CUSTOM_JS
 
 from backend.routers import tickets, ai, admin, health, auth
 from backend.routes import translation, estimator, voice, privacy, active_learning, weekly_digest
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 app = FastAPI()
 
@@ -334,3 +333,4 @@ async def get_open_api():
         description="API Documentation for HelpDesk AI Backend",
         routes=app.routes,
     )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.30.1
 pydantic==2.12.5
 pydantic-settings==2.3.4
 python-dotenv==1.0.1
+structlog==24.4.0
 supabase==2.5.1
 slowapi==0.1.9
 prometheus-client==0.20.0


### PR DESCRIPTION
## Issue
Closes #2944 — Implement detailed log level configurations in FastAPI backend

## Problem
The backend logger had three issues:
1. Log level was hardcoded to `INFO` in `backend/logger.py` — not configurable.
2. `main.py` separately called `logging.basicConfig(level=INFO)`, creating two independent log configurations that could diverge.
3. `structlog` was missing from `requirements.txt`, so `import structlog` fails in a clean environment / CI.

## Changes
- `backend/config.py`: add `LOG_LEVEL: str = "INFO"` setting.
- `backend/logger.py`: rewrite to read level from settings (idempotent `configure_logging`), normalize level input (name/integer/case), and guard against duplicate-handler stacking.
- `main.py`: replace `logging.basicConfig` + `getLogger` with the unified `get_logger(__name__)`.
- `requirements.txt`: add `structlog==24.4.0`.
- `.env.example`: document `LOG_LEVEL`.
- `backend/tests/test_logger.py`: new — 10 tests covering JSON structure, configurable level, normalization, and idempotency.

## Test Results
```
backend/tests/test_logger.py: 10 passed in 0.59s
```
Verified locally with `structlog==24.4.0`, `pydantic-settings==2.3.4`, `pytest==8.2.2` (Python 3.14). The full backend suite requires supabase/torch/transformers and was not run locally; CI (`backend-ci.yml`) will cover it.
