### PR TITLE
fix(critical): remove mock token auth bypass backdoor (#3053)

### DIFF
--- a/backend/auth/tenant_middleware.py
+++ b/backend/auth/tenant_middleware.py
@@ -1,4 +1,3 @@
-import os
 import time
 import logging
 from typing import Dict, Optional
@@ -79,19 +78,6 @@ class TenantSecurityManager:
             )
         
         token = credentials.credentials
-
-        mock_enabled = os.getenv("MOCK_AUTH_ENABLED", "false").lower() == "true"
-        if mock_enabled and token.startswith("mock-token-"):
-            parts = token.split("-")
-            company_id = parts[2] if len(parts) > 2 else "company-mock-default"
-            role = parts[3] if len(parts) > 3 else "user"
-            user_id = parts[4] if len(parts) > 4 else f"user-{company_id}-{role}"
-
-            if company_id == "master":
-                return {"id": "master-admin-id", "company_id": None, "role": "master_admin"}
-
-            logger.warning(f"Mock auth used — user={user_id} company={company_id} role={role}")
-            return {"id": user_id, "company_id": company_id, "role": role}
 
         if not self.supabase:
             raise HTTPException(


### PR DESCRIPTION
﻿## Summary

Removes the **critical mock token authentication backdoor** in ackend/auth/tenant_middleware.py. The mock-token- prefix allowed complete auth bypass when MOCK_AUTH_ENABLED=true was set, enabling impersonation of any user, company, or role.

## Changes

1. **Removed mock token parsing logic** (lines 83–94) — the code that matched mock-token- prefixes and synthesized user profiles was deleted
2. **Removed unused os import** — no longer needed after removing os.getenv("MOCK_AUTH_ENABLED")
3. **All tokens now validated through Supabase Auth** — no backdoor path remains

## Why this matters

An attacker who knew about this feature could:
- Send Authorization: Bearer mock-token-master-x to get master_admin with unrestricted access
- Send Authorization: Bearer mock-token-company42-admin to impersonate any company's admin

This bypassed every downstream security check (tenant isolation, role verification, resource ownership).

## Testing

- Token auth continues unchanged for real Supabase JWT tokens
- The env var MOCK_AUTH_ENABLED is no longer recognized (safe removal)

Closes #3053
