### PR TITLE
fix: add missing Hardware category to regex override layer (#3069)

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -126,7 +126,8 @@ class ClassifierService:
         tech_keywords = {
             "Network": ["IP address", "hostname", "connection", "network", "bandwidth", "DNS", "firewall", "VPN", "Connectivity", "Latency", "Routing", "Spikes"],
             "Software": ["crash", "load", "website", "application", "error", "bug", "failing", "software", "SQL", "Cluster", "Database", "Production", "Latency"],
-            "Access": ["login", "password", "access", "authentication", "account", "permission", "MFA", "OAuth"]
+            "Access": ["login", "password", "access", "authentication", "account", "permission", "MFA", "OAuth"],
+            "Hardware": ["laptop", "hardware", "keyboard", "monitor", "mouse", "printer", "battery", "screen", "broken"]
         }
         
         lower_text = text.lower()


### PR DESCRIPTION
## Description
This PR resolves issue #3069 where the `Hardware` category was omitted from the `tech_keywords` dictionary inside the `ClassifierService.predict` method. 

While the top-level `TEAM_MAP` correctly maps `"Hardware"` to `"Hardware Support"`, the missing key in the regex override layer meant that low-confidence or generic hardware issues (e.g., tickets containing signals like "broken screen" or "keyboard not working") were falling through the cracks instead of getting flagged for a keyword-validation boost.

## Changes Made
* Added the `"Hardware"` category key to the `tech_keywords` dictionary.
* Populated it with relevant infrastructure signals: `"laptop"`, `"hardware"`, `"keyboard"`, `"monitor"`, `"mouse"`, `"printer"`, `"battery"`, `"screen"`, and `"broken"`.

## Related Issues
Closes #3069

## Verification Steps
1. Passed an issue text with high-value hardware signals (e.g., *"broken laptop screen"*) where the ML model's prediction confidence drops below `0.9`.
2. Verified that the regex override tier successfully catches the keywords, forces the category to `"Hardware"`, routes the ticket to `"Hardware Support"`, and boosts confidence to `0.92`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hardware-related keyword handling so some inputs are now categorized more accurately and routed to the right team.

* **Bug Fixes**
  * Duplicate detection is now faster and more reliable, especially as ticket history grows.
  * Notification delivery now better respects digest frequency settings, preventing mismatched daily/weekly emails.
  * Settings lookup now handles failures more safely and avoids stale cache issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->