### PR TITLE
fix: Implement strict CORS configurations and session token revocation (#2971)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,7 +1,7 @@
-
+import hashlib
 import logging
 import os
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from backend.dependencies import supabase
 from backend.models import LoginBody, SignupBody
 from backend.limiter import limiter, AUTH_LIMIT
@@ -14,6 +14,10 @@ REFRESH_COOKIE = "refresh_token"
 ACCESS_MAX_AGE = 60 * 60
 REFRESH_MAX_AGE = 60 * 60 * 24 * 7
 
+# Redis key prefix for revoked tokens (TTL-keyed denylist)
+_REVOKED_PREFIX = "helpdesk:revoked:"
+
+
 def _cookie_kwargs() -> dict:
     secure = os.getenv("ENV", "production").lower() != "development"
     return {
@@ -23,6 +27,7 @@ def _cookie_kwargs() -> dict:
         "path": "/",
     }
 
+
 def extract_token(request: Request) -> str | None:
     cookie_token = request.cookies.get(ACCESS_COOKIE)
     if cookie_token:
@@ -31,6 +36,7 @@ def extract_token(request: Request) -> str | None:
     if auth and auth.lower().startswith("bearer "):
         return auth.split(" ", 1)[1].strip() or None
     return None
+
 
 def _set_session_cookies(response: Response, session) -> None:
     if not session or not getattr(session, "access_token", None):
@@ -50,15 +56,70 @@ def _set_session_cookies(response: Response, session) -> None:
             **_cookie_kwargs(),
         )
 
+
 def _clear_session_cookies(response: Response) -> None:
     kwargs = _cookie_kwargs()
     response.delete_cookie(ACCESS_COOKIE, path=kwargs["path"])
     response.delete_cookie(REFRESH_COOKIE, path=kwargs["path"])
 
+
+def _get_redis():
+    """Return the shared Redis client if available, else None."""
+    try:
+        import redis as _redis
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        client = _redis.from_url(url, decode_responses=True, socket_connect_timeout=1)
+        client.ping()
+        return client
+    except Exception:
+        return None
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _revoke_token(token: str, ttl: int = ACCESS_MAX_AGE) -> None:
+    """Add token to Redis denylist so it is rejected even before natural expiry."""
+    try:
+        redis = _get_redis()
+        if redis:
+            redis.setex(f"{_REVOKED_PREFIX}{_token_hash(token)}", ttl, "1")
+    except Exception as exc:
+        logger.warning("[Auth] Redis denylist write failed: %s", exc)
+
+
+def _is_token_revoked(token: str) -> bool:
+    """Return True if the token appears in the Redis denylist."""
+    try:
+        redis = _get_redis()
+        if redis:
+            return bool(redis.exists(f"{_REVOKED_PREFIX}{_token_hash(token)}"))
+    except Exception as exc:
+        logger.warning("[Auth] Redis denylist read failed: %s", exc)
+    return False
+
+
+def _service_supabase():
+    """Return a service-role Supabase client for admin operations."""
+    from supabase import create_client
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_KEY")
+    if not url or not key:
+        return None
+    return create_client(url, key)
+
+
 async def get_current_user(request: Request) -> dict:
     token = extract_token(request)
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
+    # Reject tokens that were explicitly revoked via logout
+    if _is_token_revoked(token):
+        raise HTTPException(
+            status_code=401,
+            detail="Session has been revoked. Please log in again.",
+        )
     if not supabase:
         raise HTTPException(status_code=503, detail="Database connection offline")
     try:
@@ -147,8 +208,36 @@ async def auth_signup(body: SignupBody, response: Response):
     return {"user": user_payload, "message": "Signup complete"}
 
 @router.post("/logout")
-async def auth_logout(response: Response):
-    """Clear session cookies to log out the current user."""
+@limiter.limit("10/minute")
+async def auth_logout(request: Request, response: Response):
+    """Log out the current user with full session revocation.
+
+    Performs three layers of session invalidation:
+    1. Adds the access token to a Redis denylist so it is rejected immediately on
+       any subsequent request, even before its natural JWT expiry.
+    2. Calls the Supabase admin API (service role) to sign the user out server-side,
+       which invalidates the refresh token and prevents silent token renewal.
+    3. Clears both the access_token and refresh_token HttpOnly cookies from the browser.
+    """
+    token = extract_token(request)
+    if token:
+        # Layer 1: denylist the raw access token in Redis for its remaining lifetime
+        _revoke_token(token, ttl=ACCESS_MAX_AGE)
+
+        # Layer 2: sign out via Supabase admin API to invalidate the refresh token
+        try:
+            admin = _service_supabase()
+            if admin:
+                user_result = admin.auth.get_user(token)
+                user = getattr(user_result, "user", None)
+                user_id = getattr(user, "id", None) if user else None
+                if user_id:
+                    admin.auth.admin.sign_out(user_id)
+        except Exception as exc:
+            # Non-fatal: cookies are cleared regardless; Redis denylist still protects
+            logger.warning("[Auth] Admin sign-out failed: %s", exc)
+
+    # Layer 3: clear cookies from the browser
     _clear_session_cookies(response)
     return {"ok": True}
 
@@ -156,4 +245,3 @@ async def auth_logout(response: Response):
 async def auth_me(user: dict = Depends(get_current_user)):
     """Return the currently authenticated user's profile."""
     return {"user": user}
-

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from fastapi import FastAPI, Request, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
@@ -18,6 +19,30 @@ configure_logging()
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
+
+# ---------------------------------------------------------------------------
+# CORS — strict allowlist driven by environment, no wildcards
+# ---------------------------------------------------------------------------
+_allowed_origins = [
+    o.strip()
+    for o in os.getenv(
+        "ALLOWED_ORIGINS",
+        "https://helpdeskaiv1.vercel.app,http://localhost:5173,http://localhost:3000",
+    ).split(",")
+    if o.strip()
+]
+# Optional regex for staging/preview deployments (e.g. https://.*\.vercel\.app)
+_origin_regex = os.getenv("ALLOWED_ORIGIN_REGEX", "")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins,
+    allow_origin_regex=_origin_regex or None,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    allow_headers=["Authorization", "Content-Type", "X-CSRF-Token"],
+    expose_headers=["X-CSRF-Token"],
+)
 
 app.add_middleware(CSRFTokenMiddleware)
 app.include_router(metrics_router.router)


### PR DESCRIPTION
## Fixes #2971

### Problem
The backend had no CORS middleware configured in `main.py` on the `gssoc` branch, allowing any origin to make authenticated cross-origin requests. Additionally, the `/auth/logout` endpoint only cleared cookies without revoking the JWT server-side, meaning a logged-out user's token remained valid until natural expiry.

### Changes

#### CORS Hardening (`main.py`)
- Added `CORSMiddleware` with environment-driven origin allowlist (`ALLOWED_ORIGINS`)
- Support optional regex pattern for staging/preview deployments (`ALLOWED_ORIGIN_REGEX`)
- Restricted methods to `GET, POST, PUT, PATCH, DELETE` — no wildcards
- Restricted headers to `Authorization, Content-Type, X-CSRF-Token`
- Exposed `X-CSRF-Token` header for browser CSRF flows
- **No wildcard origins** — explicit allowlist only

#### Session Token Revocation (`backend/routers/auth.py`)
- Added Redis-backed token denylist with SHA-256 hashing
- `_revoke_token()` adds tokens to denylist with TTL matching JWT lifetime
- `_is_token_revoked()` checks denylist on every authenticated request
- `get_current_user()` now rejects revoked tokens with 401
- `auth_logout()` now performs **3-layer revocation**:
  1. **Redis denylist** — immediate rejection, before JWT natural expiry
  2. **Supabase admin sign_out** — invalidates refresh token server-side
  3. **Cookie clearing** — removes browser cookies
- Rate-limited logout to 10/minute to prevent abuse

### Acceptance Criteria
- [x] Tighten session checks — revoked tokens are rejected on every request
- [x] Block unauthorized cross-origin header attempts — strict CORS allowlist
- [x] Session token revocation on logout — 3-layer invalidation

### GSSoC Compliance
- [x] Targets `gssoc` branch (not `main`)
- [x] Starred the repository
- [x] Following project admin @ritesh-1918