### PR TITLE
Add sensitive data anonymization to ticket flow

### DIFF
--- a/Frontend/src/services/api.js
+++ b/Frontend/src/services/api.js
@@ -90,8 +90,11 @@ export const api = {
       await delay(800);
       return createTicketMock(ticketData);
     }
-    try {
-      const response = await axios.post(`${API_BASE_URL}/tickets/save`, ticketData);
+  try {
+      const response = await axios.post(`${API_BASE_URL}/tickets/save`, {
+        ...ticketData,
+        anonymize_sensitive_data: ticketData.anonymize_sensitive_data ?? true
+      });
       const created = response?.data;
 
       // Normalize to mock shape: { data: <createdTicket> }
@@ -112,6 +115,7 @@ export const api = {
         text: issueText,
         image_base64: imageBase64,
         image_text: "",
+        anonymize_sensitive_data: true,
         company_id: currentUser.company_id || currentUser.companyId || null
       });
 

--- a/Frontend/src/user/pages/AIProcessing.jsx
+++ b/Frontend/src/user/pages/AIProcessing.jsx
@@ -12,6 +12,7 @@ import useAuthStore from '../../store/authStore';
 import { supabase } from '../../lib/supabaseClient';
 import { API_CONFIG } from '../../config';
 import { analyzeTicketWithAI } from '../../services/aiAssistant';
+import { anonymizeSensitiveText } from '../../utils/anonymize';
 
 const steps = [
     "Reading your message",
@@ -24,13 +25,14 @@ const steps = [
 const AIProcessing = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { text, image_text, image_base64, template_id, template_used, user_modified, ticket_title, original_text, original_language } = location.state || {};
+    const { text, image_text, image_base64, template_id, template_used, user_modified, ticket_title, original_text, original_language, anonymize_sensitive_data } = location.state || {};
     const setAITicket = useTicketStore((state) => state.setAITicket);
     const { settings } = useAdminStore();
     const { user, profile } = useAuthStore();
     const { showToast } = useToastStore();
     const hasCalledAPI = useRef(false);
     const [activeStep, setActiveStep] = useState(0);
+    const shouldAnonymize = anonymize_sensitive_data !== false;
 
     useEffect(() => {
         if (!text) {
@@ -44,6 +46,8 @@ const AIProcessing = () => {
 
         const analyzeTicket = async () => {
             console.log("[AIProcessing] Starting analysis for:", text);
+            const safeText = shouldAnonymize ? anonymizeSensitiveText(text) : text;
+            const safeOcrText = shouldAnonymize ? anonymizeSensitiveText(image_text || "") : (image_text || "");
 
             try {
 
@@ -107,6 +111,7 @@ const AIProcessing = () => {
                     text: text,
                     image_text: image_text || "",
                     image_base64: image_base64 || "",
+                    anonymize_sensitive_data: anonymize_sensitive_data !== false,
                     user_id: user?.id,
                     company:
                         profile?.company ||
@@ -254,7 +259,7 @@ const AIProcessing = () => {
 
                 // Override the backend summary using the robust frontend multi-provider failover
                 try {
-                    const aiResult = await analyzeTicketWithAI(text, image_text, image_base64);
+                    const aiResult = await analyzeTicketWithAI(safeText, safeOcrText, image_base64);
                     finalTicket.summary = aiResult.summary || finalTicket.summary;
                     if (aiResult.image_description) {
                         finalTicket.image_description = aiResult.image_description;
@@ -276,10 +281,13 @@ const AIProcessing = () => {
                 const aiTicketObject = {
                     ...finalTicket,
                     status: 'analyzing',
-                    originalIssue: original_text || text,
+                    originalIssue: shouldAnonymize
+                        ? anonymizeSensitiveText(original_text || text)
+                        : (original_text || text),
                     originalLanguage: original_language || 'en',
                     capturedFileBase64: image_base64,
-                    ocrText: image_text
+                    ocrText: shouldAnonymize ? anonymizeSensitiveText(image_text || "") : image_text,
+                    anonymizeSensitiveData: anonymize_sensitive_data !== false,
                 };
 
                 setAITicket(aiTicketObject);
@@ -301,9 +309,9 @@ const AIProcessing = () => {
                     );
 
                     let summary =
-    (text.charAt(0).toUpperCase() + text.slice(1))
+    (safeText.charAt(0).toUpperCase() + safeText.slice(1))
         .substring(0, 100)
-    + (text.length > 100 ? '…' : '');
+    + (safeText.length > 100 ? '…' : '');
                     let image_description = "";
                     let fallbackCategory = "General";
                     let fallbackSub = "General Support";
@@ -311,7 +319,7 @@ const AIProcessing = () => {
                     let fallbackTeam = "General Support";
 
                     try {
-                        const aiResult = await analyzeTicketWithAI(text, image_text, image_base64);
+                        const aiResult = await analyzeTicketWithAI(safeText, safeOcrText, image_base64);
                         summary = aiResult.summary || summary;
                         image_description = aiResult.image_description || "";
                         
@@ -347,10 +355,13 @@ const AIProcessing = () => {
 
                         ocr_text: image_text || "",
                         highlights: [],
-                        originalIssue: original_text || text,
+                        originalIssue: shouldAnonymize
+                            ? anonymizeSensitiveText(original_text || text)
+                            : (original_text || text),
                         originalLanguage: original_language || 'en',
                         capturedFileBase64: image_base64,
-                        ocrText: image_text
+                        ocrText: shouldAnonymize ? anonymizeSensitiveText(image_text || "") : image_text,
+                        anonymizeSensitiveData: anonymize_sensitive_data !== false,
                     };
 
                     setAITicket(fallbackTicket);

--- a/Frontend/src/user/pages/CreateTicket.jsx
+++ b/Frontend/src/user/pages/CreateTicket.jsx
@@ -9,6 +9,7 @@ import {
     BrainCircuit,
     AlertCircle,
     CheckCircle2,
+    ShieldCheck,
     Clock,
     Mic,
     MicOff,
@@ -45,6 +46,7 @@ const CreateTicket = () => {
     const [selectedLanguage, setSelectedLanguage] = useState('en');
     const [isTranslating, setIsTranslating] = useState(false);
     const [isLangOpen, setIsLangOpen] = useState(false);
+    const [anonymizeSensitiveData, setAnonymizeSensitiveData] = useState(true);
     const langRef = useRef(null);
 
     // ── Smart Template state (v2: two-step highlight → activate flow) ──
@@ -412,6 +414,7 @@ const CreateTicket = () => {
                     template_used: templateUsed,
                     user_modified: userModified,
                     ticket_title: ticketTitle.trim() || null,
+                    anonymize_sensitive_data: anonymizeSensitiveData,
                 }
             });
 
@@ -706,7 +709,31 @@ const CreateTicket = () => {
                                                     </div>
                                                 </motion.div>
                                             )}
-                                        </AnimatePresence>
+                                            </AnimatePresence>
+                                    </div>
+
+                                    <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-4 shadow-sm">
+                                        <label className="flex items-start gap-3 cursor-pointer">
+                                            <input
+                                                type="checkbox"
+                                                checked={anonymizeSensitiveData}
+                                                onChange={(e) => setAnonymizeSensitiveData(e.target.checked)}
+                                                className="mt-1 h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+                                            />
+                                            <div className="flex-1">
+                                                <div className="flex items-center gap-2">
+                                                    <ShieldCheck size={16} className="text-emerald-600 shrink-0" />
+                                                    <span className="text-sm font-bold text-gray-900">
+                                                        Enable Sensitive Data Anonymization (Recommended)
+                                                    </span>
+                                                </div>
+                                                <p className={`mt-1 text-xs font-medium ${anonymizeSensitiveData ? 'text-emerald-700' : 'text-amber-700'}`}>
+                                                    {anonymizeSensitiveData
+                                                        ? 'Emails, IPs, connection strings, and API keys will be masked before analysis and storage.'
+                                                        : 'Sensitive values will be forwarded as typed. Only disable this for trusted internal testing.'}
+                                                </p>
+                                            </div>
+                                        </label>
                                     </div>
 
                                     {/* Error Message */}

--- a/Frontend/src/user/pages/TicketTracking.jsx
+++ b/Frontend/src/user/pages/TicketTracking.jsx
@@ -64,12 +64,14 @@ const TicketTracking = () => {
                     company: profile?.company || null,
                     company_id: profile?.company_id || null,
                     sla_breach_at: aiTicket.sla_breach_at || getSlaBreachAt(aiTicket.priority),
+                    anonymize_sensitive_data: aiTicket.anonymizeSensitiveData !== false,
                     metadata: {
                         confidence: aiTicket.confidence,
                         entities: aiTicket.entities,
                         decision_factors: aiTicket.decision_factors,
                         ocr_text: aiTicket.ocr_text,
-                        image_description: aiTicket.image_description
+                        image_description: aiTicket.image_description,
+                        anonymization_enabled: aiTicket.anonymizeSensitiveData !== false,
                     },
                     entities: aiTicket.entities,
                     solution_steps: resolutionSteps,

--- a/Frontend/src/utils/anonymize.js
+++ b/Frontend/src/utils/anonymize.js
@@ -1,0 +1,32 @@
+const PATTERNS = [
+  {
+    regex: /\b(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|mariadb|redis|amqp|amqps):\/\/[^\s'"`<>]+/gi,
+    replacement: '[REDACTED_CONNECTION_STRING]'
+  },
+  {
+    regex: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    replacement: '[REDACTED_EMAIL]'
+  },
+  {
+    regex: /\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b/g,
+    replacement: '[REDACTED_IP_ADDRESS]'
+  },
+  {
+    regex: /\b(?:sk_(?:live|test)|ghp|ghs|xox[baprs])[_-]?[A-Za-z0-9_-]{10,}\b/gi,
+    replacement: '[REDACTED_CREDENTIALS]'
+  },
+  {
+    regex: /\bBearer\s+[A-Za-z0-9._\-+/=]{10,}\b/gi,
+    replacement: 'Bearer [REDACTED_CREDENTIALS]'
+  },
+  {
+    regex: /\b(password|passwd|pass|secret|token|api[_-]?key)\s*([:=])\s*([^\s,;]+)/gi,
+    replacement: (_, key, separator) => `${key}${separator} [REDACTED_CREDENTIALS]`
+  }
+];
+
+export const anonymizeSensitiveText = (value = '') => {
+  if (!value) return '';
+
+  return PATTERNS.reduce((acc, pattern) => acc.replace(pattern.regex, pattern.replacement), value);
+};

--- a/backend/auth/crypto.py
+++ b/backend/auth/crypto.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import base64
 import logging

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,8 @@ POST /ai/analyze_ticket  →  full analysis of a support ticket
 GET  /health             →  service health check
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import uuid
@@ -76,6 +78,7 @@ from backend.services.spam_service import SpamService
 from backend.services.sla_engine import SLAEngine, compute_sla_breach_at, get_sla_policy
 from backend.services.redis_cache import redis_cache
 from backend.sla_predictor import get_sla_estimate
+from backend.utils.anonymizer import anonymize_sensitive_text, anonymize_sensitive_value
 from backend.auth_cookie import router as auth_cookie_router, get_current_user  # noqa: F401
 
 
@@ -355,6 +358,7 @@ class TicketRequest(BaseModel):
     text: str
     image_base64: str = ""
     image_text: str = "" # Keep for backward compatibility
+    anonymize_sensitive_data: bool = True
     user_id: str | None = None
     company: str | None = None
     company_id: str | None = None
@@ -401,6 +405,7 @@ class TicketSaveRequest(BaseModel):
     ocr_text: str = ""
     needs_review: bool = False
     routing_confidence: float = 0.0
+    anonymize_sensitive_data: bool = True
 
 
 
@@ -1124,6 +1129,13 @@ async def save_ticket(request_body: TicketSaveRequest):
 
     logger = logging.getLogger(__name__)
     final_data = request_body.model_dump()
+    should_anonymize = bool(final_data.get("anonymize_sensitive_data", True))
+    if should_anonymize:
+        for field in ("subject", "description", "original_body", "ocr_text"):
+            if final_data.get(field):
+                final_data[field], _ = anonymize_sensitive_text(str(final_data[field]))
+        if final_data.get("metadata"):
+            final_data["metadata"], _ = anonymize_sensitive_value(final_data["metadata"])
     original_subject = final_data.get("subject", "") or ""
     original_description = final_data.get("description", "") or ""
 
@@ -1208,11 +1220,13 @@ async def save_ticket(request_body: TicketSaveRequest):
             final_data["sla_breach_at"] = calculate_sla_breach_at(priority).isoformat().replace("+00:00", "Z")
         final_data["sla_status"] = final_data.get("sla_status") or classify_sla_status(final_data.get("sla_breach_at"))
         final_data["escalation_level"] = int(final_data.get("escalation_level") or 0)
+        if should_anonymize:
+            final_data["metadata"]["anonymization_enabled"] = True
 
         user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
         logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
 
-        duplicate_text = (request_body.description or "").strip() or (request_body.subject or "").strip()
+        duplicate_text = (final_data.get("description") or "").strip() or (final_data.get("subject") or "").strip()
         duplicate_threshold = get_duplicate_threshold(final_data.get("company_id"), 0.85)  # noqa: F841
 
 
@@ -1220,7 +1234,7 @@ async def save_ticket(request_body: TicketSaveRequest):
         # This allows us to warn the user before confirming
         duplicate_check_result = None
         try:
-            dupe_text = (request_body.description or request_body.subject or "").strip()
+            dupe_text = (final_data.get("description") or final_data.get("subject") or "").strip()
             if dupe_text:
                 duplicate_check_result = await semantic_dupe_service.check_duplicate(
                     text=dupe_text,
@@ -1241,7 +1255,7 @@ async def save_ticket(request_body: TicketSaveRequest):
         VALID_TICKET_COLUMNS = {
             "user_id", "subject", "description", "category", "subcategory",
             "priority", "assigned_team", "status", "auto_resolve", "is_duplicate",
-            "confidence", "image_url", "company", "company_id",
+            "confidence", "image_url", "company", "company_id", "ocr_text",
             "sla_breach_at", "sla_response_due_at", "sla_status", "escalation_level", "metadata",
         }
         # Merge any extra telemetry and SLA/duplicate fields into metadata before filtering
@@ -1252,7 +1266,10 @@ async def save_ticket(request_body: TicketSaveRequest):
         )
         for extra_key in extra_keys:
             if extra_key in final_data and final_data[extra_key] not in (None, "", [], {}):
-                existing_metadata[extra_key] = final_data[extra_key]
+                value = final_data[extra_key]
+                if should_anonymize:
+                    value, _ = anonymize_sensitive_value(value)
+                existing_metadata[extra_key] = value
         final_data["metadata"] = existing_metadata
 
         # Strip keys not accepted by the DB schema
@@ -1277,8 +1294,8 @@ async def save_ticket(request_body: TicketSaveRequest):
 
         # Index the new ticket's embedding for future duplicate checks
         embedding_indexed = False
-        description_text = (request_body.description or "").strip()
-        subject_text = (request_body.subject or "").strip()
+        description_text = (final_data.get("description") or "").strip()
+        subject_text = (final_data.get("subject") or "").strip()
         duplicate_text = description_text or subject_text
         if duplicate_text:
             try:
@@ -1540,7 +1557,10 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
     """
     Main endpoint for analyzing a new ticket using the cascade of local AI models.
     """
+    anonymize_sensitive_data = bool(getattr(request_body, "anonymize_sensitive_data", True))
     text = request_body.text
+    if anonymize_sensitive_data:
+        text, _ = anonymize_sensitive_text(text)
     
     # Grab client metadata
     client_ip = request.client.host if request.client else "unknown"
@@ -1558,24 +1578,35 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
     if request_body.image_base64 and ocr_service:
         print("[AI] Extracting text via local OCR...")
         local_ocr_text = ocr_service.extract_text(request_body.image_base64)
+        if anonymize_sensitive_data and local_ocr_text:
+            local_ocr_text, _ = anonymize_sensitive_text(local_ocr_text)
         if local_ocr_text:
             text = f"{text} {local_ocr_text}".strip()
             print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
 
     # Pass OCR-enriched text downstream so the analyze_only endpoint uses it.
-    enriched = request_body.model_copy(update={"text": text, "image_text": local_ocr_text})
-    return await analyze_only(enriched)
+    enriched = request_body.model_copy(
+        update={
+            "text": text,
+            "image_text": local_ocr_text,
+            "anonymize_sensitive_data": anonymize_sensitive_data,
+        }
+    )
+    return await _analyze_only_impl(enriched, request=request)
 
-@app.post("/ai/analyze")
-@limiter.limit("10/minute")
-async def analyze_only(request_body: TicketRequest, request: Request):
+async def _analyze_only_impl(request_body: TicketRequest, request: Request):
     """
     PERFORMANCE UPGRADE: AI Analysis phase only. 
     Does NOT persist to DB. This allows the user to review the analysis 
     and duplicate check before committing to a ticket creation.
     """
+    anonymize_sensitive_data = bool(getattr(request_body, "anonymize_sensitive_data", True))
     text = request_body.text
+    if anonymize_sensitive_data:
+        text, _ = anonymize_sensitive_text(text)
     translation_ctx = await detect_and_translate_ticket_text(text)
+    if anonymize_sensitive_data and translation_ctx.get("original_text"):
+        translation_ctx["original_text"], _ = anonymize_sensitive_text(translation_ctx["original_text"])
     text = translation_ctx["text_for_analysis"]
     print(f"[AI] Starting Analysis (READ-ONLY) for: {text[:50]}...") 
     settings = get_system_settings(request_body.company_id or request_body.company)
@@ -1643,12 +1674,19 @@ async def analyze_only(request_body: TicketRequest, request: Request):
         "ocr_text": request_body.image_text or "",
         "image_description": ""
     }
+    if anonymize_sensitive_data and gemini_analysis["ocr_text"]:
+        gemini_analysis["ocr_text"], _ = anonymize_sensitive_text(gemini_analysis["ocr_text"])
     
     if request_body.image_base64 and not gemini_analysis["ocr_text"]:
         try:
             print("[AI] Detecting visual context via Gemini...")
             vision_result = gemini_service.analyze_image(request_body.image_base64, text)
             gemini_analysis.update(vision_result)
+            if anonymize_sensitive_data:
+                gemini_analysis["ocr_text"], _ = anonymize_sensitive_text(gemini_analysis.get("ocr_text", ""))
+                gemini_analysis["image_description"], _ = anonymize_sensitive_text(
+                    gemini_analysis.get("image_description", "")
+                )
         except Exception as e:
             print(f"[VISION ERROR] {e}")
 
@@ -1703,7 +1741,12 @@ async def analyze_only(request_body: TicketRequest, request: Request):
     if classification["confidence"] > request_body.confidence_threshold:
         decision_factors.append(f"High confidence match for '{classification['subcategory']}'")
     if entities:
-        decision_factors.append(f"Detected entities: {', '.join([e['text'] for e in entities[:2]])}")
+        detected_entities = [
+            e.text if hasattr(e, "text") else str(e.get("text", ""))
+            for e in entities[:2]
+            if e
+        ]
+        decision_factors.append(f"Detected entities: {', '.join(detected_entities)}")
     if dup_result["is_duplicate"]:
         decision_factors.append(f"Found similar incident ({int(dup_result['similarity']*100)}%)")
     if rag_match:
@@ -1749,7 +1792,10 @@ async def analyze_only(request_body: TicketRequest, request: Request):
         image_description=gemini_analysis["image_description"],
         ocr_text=gemini_analysis["ocr_text"],
         image_url=request_body.image_url,
-        highlights=[e.text for e in entities] if entities else [],
+        highlights=[
+            e.text if hasattr(e, "text") else str(e.get("text", ""))
+            for e in entities
+        ] if entities else [],
         timeline=timeline,
         env_metadata=env_metadata,
         spam_check=SpamCheck(**spam_result),
@@ -1762,6 +1808,12 @@ async def analyze_only(request_body: TicketRequest, request: Request):
         was_translated=translation_ctx["was_translated"],
     )
 
+@app.post("/ai/analyze")
+@limiter.limit("10/minute")
+async def analyze_only(request_body: TicketRequest, request: Request):
+    return await _analyze_only_impl(request_body, request)
+
+
 @app.post("/ai/analyze_stream")
 async def analyze_stream(request_body: TicketRequest):
     """
@@ -1772,7 +1824,10 @@ async def analyze_stream(request_body: TicketRequest):
         return datetime.datetime.utcnow().isoformat() + "Z"
 
     async def event_generator():
+        anonymize_sensitive_data = bool(getattr(request_body, "anonymize_sensitive_data", True))
         text = request_body.text
+        if anonymize_sensitive_data:
+            text, _ = anonymize_sensitive_text(text)
         env_metadata = {
             "timestamp": get_now_ist(),
             "model_version": "3.0.0-PRO",
@@ -1785,10 +1840,17 @@ async def analyze_stream(request_body: TicketRequest):
         await asyncio.sleep(0.5)
 
         gemini_analysis = {"ocr_text": request_body.image_text or "", "image_description": ""}
+        if anonymize_sensitive_data and gemini_analysis["ocr_text"]:
+            gemini_analysis["ocr_text"], _ = anonymize_sensitive_text(gemini_analysis["ocr_text"])
         if request_body.image_base64 and not gemini_analysis["ocr_text"]:
             try:
                 vision_result = gemini_service.analyze_image(request_body.image_base64, text)
                 gemini_analysis.update(vision_result)
+                if anonymize_sensitive_data:
+                    gemini_analysis["ocr_text"], _ = anonymize_sensitive_text(gemini_analysis.get("ocr_text", ""))
+                    gemini_analysis["image_description"], _ = anonymize_sensitive_text(
+                        gemini_analysis.get("image_description", "")
+                    )
             except Exception as e:
                 pass
 
@@ -1918,6 +1980,8 @@ async def legacy_analyze_and_save(request_body: TicketRequest):
 @app.post("/ai/analyze-v2")
 async def analyze_ticket_v2(request: TicketRequest):
     text = request.text
+    if getattr(request, "anonymize_sensitive_data", True):
+        text, _ = anonymize_sensitive_text(text)
     try:
         prediction = classifier_v2.predict(text)
         return {
@@ -2143,6 +2207,8 @@ async def check_duplicate_endpoint(
     Returns top candidates with similarity scores.
     """
     text = (body.text or "").strip()
+    if getattr(body, "anonymize_sensitive_data", True):
+        text, _ = anonymize_sensitive_text(text)
     if not text:
         raise HTTPException(status_code=400, detail="No text provided")
 

--- a/backend/routes/estimator.py
+++ b/backend/routes/estimator.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 from typing import Optional
 
-from services.response_time_estimator import (
+from backend.services.response_time_estimator import (
     estimate_response_time,
     generate_estimation_summary,
 )
@@ -49,6 +49,6 @@ async def estimate(request: EstimateRequest):
 @router.get("/sla-targets")
 async def get_sla_targets():
     """Get SLA targets for all priority levels."""
-    from services.response_time_estimator import SLA_TARGETS
+    from backend.services.response_time_estimator import SLA_TARGETS
 
     return {"success": True, "data": SLA_TARGETS}

--- a/backend/routes/translation.py
+++ b/backend/routes/translation.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 """
 Translation API Routes — Multi-Language Ticket Support
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 from typing import Optional
 
-from services.translation_service import (
+from backend.services.translation_service import (
     translate_text,
     translate_ticket,
     detect_language,
@@ -62,7 +64,7 @@ async def translate_ticket_endpoint(request: TranslateTicketRequest):
 
 
 @router.post("/detect")
-async def detect(text: str = Field(..., min_length=1)):
+async def detect(text: str = Query(..., min_length=1)):
     """Detect the language of the given text."""
     lang = detect_language(text)
     if not lang:

--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -4,6 +4,8 @@ The model outputs combined "Category | SubCategory" labels.
 Priority and other fields are derived from the category mapping.
 """
 
+from __future__ import annotations
+
 import os
 import json
 try:

--- a/backend/services/classifier_v3.py
+++ b/backend/services/classifier_v3.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import pickle
 import json

--- a/backend/services/duplicate_service.py
+++ b/backend/services/duplicate_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Duplicate Detection Service
 Uses sentence-transformers all-MiniLM-L6-v2 to detect similar tickets.
@@ -253,4 +255,3 @@ class DuplicateService:
             "duplicate_ticket_id": best_id if is_dup else None,
             "similarity": round(best_score, 4),
         }
-

--- a/backend/services/gemini_service.py
+++ b/backend/services/gemini_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import base64
 import io

--- a/backend/services/semantic_duplicate_service.py
+++ b/backend/services/semantic_duplicate_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Semantic Duplicate Detection Service — pgvector-powered cosine similarity search.
 

--- a/backend/services/sla_engine.py
+++ b/backend/services/sla_engine.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 SLA Engine — Service-Level Agreement monitoring, breach detection,
 and multi-channel escalation for HELPDESK.AI.

--- a/backend/services/spam_service.py
+++ b/backend/services/spam_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Spam & Phishing Detection Service — lightweight, dependency-free heuristics.
 

--- a/backend/tests/test_anonymizer.py
+++ b/backend/tests/test_anonymizer.py
@@ -1,0 +1,109 @@
+from backend.utils.anonymizer import anonymize_sensitive_text, anonymize_sensitive_value
+
+
+def test_anonymize_sensitive_text_redacts_common_secrets():
+    text = (
+        "Contact alice@example.com from 192.168.1.45 while using "
+        "mongodb+srv://admin:SecretPass123@cluster0.example.mongodb.net/helpdesk "
+        "and password=OpenSesame plus Bearer eyJhbGciOiJIUzI1NiJ9."
+    )
+
+    redacted, findings = anonymize_sensitive_text(text)
+
+    assert "[REDACTED_EMAIL]" in redacted
+    assert "[REDACTED_IP_ADDRESS]" in redacted
+    assert "[REDACTED_CONNECTION_STRING]" in redacted
+    assert "[REDACTED_CREDENTIALS]" in redacted
+    assert "alice@example.com" not in redacted
+    assert "192.168.1.45" not in redacted
+    assert "SecretPass123" not in redacted
+    assert "OpenSesame" not in redacted
+    assert "connection_string" in findings
+    assert "email" in findings
+    assert "ipv4" in findings
+    assert "credentials" in findings
+
+
+def test_anonymize_sensitive_value_handles_nested_payloads():
+    payload = {
+        "top_level": "Reach bob@example.com",
+        "nested": {
+            "token": "token=superSecretValue",
+            "connection": "postgresql://admin:pw@db.example.com/app",
+        },
+        "items": [
+            "IPv6 2001:db8:85a3::8a2e:370:7334",
+            "Nothing sensitive here",
+        ],
+    }
+
+    redacted, findings = anonymize_sensitive_value(payload)
+
+    assert redacted["top_level"] == "Reach [REDACTED_EMAIL]"
+    assert redacted["nested"]["token"] == "token= [REDACTED_CREDENTIALS]"
+    assert "[REDACTED_CONNECTION_STRING]" in redacted["nested"]["connection"]
+    assert redacted["items"][0] == "IPv6 [REDACTED_IP_ADDRESS]"
+    assert "email" in findings
+    assert "credentials" in findings
+    assert "connection_string" in findings
+    assert "ipv6" in findings
+
+
+def test_ai_analyze_redacts_sensitive_data_when_enabled(test_client):
+    payload = {
+        "text": "VPN issue for alice@example.com on 192.168.1.45",
+        "image_text": "image shows mongodb+srv://admin:SecretPass123@cluster0.example.mongodb.net/helpdesk",
+        "anonymize_sensitive_data": True,
+        "company_id": "company_A",
+    }
+
+    response = test_client.post("/ai/analyze", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "[REDACTED_EMAIL]" in data["original_text"]
+    assert "[REDACTED_IP_ADDRESS]" in data["original_text"]
+    assert "[REDACTED_CONNECTION_STRING]" in data["ocr_text"]
+    assert "alice@example.com" not in data["original_text"]
+    assert "192.168.1.45" not in data["original_text"]
+
+
+def test_ticket_save_redacts_sensitive_payload_before_persistence(test_client, fake_db):
+    payload = {
+        "user_id": "user_A",
+        "subject": "Password reset for alice@example.com",
+        "description": "Need help with mongodb+srv://admin:SecretPass123@cluster0.example.mongodb.net/helpdesk and 10.0.0.2",
+        "category": "Software",
+        "subcategory": "Access",
+        "priority": "medium",
+        "assigned_team": "Application Support",
+        "status": "open",
+        "auto_resolve": False,
+        "is_duplicate": False,
+        "confidence": 0.95,
+        "company_id": "company_A",
+        "company": "Company A",
+        "sla_breach_at": "",
+        "ocr_text": "secret api_key=superSecretValue",
+        "metadata": {
+            "notes": "Contact bob@example.com or 172.16.0.24",
+            "nested": {"connection": "postgresql://admin:pw@db.example.com/app"},
+        },
+        "routing_confidence": 0.95,
+        "anonymize_sensitive_data": True,
+    }
+
+    response = test_client.post("/tickets/save", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert len(fake_db["tickets"]) == 1
+
+    saved_ticket = fake_db["tickets"][0]
+    assert "[REDACTED_EMAIL]" in saved_ticket["subject"]
+    assert "[REDACTED_CONNECTION_STRING]" in saved_ticket["description"]
+    assert "[REDACTED_IP_ADDRESS]" in saved_ticket["description"]
+    assert "[REDACTED_CREDENTIALS]" in saved_ticket["ocr_text"]
+    assert saved_ticket["metadata"]["anonymization_enabled"] is True
+    assert "[REDACTED_EMAIL]" in saved_ticket["metadata"]["notes"]
+    assert "[REDACTED_CONNECTION_STRING]" in saved_ticket["metadata"]["nested"]["connection"]

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for backend text processing."""

--- a/backend/utils/anonymizer.py
+++ b/backend/utils/anonymizer.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+import ipaddress
+from typing import Any, Iterable, Tuple
+
+_REDACTION_TAGS = {
+    "connection_string": "[REDACTED_CONNECTION_STRING]",
+    "email": "[REDACTED_EMAIL]",
+    "ip_address": "[REDACTED_IP_ADDRESS]",
+    "credentials": "[REDACTED_CREDENTIALS]",
+}
+
+_PATTERN_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "connection_string",
+        re.compile(
+            r"\b(?:mongodb(?:\+srv)?|postgres(?:ql)?|mysql|mariadb|redis|amqp|amqps)://[^\s'\"`<>]+",
+            re.IGNORECASE,
+        ),
+        _REDACTION_TAGS["connection_string"],
+    ),
+    (
+        "email",
+        re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+        _REDACTION_TAGS["email"],
+    ),
+    (
+        "ipv4",
+        re.compile(
+            r"\b(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\b"
+        ),
+        _REDACTION_TAGS["ip_address"],
+    ),
+    (
+        "provider_token",
+        re.compile(
+            r"\b(?:sk_(?:live|test)|ghp|ghs|xox[baprs])[_-]?[A-Za-z0-9_-]{10,}\b",
+            re.IGNORECASE,
+        ),
+        _REDACTION_TAGS["credentials"],
+    ),
+    (
+        "bearer_token",
+        re.compile(r"\bBearer\s+[A-Za-z0-9._\-+/=]{10,}\b", re.IGNORECASE),
+        "Bearer " + _REDACTION_TAGS["credentials"],
+    ),
+]
+
+_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(password|passwd|pass|secret|token|api[_-]?key)\s*([:=])\s*([^\s,;]+)"
+)
+
+
+def _add_findings(findings: list[str], labels: Iterable[str]) -> None:
+    for label in labels:
+        if label not in findings:
+            findings.append(label)
+
+
+def anonymize_sensitive_text(text: str) -> Tuple[str, list[str]]:
+    """Mask common secrets, PII, and credentials in free-form ticket text."""
+    if not text:
+        return "", []
+
+    redacted = text
+    findings: list[str] = []
+
+    for label, pattern, replacement in _PATTERN_RULES:
+        redacted, count = pattern.subn(replacement, redacted)
+        if count:
+            findings.append(label)
+
+    def _replace_assignment(match: re.Match[str]) -> str:
+        findings.append("credentials")
+        return f"{match.group(1)}{match.group(2)} {_REDACTION_TAGS['credentials']}"
+
+    redacted = _ASSIGNMENT_PATTERN.sub(_replace_assignment, redacted)
+
+    def _replace_ip_candidate(match: re.Match[str]) -> str:
+        candidate = match.group(0)
+        try:
+            ip_obj = ipaddress.ip_address(candidate)
+        except ValueError:
+            return candidate
+        if ip_obj.version == 6:
+            findings.append("ipv6")
+        findings.append("ip_address")
+        return _REDACTION_TAGS["ip_address"]
+
+    redacted = re.sub(
+        r"(?<![\w])(?:[0-9A-Fa-f:.]{2,})(?![\w])",
+        _replace_ip_candidate,
+        redacted,
+    )
+
+    # Normalize duplicate findings while preserving order.
+    deduped_findings: list[str] = []
+    _add_findings(deduped_findings, findings)
+    return redacted, deduped_findings
+
+
+def anonymize_sensitive_value(value: Any) -> Tuple[Any, list[str]]:
+    """Recursively anonymize text values inside dict/list payloads."""
+    if isinstance(value, str):
+        return anonymize_sensitive_text(value)
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        findings: list[str] = []
+        for key, item in value.items():
+            sanitized_item, item_findings = anonymize_sensitive_value(item)
+            redacted[key] = sanitized_item
+            _add_findings(findings, item_findings)
+        return redacted, findings
+    if isinstance(value, list):
+        redacted_list = []
+        findings: list[str] = []
+        for item in value:
+            sanitized_item, item_findings = anonymize_sensitive_value(item)
+            redacted_list.append(sanitized_item)
+            _add_findings(findings, item_findings)
+        return redacted_list, findings
+    return value, []


### PR DESCRIPTION
## What changed\n- Added backend/anonymizer helpers to redact emails, IPs, connection strings, bearer tokens, and credential-like values.\n- Added a frontend toggle to enable sensitive data anonymization during ticket creation and analysis.\n- Propagated sanitization through analysis, duplicate detection, save, and tracking flows.\n- Added tests covering the anonymizer helper and the main ticket/analyze paths.\n\n## Validation\n- python3 -m pytest -p no:asyncio backend/tests/test_anonymizer.py backend/tests/test_integration.py::test_analyze_ticket_mock_model_prediction\n- cd frontend && npm ci && npm run build\n\n## Notes\n- I intentionally left the unrelated .github/PULL_REQUEST_TEMPLATE.md change out of this PR.