### PR TITLE
Make keyword override a fallback in classifier

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -43,6 +43,8 @@ AUTO_RESOLVE_SUBS = {
     "WiFi Issue", "Printer Error", "Monitor Problem",
 }
 
+KEYWORD_OVERRIDE_CONFIDENCE_THRESHOLD = 0.5
+
 
 class ClassifierService:
     def __init__(self):
@@ -122,22 +124,22 @@ class ClassifierService:
         # Derive auto_resolve
         auto_resolve = subcategory in AUTO_RESOLVE_SUBS
 
-        # --- Regex Override Layer (Boost for Technical Keywords) ---
+        # --- Regex Fallback Layer (Boost for Technical Keywords) ---
         tech_keywords = {
             "Network": ["IP address", "hostname", "connection", "network", "bandwidth", "DNS", "firewall", "VPN", "Connectivity", "Latency", "Routing", "Spikes"],
             "Software": ["crash", "load", "website", "application", "error", "bug", "failing", "software", "SQL", "Cluster", "Database", "Production", "Latency"],
             "Access": ["login", "password", "access", "authentication", "account", "permission", "MFA", "OAuth"]
         }
-        
+
         lower_text = text.lower()
         for cat, keywords in tech_keywords.items():
             if any(k.lower() in lower_text for k in keywords):
-                # If current prediction is generic, or we have a high-value technical keyword
-                if category == "General" or confidence < 0.9:
+                # Treat keywords as a fallback signal when the model is uncertain.
+                if category == "General" or confidence < KEYWORD_OVERRIDE_CONFIDENCE_THRESHOLD:
                     category = cat
                     assigned_team = TEAM_MAP.get(cat, "General Support")
-                    # Boost confidence significantly for verified technical signals
-                    confidence = max(confidence, 0.92) 
+                    # Boost confidence modestly to reflect the fallback signal without hiding model uncertainty.
+                    confidence = max(confidence, 0.70)
                     break
 
         return {

--- a/backend/tests/test_classifier_service_override.py
+++ b/backend/tests/test_classifier_service_override.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import torch
+
+from backend.services.classifier_service import ClassifierService
+
+
+class DummyTokenizer:
+    def __call__(self, *args, **kwargs):
+        return {
+            "input_ids": torch.tensor([[101, 102, 0, 0]]),
+            "attention_mask": torch.tensor([[1, 1, 0, 0]]),
+        }
+
+
+class DummyModel:
+    def __init__(self, logits):
+        self._logits = logits
+
+    def __call__(self, input_ids=None, attention_mask=None):
+        return SimpleNamespace(logits=self._logits)
+
+
+def _build_service(logits):
+    service = ClassifierService()
+    service._loaded = True
+    service.tokenizer = DummyTokenizer()
+    service.model = DummyModel(logits)
+    service.id2label = {
+        "0": "Access | Login Failure",
+        "1": "Network | VPN Connection",
+        "2": "Software | Application Crash",
+    }
+    return service
+
+
+def test_predict_preserves_high_confidence_model_result():
+    service = _build_service(torch.tensor([[0.1, 0.2, 6.0]]))
+
+    result = service.predict("login authentication issue")
+
+    assert result["category"] == "Software"
+    assert result["assigned_team"] == "Application Support"
+    assert result["confidence"] > 0.9
+
+
+def test_predict_uses_keyword_fallback_when_model_is_uncertain():
+    service = _build_service(torch.tensor([[0.1, 0.2, 0.3]]))
+
+    result = service.predict("login authentication issue")
+
+    assert result["category"] == "Access"
+    assert result["assigned_team"] == "IAM Team"
+    assert result["confidence"] >= 0.7


### PR DESCRIPTION
## What changed\n- Converted the classifier keyword override layer into a true fallback when the model is uncertain.\n- Kept keyword routing available for low-confidence predictions and generic categories.\n- Added a regression test proving high-confidence ML predictions are preserved while uncertain ones can still fall back to keywords.\n\n## Validation\n- python3 -m pytest -p no:asyncio backend/tests/test_classifier_service_override.py\n\n## Notes\n- This change keeps the DistilBERT signal intact when confidence is already strong, which was the core regression described in #3109.