### PR TITLE
Add bulk ticket action processing

### DIFF
--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -1,29 +1,27 @@
 import jsPDF from 'jspdf';
 import Papa from 'papaparse';
+import axios from 'axios';
 import { Download, FileText } from 'lucide-react';
 import React, { useCallback, useState, useMemo, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import useAuthStore from "../../store/authStore";
 import useToastStore from "../../store/toastStore";
 import { supabase } from "../../lib/supabaseClient";
+import { API_CONFIG } from "../../config";
 import useTicketsRealtime from "../../hooks/useTicketsRealtime";
 import {
     Search,
-    Filter,
     Inbox,
     Activity,
     ShieldAlert,
     Clock,
-    ChevronRight,
-    BarChart3,
-    User,
     ArrowUpRight,
     ExternalLink,
     AlertCircle,
-    CheckCircle2,
     Loader2,
-    Save,
     RotateCcw,
+    Square,
+    CheckSquare2,
 } from 'lucide-react';
 import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
@@ -51,6 +49,13 @@ const AdminTickets = () => {
     const [languageFilter, setLanguageFilter] = useState('All');
     const [slaAtRisk, setSlaAtRisk] = useState(false);
     const [agents, setAgents] = useState([]); // All staff/admins in the company
+    const [selectedTicketIds, setSelectedTicketIds] = useState([]);
+    const [bulkStatus, setBulkStatus] = useState('');
+    const [bulkPriority, setBulkPriority] = useState('');
+    const [bulkTeam, setBulkTeam] = useState('');
+    const [bulkAgent, setBulkAgent] = useState('');
+    const [bulkActionLoading, setBulkActionLoading] = useState('');
+    const [bulkActionError, setBulkActionError] = useState('');
 
     const ticketMatchesFilters = useCallback((ticket) => {
         if (statusFilter !== 'All' && String(ticket.status || '').toLowerCase() !== statusFilter.toLowerCase()) return false;
@@ -64,6 +69,8 @@ const AdminTickets = () => {
         }
         return true;
     }, [categoryFilter, priorityFilter, statusFilter, teamFilter, languageFilter]);
+
+    const selectedTicketSet = useMemo(() => new Set(selectedTicketIds.map(String)), [selectedTicketIds]);
 
     const handleRealtimeInsert = useCallback((ticket) => {
         showToast(`New Incident Reported: #${formatTicketId(ticket.id)}`, "success");
@@ -176,8 +183,26 @@ const AdminTickets = () => {
         }
     };
 
-    const exportCSV = () => {
-        const exportData = filteredTickets.map(t => ({
+    const toggleTicketSelection = useCallback((ticketId) => {
+        setSelectedTicketIds(prev => {
+            const ticketKey = String(ticketId);
+            return prev.some(id => String(id) === ticketKey)
+                ? prev.filter(id => String(id) !== ticketKey)
+                : [...prev, ticketId];
+        });
+    }, []);
+
+    const clearTicketSelection = useCallback(() => {
+        setSelectedTicketIds([]);
+        setBulkStatus('');
+        setBulkPriority('');
+        setBulkTeam('');
+        setBulkAgent('');
+        setBulkActionError('');
+    }, []);
+
+    const exportTickets = (rows) => {
+        const exportData = rows.map(t => ({
             ID: formatTicketId(t.id),
             Title: t.summary || t.subject || '',
             Category: t.category || '',
@@ -197,13 +222,15 @@ const AdminTickets = () => {
         URL.revokeObjectURL(url);
     };
 
-    const exportPDF = () => {
+    const exportCSV = (rows = filteredTickets) => exportTickets(rows);
+
+    const exportPDF = (rows = filteredTickets) => {
         const doc = new jsPDF();
         doc.setFontSize(16);
         doc.text('Ticket Export Report', 14, 15);
         doc.setFontSize(8);
         let y = 25;
-        filteredTickets.forEach((t, i) => {
+        rows.forEach((t, i) => {
             if (y > 270) { doc.addPage(); y = 15; }
             doc.text(
                 `#${formatTicketId(t.id)} | ${t.summary || t.subject || 'N/A'} | ${t.category || ''} | ${t.priority || ''} | ${t.status || ''} | ${t.created_at ? new Date(t.created_at).toLocaleDateString() : ''}`,
@@ -216,7 +243,7 @@ const AdminTickets = () => {
 
     const categories = ['All', 'Network', 'Hardware', 'Software', 'Access', 'Account'];
     const priorities = ['All', 'Low', 'Medium', 'High'];
-    const statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed'];
+    const statuses = ['All', 'Open', 'Pending', 'In Progress', 'Resolved', 'Closed'];
     const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
 
     const filteredTickets = useMemo(() => {
@@ -246,6 +273,63 @@ const AdminTickets = () => {
         return result;
     }, [tickets, searchQuery, languageFilter, slaAtRisk]);
 
+    useEffect(() => {
+        const visibleIds = new Set(filteredTickets.map(ticket => String(ticket.id)));
+        setSelectedTicketIds((prev) => {
+            const next = prev.filter(ticketId => visibleIds.has(String(ticketId)));
+            if (next.length === prev.length && next.every((ticketId, index) => String(ticketId) === String(prev[index]))) {
+                return prev;
+            }
+            return next;
+        });
+    }, [filteredTickets]);
+
+    const selectedTickets = useMemo(
+        () => filteredTickets.filter(ticket => selectedTicketSet.has(String(ticket.id))),
+        [filteredTickets, selectedTicketSet]
+    );
+    const selectedCount = selectedTickets.length;
+    const isAllVisibleSelected = filteredTickets.length > 0 && filteredTickets.every(ticket => selectedTicketSet.has(String(ticket.id)));
+    const bulkAgentOptions = useMemo(() => [
+        { value: '', label: 'Choose Agent' },
+        ...agents.map(agent => ({ value: agent.id, label: agent.full_name || agent.id })),
+    ], [agents]);
+
+    const runBulkAction = async (action, value, successLabel) => {
+        if (!selectedCount) {
+            setBulkActionError('Select at least one ticket before applying a bulk action.');
+            return;
+        }
+        if (!value) {
+            setBulkActionError('Pick a value before applying the bulk action.');
+            return;
+        }
+
+        setBulkActionError('');
+        setBulkActionLoading(action);
+        try {
+            const { data } = await axios.post(`${API_CONFIG.BACKEND_URL}/tickets/bulk-action`, {
+                ticket_ids: selectedTickets.map(ticket => ticket.id),
+                action,
+                value,
+                company_id: profile?.company_id || profile?.company || null,
+            });
+
+            showToast(
+                `${successLabel} ${data?.updated_count || selectedCount} tickets.`,
+                "success"
+            );
+            await fetchTickets();
+            clearTicketSelection();
+        } catch (err) {
+            const detail = err?.response?.data?.detail || err.message || 'Bulk action failed.';
+            setBulkActionError(detail);
+            showToast(`Bulk action failed: ${detail}`, "error");
+        } finally {
+            setBulkActionLoading('');
+        }
+    };
+
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();
         if (p === 'high' || p === 'critical') return 'text-red-600 bg-red-50 border-red-100';
@@ -274,14 +358,14 @@ const AdminTickets = () => {
                 {/* ✅ EXPORT BUTTONS */}
                 <div className="flex items-center gap-3">
                     <button
-                        onClick={exportCSV}
+                        onClick={() => exportCSV(selectedCount > 0 ? selectedTickets : filteredTickets)}
                         className="flex items-center gap-2 px-5 py-2.5 bg-emerald-600 text-white rounded-2xl text-[11px] font-black uppercase tracking-widest hover:bg-emerald-700 transition-all shadow-lg shadow-emerald-500/20"
                     >
                         <Download size={14} />
                         Export CSV
                     </button>
                     <button
-                        onClick={exportPDF}
+                        onClick={() => exportPDF(selectedCount > 0 ? selectedTickets : filteredTickets)}
                         className="flex items-center gap-2 px-5 py-2.5 bg-slate-900 text-white rounded-2xl text-[11px] font-black uppercase tracking-widest hover:bg-indigo-600 transition-all shadow-lg shadow-slate-900/10"
                     >
                         <FileText size={14} />
@@ -289,6 +373,124 @@ const AdminTickets = () => {
                     </button>
                 </div>
             </div>
+
+            {selectedCount > 0 && (
+                <div className="rounded-[2rem] border border-emerald-200 bg-emerald-50/70 p-5 shadow-lg shadow-emerald-100/40">
+                    <div className="flex flex-col xl:flex-row xl:items-center justify-between gap-4">
+                        <div>
+                            <p className="text-[10px] font-black uppercase tracking-[0.28em] text-emerald-500 flex items-center gap-2">
+                                <CheckSquare2 size={13} />
+                                Bulk Selection Active
+                            </p>
+                            <h2 className="text-lg font-black text-slate-900">
+                                {selectedCount} selected ticket{selectedCount === 1 ? '' : 's'}
+                            </h2>
+                            <p className="text-sm text-slate-500 font-medium">
+                                Apply one action to every selected ticket, then export the current selection if you need a handoff bundle.
+                            </p>
+                        </div>
+
+                        <div className="flex flex-wrap items-center gap-3">
+                            <button
+                                type="button"
+                                onClick={clearTicketSelection}
+                                className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-500 hover:text-slate-800 hover:border-slate-300 transition-all"
+                            >
+                                <RotateCcw size={14} />
+                                Clear
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => exportCSV(selectedTickets)}
+                                className="inline-flex items-center gap-2 rounded-2xl border border-emerald-200 bg-white px-4 py-3 text-[11px] font-black uppercase tracking-widest text-emerald-700 hover:bg-emerald-600 hover:text-white transition-all"
+                            >
+                                <Download size={14} />
+                                Export Selected
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="mt-5 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3">
+                        <div className="flex items-center gap-2 rounded-2xl border border-white bg-white/90 p-3 shadow-sm">
+                            <Select
+                                value={bulkStatus}
+                                onChange={(e) => setBulkStatus(e.target.value)}
+                                placeholder="Bulk Status"
+                                buttonClassName="w-full bg-transparent border-0 px-0 py-0 text-[11px] font-black uppercase tracking-widest text-slate-700 flex items-center justify-between"
+                                options={statuses.filter(s => s !== 'All').map(s => ({ value: s.toLowerCase(), label: s }))}
+                            />
+                            <button
+                                type="button"
+                                disabled={!bulkStatus || bulkActionLoading === 'status'}
+                                onClick={() => runBulkAction('status', bulkStatus, 'Updated status on')}
+                                className="rounded-xl bg-slate-900 px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {bulkActionLoading === 'status' ? 'Applying' : 'Apply'}
+                            </button>
+                        </div>
+
+                        <div className="flex items-center gap-2 rounded-2xl border border-white bg-white/90 p-3 shadow-sm">
+                            <Select
+                                value={bulkPriority}
+                                onChange={(e) => setBulkPriority(e.target.value)}
+                                placeholder="Bulk Priority"
+                                buttonClassName="w-full bg-transparent border-0 px-0 py-0 text-[11px] font-black uppercase tracking-widest text-slate-700 flex items-center justify-between"
+                                options={priorities.filter(p => p !== 'All').map(p => ({ value: p.toLowerCase(), label: p }))}
+                            />
+                            <button
+                                type="button"
+                                disabled={!bulkPriority || bulkActionLoading === 'priority'}
+                                onClick={() => runBulkAction('priority', bulkPriority, 'Updated priority on')}
+                                className="rounded-xl bg-slate-900 px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {bulkActionLoading === 'priority' ? 'Applying' : 'Apply'}
+                            </button>
+                        </div>
+
+                        <div className="flex items-center gap-2 rounded-2xl border border-white bg-white/90 p-3 shadow-sm">
+                            <Select
+                                value={bulkTeam}
+                                onChange={(e) => setBulkTeam(e.target.value)}
+                                placeholder="Bulk Team"
+                                buttonClassName="w-full bg-transparent border-0 px-0 py-0 text-[11px] font-black uppercase tracking-widest text-slate-700 flex items-center justify-between"
+                                options={teams.filter(t => t !== 'All').map(t => ({ value: t, label: t }))}
+                            />
+                            <button
+                                type="button"
+                                disabled={!bulkTeam || bulkActionLoading === 'assigned_team'}
+                                onClick={() => runBulkAction('assigned_team', bulkTeam, 'Rerouted')}
+                                className="rounded-xl bg-slate-900 px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {bulkActionLoading === 'assigned_team' ? 'Applying' : 'Apply'}
+                            </button>
+                        </div>
+
+                        <div className="flex items-center gap-2 rounded-2xl border border-white bg-white/90 p-3 shadow-sm">
+                            <Select
+                                value={bulkAgent}
+                                onChange={(e) => setBulkAgent(e.target.value)}
+                                placeholder="Bulk Agent"
+                                buttonClassName="w-full bg-transparent border-0 px-0 py-0 text-[11px] font-black uppercase tracking-widest text-slate-700 flex items-center justify-between"
+                                options={bulkAgentOptions}
+                            />
+                            <button
+                                type="button"
+                                disabled={!bulkAgent || bulkActionLoading === 'assigned_agent_id'}
+                                onClick={() => runBulkAction('assigned_agent_id', bulkAgent, 'Assigned')}
+                                className="rounded-xl bg-indigo-600 px-3 py-2 text-[10px] font-black uppercase tracking-widest text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {bulkActionLoading === 'assigned_agent_id' ? 'Applying' : 'Apply'}
+                            </button>
+                        </div>
+                    </div>
+
+                    {bulkActionError && (
+                        <p className="mt-4 text-[10px] font-black uppercase tracking-widest text-red-600">
+                            {bulkActionError}
+                        </p>
+                    )}
+                </div>
+            )}
 
             {/* 2. Advanced Filtering Station */}
             <div className="bg-white p-6 rounded-[2rem] border border-slate-200 shadow-xl shadow-slate-200/50 space-y-6">
@@ -390,6 +592,22 @@ const AdminTickets = () => {
                     <table className="w-full border-collapse">
                         <thead>
                             <tr className="bg-slate-50/80 border-b border-slate-100">
+                                <th className="px-4 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            if (isAllVisibleSelected) {
+                                                setSelectedTicketIds([]);
+                                            } else {
+                                                setSelectedTicketIds(filteredTickets.map(ticket => ticket.id));
+                                            }
+                                        }}
+                                        className="inline-flex items-center justify-center text-slate-400 hover:text-emerald-600 transition-colors"
+                                        title={isAllVisibleSelected ? 'Clear all visible selections' : 'Select all visible tickets'}
+                                    >
+                                        {isAllVisibleSelected ? <CheckSquare2 size={16} /> : <Square size={16} />}
+                                    </button>
+                                </th>
                                 <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">
                                     <div className="flex items-center gap-2">
                                         ID
@@ -416,6 +634,23 @@ const AdminTickets = () => {
 
                                 return (
                                 <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : slaRowClass} ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
+                                    <td className="px-4 py-6 align-top">
+                                        <button
+                                            type="button"
+                                            onClick={(event) => {
+                                                event.stopPropagation();
+                                                toggleTicketSelection(ticket.id);
+                                            }}
+                                            className="inline-flex items-center justify-center text-slate-400 hover:text-emerald-600 transition-colors"
+                                            title={`Select ticket #${formatTicketId(ticket.id)}`}
+                                        >
+                                            {selectedTicketSet.has(String(ticket.id)) ? (
+                                                <CheckSquare2 size={16} className="text-emerald-600" />
+                                            ) : (
+                                                <Square size={16} />
+                                            )}
+                                        </button>
+                                    </td>
                                     {/* Ticket ID */}
                                     <td className="px-6 py-6">
                                         <span className="font-mono text-xs font-black text-emerald-600">#{formatTicketId(ticket.id)}</span>

--- a/backend/auth/crypto.py
+++ b/backend/auth/crypto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import base64
 import logging

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,8 @@ POST /ai/analyze_ticket  →  full analysis of a support ticket
 GET  /health             →  service health check
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import uuid
@@ -493,6 +495,20 @@ class AuditLogRecord(BaseModel):
     new_value: dict | list | str | None = None
     created_at: str
     performed_by_profile: AuditLogProfile | None = None
+
+
+class BulkTicketActionRequest(BaseModel):
+    ticket_ids: list[str]
+    action: str
+    value: str | None = None
+    company_id: str | None = None
+
+
+class BulkTicketActionResponse(BaseModel):
+    action: str
+    requested_count: int
+    updated_count: int
+    updated_ticket_ids: list[str]
 
 
 # --- In-Memory Database (to be replaced with SQL later) ---
@@ -1058,6 +1074,18 @@ async def get_tickets(
     res = query.execute()
     return res.data
 
+
+ALLOWED_BULK_ACTIONS = {
+    "status",
+    "priority",
+    "assigned_team",
+    "assigned_agent_id",
+}
+
+ALLOWED_BULK_STATUSES = {"open", "in progress", "pending", "resolved", "closed"}
+ALLOWED_BULK_PRIORITIES = {"low", "medium", "high", "critical"}
+
+
 def trigger_webhook_for_new_ticket(company_id: str, ticket: dict) -> None:
     """Trigger Slack or Microsoft Teams webhook for new Critical/High tickets (Issue #175)."""
     if not supabase or not company_id:
@@ -1529,6 +1557,88 @@ async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_
             return updated_ticket
     
     raise HTTPException(status_code=404, detail="Ticket not found")
+
+
+@app.post("/tickets/bulk-action", response_model=BulkTicketActionResponse)
+async def bulk_ticket_action(
+    payload: BulkTicketActionRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Apply a bounded bulk change to a set of tickets within the caller's company scope."""
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    ticket_ids = [str(ticket_id).strip() for ticket_id in payload.ticket_ids if str(ticket_id).strip()]
+    if not ticket_ids:
+        raise HTTPException(status_code=400, detail="At least one ticket id is required")
+    if len(ticket_ids) > 100:
+        raise HTTPException(status_code=400, detail="Bulk actions are limited to 100 tickets per request")
+
+    action = str(payload.action or "").strip().lower()
+    if action not in ALLOWED_BULK_ACTIONS:
+        raise HTTPException(status_code=400, detail="Unsupported bulk action")
+
+    raw_value = str(payload.value or "").strip()
+    if action in {"status", "priority", "assigned_team", "assigned_agent_id"} and not raw_value:
+        raise HTTPException(status_code=400, detail="A value is required for the selected bulk action")
+
+    normalized_value = raw_value.lower() if action in {"status", "priority"} else raw_value
+    if action == "status" and normalized_value not in ALLOWED_BULK_STATUSES:
+        raise HTTPException(status_code=400, detail="Unsupported bulk status")
+    if action == "priority" and normalized_value not in ALLOWED_BULK_PRIORITIES:
+        raise HTTPException(status_code=400, detail="Unsupported bulk priority")
+
+    profile = _get_authenticated_profile(current_user)
+    company_scope = _ticket_company_scope(profile, payload.company_id or profile.get("company_id"))
+
+    query = (
+        supabase.table("tickets")
+        .select("id, company_id, status, priority, assigned_team, assigned_agent_id, resolved_at")
+        .in_("id", ticket_ids)
+    )
+    if company_scope:
+        query = query.eq("company_id", company_scope)
+
+    result = query.execute()
+    rows = result.data or []
+    rows_by_id = {str(row.get("id")): row for row in rows}
+    missing_ids = [ticket_id for ticket_id in ticket_ids if ticket_id not in rows_by_id]
+    if missing_ids:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Tickets not found or not accessible: {', '.join(missing_ids)}",
+        )
+
+    updated_ticket_ids: list[str] = []
+    current_timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+
+    for ticket_id in ticket_ids:
+        updates: dict[str, str] = {"updated_at": current_timestamp}
+
+        if action == "status":
+            updates["status"] = normalized_value
+            if normalized_value in {"resolved", "closed"}:
+                updates["resolved_at"] = current_timestamp
+        elif action == "priority":
+            updates["priority"] = normalized_value
+        elif action == "assigned_team":
+            updates["assigned_team"] = raw_value
+        elif action == "assigned_agent_id":
+            updates["assigned_agent_id"] = raw_value
+            updates["status"] = "in progress"
+
+        update_result = supabase.table("tickets").update(updates).eq("id", ticket_id).execute()
+        if not update_result.data:
+            raise HTTPException(status_code=500, detail=f"Failed to update ticket {ticket_id}")
+
+        updated_ticket_ids.append(ticket_id)
+
+    return BulkTicketActionResponse(
+        action=action,
+        requested_count=len(ticket_ids),
+        updated_count=len(updated_ticket_ids),
+        updated_ticket_ids=updated_ticket_ids,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/routes/translation.py
+++ b/backend/routes/translation.py
@@ -2,7 +2,7 @@
 Translation API Routes — Multi-Language Ticket Support
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 from typing import Optional
 
@@ -62,7 +62,7 @@ async def translate_ticket_endpoint(request: TranslateTicketRequest):
 
 
 @router.post("/detect")
-async def detect(text: str = Field(..., min_length=1)):
+async def detect(text: str = Query(..., min_length=1)):
     """Detect the language of the given text."""
     lang = detect_language(text)
     if not lang:

--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -3,6 +3,8 @@ Duplicate Detection Service
 Uses sentence-transformers all-MiniLM-L6-v2 to detect similar tickets.
 """
 
+from __future__ import annotations
+
 import uuid
 import os
 from typing import Any
@@ -253,4 +255,3 @@ class DuplicateService:
             "duplicate_ticket_id": best_id if is_dup else None,
             "similarity": round(best_score, 4),
         }
-

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import base64
 import io

--- a/backend/services/semantic_duplicate_service.py
+++ b/backend/services/semantic_duplicate_service.py
@@ -13,6 +13,8 @@ Usage:
     await service.index_ticket(ticket_id, text)
 """
 
+from __future__ import annotations
+
 import os
 import json
 import logging

--- a/backend/services/sla_engine.py
+++ b/backend/services/sla_engine.py
@@ -9,6 +9,8 @@ Architecture:
   - Multi-channel dispatch (Email / Slack / Teams / Webhook)
 """
 
+from __future__ import annotations
+
 import os
 import json
 import logging

--- a/backend/services/spam_service.py
+++ b/backend/services/spam_service.py
@@ -7,6 +7,8 @@ classification cascade so high-risk tickets can be flagged in the UI and
 kept away from support agents' inboxes.
 """
 
+from __future__ import annotations
+
 import re
 from urllib.parse import urlparse
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -24,6 +24,7 @@ class FakeTable:
         self.db = db
         self.name = name
         self.filters = {}
+        self.in_filters = {}
         self.payload = None
         self.limit_count = None
         self.is_single = False
@@ -48,6 +49,10 @@ class FakeTable:
 
     def eq(self, field, value):
         self.filters[field] = value
+        return self
+
+    def in_(self, field, values):
+        self.in_filters[field] = list(values)
         return self
 
     def order(self, field, desc=False):
@@ -101,6 +106,9 @@ class FakeTable:
         rows = list(self.db.get(self.name, []))
         for key, value in self.filters.items():
             rows = [row for row in rows if _safe_eq(row.get(key), value)]
+
+        for key, values in self.in_filters.items():
+            rows = [row for row in rows if any(_safe_eq(row.get(key), value) for value in values)]
 
         if self.order_field:
             rows.sort(key=lambda x: x.get(self.order_field, ""), reverse=self.order_desc)

--- a/backend/tests/test_bulk_ticket_actions.py
+++ b/backend/tests/test_bulk_ticket_actions.py
@@ -1,0 +1,102 @@
+from backend.auth_cookie import get_current_user
+
+
+def authenticate_as(test_client, user_id):
+    test_client.app.dependency_overrides[get_current_user] = lambda: {"id": user_id}
+
+
+def clear_authentication(test_client):
+    test_client.app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_bulk_status_updates_are_company_scoped(test_client, fake_db):
+    fake_db["tickets"] = [
+        {
+            "id": "ticket-1",
+            "company_id": "company_A",
+            "status": "open",
+            "priority": "low",
+            "assigned_team": "General Support",
+            "assigned_agent_id": None,
+            "resolved_at": None,
+        },
+        {
+            "id": "ticket-2",
+            "company_id": "company_A",
+            "status": "in progress",
+            "priority": "medium",
+            "assigned_team": "General Support",
+            "assigned_agent_id": None,
+            "resolved_at": None,
+        },
+        {
+            "id": "ticket-3",
+            "company_id": "company_B",
+            "status": "open",
+            "priority": "high",
+            "assigned_team": "Security Unit",
+            "assigned_agent_id": None,
+            "resolved_at": None,
+        },
+    ]
+
+    authenticate_as(test_client, "user_A")
+    try:
+        response = test_client.post(
+            "/tickets/bulk-action",
+            json={
+                "ticket_ids": ["ticket-1", "ticket-2"],
+                "action": "status",
+                "value": "resolved",
+                "company_id": "company_A",
+            },
+        )
+    finally:
+        clear_authentication(test_client)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["action"] == "status"
+    assert payload["updated_count"] == 2
+    assert payload["updated_ticket_ids"] == ["ticket-1", "ticket-2"]
+    assert fake_db["tickets"][0]["status"] == "resolved"
+    assert fake_db["tickets"][0]["resolved_at"] is not None
+    assert fake_db["tickets"][1]["status"] == "resolved"
+    assert fake_db["tickets"][1]["resolved_at"] is not None
+    assert fake_db["tickets"][2]["status"] == "open"
+    assert fake_db["tickets"][2]["resolved_at"] is None
+
+
+def test_bulk_assignment_forces_in_progress(test_client, fake_db):
+    fake_db["tickets"] = [
+        {
+            "id": "ticket-11",
+            "company_id": "company_A",
+            "status": "open",
+            "priority": "low",
+            "assigned_team": "General Support",
+            "assigned_agent_id": None,
+            "resolved_at": None,
+        }
+    ]
+
+    authenticate_as(test_client, "user_A")
+    try:
+        response = test_client.post(
+            "/tickets/bulk-action",
+            json={
+                "ticket_ids": ["ticket-11"],
+                "action": "assigned_agent_id",
+                "value": "agent-9",
+                "company_id": "company_A",
+            },
+        )
+    finally:
+        clear_authentication(test_client)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["action"] == "assigned_agent_id"
+    assert payload["updated_count"] == 1
+    assert fake_db["tickets"][0]["assigned_agent_id"] == "agent-9"
+    assert fake_db["tickets"][0]["status"] == "in progress"


### PR DESCRIPTION
## What changed
- Added a bulk action endpoint for tickets with company-scoped updates.
- Added admin ticket table selection, bulk status/priority/team/agent controls, and selected-row export.
- Added backend tests for bulk status updates and bulk assignment behavior.

## Why
Helps admins process high-volume ticket queues faster without manually updating tickets one by one.

## Validation
- `python3 -m pytest -p no:asyncio tests/test_bulk_ticket_actions.py tests/test_audit_service.py`
- `npm run build`
- `git diff --check`
