### PR TITLE
Fix: Update TicketResponse test mock to include sla_breach_at (#3103)

### DIFF
--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -100,6 +100,7 @@ class TicketResponse(BaseModel):
     reasoning: str = ""
     decision_factors: list[str] = []
     spam_check: SpamCheck = SpamCheck()
+    sla_breach_at: str | None = None
     version: str = "2.1.0-Neural-Diagnostic"
 
 


### PR DESCRIPTION
### Description
This pull request adds the missing `sla_breach_at` field to the `TicketResponse` Pydantic mock schema in the backend test suite (`backend/tests/test_models.py`). 

This field is defined in the primary production model (`backend/schemas.py`) but was missing in the test mock, causing mock validations and model instantiations in test cases to be out of sync.

### Changes Made
- Added `sla_breach_at: str | None = None` to the `TicketResponse` mock class in [backend/tests/test_models.py](file:///Users/harshitanagpalicloud.com/Code/Gssoc'26/HELPDESK.AI/backend/tests/test_models.py#L103).

### Related Issues
Fixes #3103
