### PR TITLE
fix(critical): remove hardcoded Supabase service role JWT from SQL migrations

### DIFF
--- a/supabase/migrations/20260331000000_resolve_vault_sync.sql
+++ b/supabase/migrations/20260331000000_resolve_vault_sync.sql
@@ -11,8 +11,10 @@ create table if not exists internal_config.secrets (
 );
 
 -- Sync the Service Role Key
+-- IMPORTANT: Replace 'CHANGE_ME' with the actual key set via the Supabase dashboard.
+-- Never commit live secrets to version control.
 insert into internal_config.secrets (name, value)
-values ('SUPABASE_SERVICE_ROLE_KEY', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MjM4NDA3OCwiZXhwIjoyMDg3OTYwMDc4fQ.b3tZ_yad4WPQi4oSqGp1ksr_zw-ldByLqZWvT7HX5aQ')
+values ('SUPABASE_SERVICE_ROLE_KEY', 'CHANGE_ME')
 on conflict (name) do update set value = excluded.value, updated_at = now();
 
 -- Ensure only the database owner can see this

--- a/supabase/migrations/20260331000001_sync_vault.sql
+++ b/supabase/migrations/20260331000001_sync_vault.sql
@@ -1,9 +1,10 @@
--- Syncing the rotated service role key after the security leak
--- This is in a migration to ensure the vault is updated during deployment
+-- Sync the service role key for triggering edge functions from Postgres.
+-- IMPORTANT: Replace 'CHANGE_ME' with the actual key set via the Supabase dashboard.
+-- Never commit live secrets to version control.
 insert into vault.secrets (name, description, secret)
 values (
   'SUPABASE_SERVICE_ROLE_KEY', 
   'Internal key for triggering edge functions from Postgres', 
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImFlanVlbmhxY2lhZ3BudGNxb2lyIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc3MjM4NDA3OCwiZXhwIjoyMDg3OTYwMDc4fQ.b3tZ_yad4WPQi4oSqGp1ksr_zw-ldByLqZWvT7HX5aQ'
+  'CHANGE_ME'
 )
 on conflict (name) do update set secret = excluded.secret;


### PR DESCRIPTION
## Summary

Removes a **live Supabase service-role JWT** that was hardcoded in two migration files committed to version control.

## Vulnerability

The JWT `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` decodes to a Supabase service_role token with a 30+ year expiry (until ~2036) for project `aejuenhqciagpntcqoir`. Anyone cloning this repository can use this token to:

- Access ALL tables with full admin privileges
- Bypass Row-Level Security policies
- Exfiltrate ALL ticket PII across all tenants
- Modify or delete any data

## Changes

| File | Before | After |
|---|---|---|
| `20260331000001_sync_vault.sql` | Hardcoded live JWT | `CHANGE_ME` placeholder |
| `20260331000000_resolve_vault_sync.sql` | Hardcoded live JWT | `CHANGE_ME` placeholder |

## Post-Merge Action Required

1. **Immediately rotate** the compromised service role key in the Supabase dashboard
2. Configure the new key via Supabase Vault (dashboard ? Project Settings ? Vault)
3. Run `git filter-branch` to purge the secret from git history
4. Consider if the webhook trigger (20260330231302) should use Supabase's built-in Database Webhooks instead

Closes #3095


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed hardcoded live secret values from initialization and sync updates.
  * Replaced them with a placeholder so real credentials must be entered manually.
  * Added guidance to avoid committing active secrets and to update them from the dashboard.
  * Kept existing access controls and update behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->