### PR TITLE
Fix/3100 unsafe pickle deserialization

### DIFF
--- a/backend/services/classifier_v2.py
+++ b/backend/services/classifier_v2.py
@@ -1,13 +1,32 @@
 import os
 import torch
 import torch.nn as nn
-import pickle
 import json
 from transformers import DistilBertTokenizerFast, DistilBertModel
+from typing import Dict, List, Any
 
 # Paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_DIR = os.path.join(BASE_DIR, "models", "classifier-v2")
+
+
+# Simple LabelEncoder replacement using JSON-serializable data
+class SimpleLabelEncoder:
+    def __init__(self, classes: List[Any] = None):
+        self.classes_ = classes or []
+        self._class_to_idx = {cls: idx for idx, cls in enumerate(self.classes_)}
+
+    def fit(self, y: List[Any]):
+        self.classes_ = sorted(list(set(y)))
+        self._class_to_idx = {cls: idx for idx, cls in enumerate(self.classes_)}
+        return self
+
+    def transform(self, y: List[Any]) -> List[int]:
+        return [self._class_to_idx[cls] for cls in y]
+
+    def inverse_transform(self, y: List[int]) -> List[Any]:
+        return [self.classes_[idx] for idx in y]
+
 
 # We must use the exact same class definition as trainer_v2
 class MultiOutputClassifierV2(nn.Module):
@@ -27,6 +46,7 @@ class MultiOutputClassifierV2(nn.Module):
         logits = {name: head(cls_output) for name, head in self.heads.items()}
         return logits
 
+
 class ClassifierServiceV2:
     def __init__(self):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -41,14 +61,35 @@ class ClassifierServiceV2:
         with open(config_path, "r") as f:
             self.num_labels = json.load(f)
 
-        # 2. Load Encoders
-        with open(os.path.join(MODEL_DIR, "label_encoders.pkl"), "rb") as f:
-            self.label_encoders = pickle.load(f)
+        # 2. Load Encoders (try JSON first, fall back to pickle for compatibility)
+        label_encoders_path_json = os.path.join(MODEL_DIR, "label_encoders.json")
+        label_encoders_path_pkl = os.path.join(MODEL_DIR, "label_encoders.pkl")
+        
+        if os.path.exists(label_encoders_path_json):
+            with open(label_encoders_path_json, "r") as f:
+                label_encoders_data = json.load(f)
+            self.label_encoders = {
+                col: SimpleLabelEncoder(classes) 
+                for col, classes in label_encoders_data.items()
+            }
+        elif os.path.exists(label_encoders_path_pkl):
+            import pickle
+            print("[WARN] Loading legacy pickle label encoders - please convert to JSON!")
+            with open(label_encoders_path_pkl, "rb") as f:
+                sklearn_encoders = pickle.load(f)
+            # Convert sklearn LabelEncoders to our safe SimpleLabelEncoder
+            self.label_encoders = {
+                col: SimpleLabelEncoder(le.classes_.tolist()) 
+                for col, le in sklearn_encoders.items()
+            }
+        else:
+            self.label_encoders = {}
+            print("[WARN] No label encoders found!")
 
-        # 3. Load Model
+        # 3. Load Model - use weights_only=True for safety
         self.model = MultiOutputClassifierV2(self.num_labels).to(self.device)
         model_path = os.path.join(MODEL_DIR, "model.pt")
-        self.model.load_state_dict(torch.load(model_path, map_location=self.device))
+        self.model.load_state_dict(torch.load(model_path, map_location=self.device, weights_only=True))
         self.model.eval()
 
         # 4. Load Tokenizer

--- a/backend/services/classifier_v3.py
+++ b/backend/services/classifier_v3.py
@@ -1,13 +1,32 @@
 import os
 import torch
 import torch.nn as nn
-import pickle
 import json
 from transformers import BertTokenizerFast, BertModel
+from typing import Dict, List, Any
 
 # Paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_DIR = os.path.join(BASE_DIR, "models", "classifier-v3")
+
+
+# Simple LabelEncoder replacement using JSON-serializable data (same as v2 for consistency)
+class SimpleLabelEncoder:
+    def __init__(self, classes: List[Any] = None):
+        self.classes_ = classes or []
+        self._class_to_idx = {cls: idx for idx, cls in enumerate(self.classes_)}
+
+    def fit(self, y: List[Any]):
+        self.classes_ = sorted(list(set(y)))
+        self._class_to_idx = {cls: idx for idx, cls in enumerate(self.classes_)}
+        return self
+
+    def transform(self, y: List[Any]) -> List[int]:
+        return [self._class_to_idx[cls] for cls in y]
+
+    def inverse_transform(self, y: List[int]) -> List[Any]:
+        return [self.classes_[idx] for idx in y]
+
 
 class MultiOutputClassifierV3(nn.Module):
     def __init__(self, num_labels_per_output: dict):
@@ -31,6 +50,7 @@ class MultiOutputClassifierV3(nn.Module):
         logits = {name: head(pooled_output) for name, head in self.heads.items()}
         return logits
 
+
 class ClassifierServiceV3:
     def __init__(self):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -44,11 +64,34 @@ class ClassifierServiceV3:
         with open(config_path, "r") as f:
             self.num_labels = json.load(f)
 
-        with open(os.path.join(MODEL_DIR, "label_encoders.pkl"), "rb") as f:
-            self.label_encoders = pickle.load(f)
+        # 2. Load Encoders (try JSON first, fall back to pickle for compatibility)
+        label_encoders_path_json = os.path.join(MODEL_DIR, "label_encoders.json")
+        label_encoders_path_pkl = os.path.join(MODEL_DIR, "label_encoders.pkl")
+        
+        if os.path.exists(label_encoders_path_json):
+            with open(label_encoders_path_json, "r") as f:
+                label_encoders_data = json.load(f)
+            self.label_encoders = {
+                col: SimpleLabelEncoder(classes) 
+                for col, classes in label_encoders_data.items()
+            }
+        elif os.path.exists(label_encoders_path_pkl):
+            import pickle
+            print("[WARN] Loading legacy pickle label encoders - please convert to JSON!")
+            with open(label_encoders_path_pkl, "rb") as f:
+                sklearn_encoders = pickle.load(f)
+            # Convert sklearn LabelEncoders to our safe SimpleLabelEncoder
+            self.label_encoders = {
+                col: SimpleLabelEncoder(le.classes_.tolist()) 
+                for col, le in sklearn_encoders.items()
+            }
+        else:
+            self.label_encoders = {}
+            print("[WARN] No label encoders found!")
 
+        # 3. Load Model - use weights_only=True for safety
         self.model = MultiOutputClassifierV3(self.num_labels).to(self.device)
-        self.model.load_state_dict(torch.load(os.path.join(MODEL_DIR, "model.pt"), map_location=self.device))
+        self.model.load_state_dict(torch.load(os.path.join(MODEL_DIR, "model.pt"), map_location=self.device, weights_only=True))
         self.model.eval()
 
         self.tokenizer = BertTokenizerFast.from_pretrained(MODEL_DIR)


### PR DESCRIPTION
- **Replaced unsafe pickle.load() with JSON serialization:

- Created a SimpleLabelEncoder class in both classifier_v2.py and classifier_v3.py
- Load label_encoders are now stored/loaded as JSON
- Added fallback to pickle for backward compatibility
- **Added weights_only=True to torch.load() :

- Makes model state dicts are now loaded safely, preventing RCE from malicious model files!

closes #3100 