### PR TITLE
fix(critical): add admin role verification to all admin router endpoints (#3049)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -5,13 +5,36 @@ from backend.schemas import ProfileUpdate
 
 router = APIRouter(prefix="/api", tags=["Admin"])
 
+
+async def _require_admin(current_user: dict = Depends(get_current_user)) -> dict:
+    """Verify the caller has an admin-level role before allowing access."""
+    user_id = current_user.get("id") or current_user.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database not connected")
+
+    try:
+        res = supabase.table("profiles").select("role").eq("id", user_id).single().execute()
+        profile = res.data or {}
+    except Exception:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    role = str(profile.get("role", "")).lower()
+    if role not in ("admin", "company_admin", "master_admin"):
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    return current_user
+
+
 @router.get("/profiles")
 async def api_get_profiles(
     role: str = None,
     status: str = None,
     limit: int = 50,
     offset: int = 0,
-    current_user: dict = Depends(get_current_user),
+    _: dict = Depends(_require_admin),
 ):
     """List admin-visible profiles with optional role and status filters."""
     if not supabase: return []
@@ -25,13 +48,10 @@ async def api_get_profiles(
 async def api_update_profile(
     user_id: str,
     updates: ProfileUpdate,
-    current_user: dict = Depends(get_current_user),
+    _: dict = Depends(_require_admin),
 ):
     """Apply an admin edit to a user profile."""
     if not supabase: return {}
-    # Schema validation in ProfileUpdate (extra="forbid") already blocks
-    # any field outside the allowlist, so a Pydantic .model_dump() with
-    # exclude_unset=True gives us only what the client actually sent.
     payload = updates.model_dump(exclude_unset=True)
     if not payload:
         return {}
@@ -41,19 +61,20 @@ async def api_update_profile(
 @router.delete("/profiles/{user_id}")
 async def api_delete_profile(
     user_id: str,
-    current_user: dict = Depends(get_current_user),
+    _: dict = Depends(_require_admin),
 ):
     """Delete a user profile and cascade auth cleanup when possible."""
     if not supabase: return {"success": False}
     supabase.table("profiles").delete().eq("id", user_id).execute()
     try:
         supabase.rpc('delete_user').execute()
-    except: pass
+    except:
+        pass
     return {"success": True}
 
 @router.get("/companies")
 async def api_get_companies(
-    current_user: dict = Depends(get_current_user),
+    _: dict = Depends(_require_admin),
 ):
     """Return the company list visible to the current admin."""
     if not supabase: return []
@@ -65,7 +86,7 @@ async def api_get_admin_requests(
     status: str = None,
     limit: int = 50,
     offset: int = 0,
-    current_user: dict = Depends(get_current_user),
+    _: dict = Depends(_require_admin),
 ):
     """List admin requests with optional status filtering."""
     if not supabase: return []


### PR DESCRIPTION
﻿## Summary

Fixes critical privilege escalation vulnerability in the admin router (ackend/routers/admin.py). All 5 admin endpoints previously used get_current_user which only verifies authentication — not admin role.

## Fix

Added _require_admin FastAPI dependency that:
1. Authenticates via get_current_user
2. Looks up the caller's profile role from the profiles table
3. Rejects requests unless the caller has dmin, company_admin, or master_admin role

Applied to all 5 endpoints:
- GET /api/profiles
- PATCH /api/profiles/{user_id}
- DELETE /api/profiles/{user_id}
- GET /api/companies
- GET /api/admin_requests

Closes #3049
