### PR TITLE
fix: make landing navbar fixed during scrolling

### DIFF
--- a/Frontend/src/components/landing/Header.jsx
+++ b/Frontend/src/components/landing/Header.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Menu, X, Play } from 'lucide-react';
+import { Menu, X, Play, ArrowRight } from 'lucide-react';
 import ThemeToggle from '../ThemeToggle';
 
 function DemoModal({ onClose }) {
@@ -82,7 +82,7 @@ export default function Header({ setShowDemo = () => {} }) {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
     return (
-        <nav className="sticky top-0 z-50 bg-white/90 dark:bg-slate-900/90 backdrop-blur-md border-b border-gray-100 dark:border-slate-800 shadow-sm transition-colors duration-300">
+        <nav className="fixed top-0 left-0 right-0 z-50 bg-white/90 dark:bg-slate-900/90 backdrop-blur-md border-b border-gray-100 dark:border-slate-800 shadow-sm transition-colors duration-300">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div className="flex justify-between items-center h-16 gap-4">
                     <div className="flex items-center gap-2 cursor-pointer shrink-0" onClick={() => navigate('/')}>


### PR DESCRIPTION
## Description

This PR fixes the landing page navigation bar so that it remains accessible while scrolling.

### Changes Made

* Changed the landing page navbar from `sticky` to `fixed`.
* Preserved the existing design, styling, responsiveness, and theme support.

### Problem

Previously, the navigation bar was not consistently accessible while scrolling on the landing page.

### Solution

Updated the navbar positioning to `fixed`, ensuring it stays visible at the top of the screen throughout scrolling.

### Files Modified

* `Frontend/src/components/landing/Header.jsx`

### Testing

* Verified that the navbar remains fixed at the top while scrolling.
* Confirmed that desktop and mobile navigation behavior remains unchanged.

### Issue

Fixes #2785 

### Checklist

* [x] Code follows the project guidelines.
* [x] No unrelated files were modified.
* [x] Existing functionality is preserved.
* [x] Changes are limited to the assigned issue.
* [x] Target branch is `gssoc`.
