### PR TITLE
fix: migrate classifier v3 label encoders to json

### DIFF
--- a/backend/services/classifier_v3.py
+++ b/backend/services/classifier_v3.py
@@ -1,13 +1,20 @@
 import os
 import torch
 import torch.nn as nn
-import pickle
 import json
 from transformers import BertTokenizerFast, BertModel
 
 # Paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_DIR = os.path.join(BASE_DIR, "models", "classifier-v3")
+
+
+class LabelEncoderView:
+    def __init__(self, classes):
+        self.classes_ = list(classes)
+
+    def inverse_transform(self, values):
+        return [self.classes_[int(value)] for value in values]
 
 class MultiOutputClassifierV3(nn.Module):
     def __init__(self, num_labels_per_output: dict):
@@ -44,8 +51,19 @@ class ClassifierServiceV3:
         with open(config_path, "r") as f:
             self.num_labels = json.load(f)
 
-        with open(os.path.join(MODEL_DIR, "label_encoders.pkl"), "rb") as f:
-            self.label_encoders = pickle.load(f)
+        label_encoders_path = os.path.join(MODEL_DIR, "label_encoders.json")
+        if not os.path.exists(label_encoders_path):
+            raise FileNotFoundError(
+                f"Missing safe label encoder artifact at {label_encoders_path}. "
+                "Regenerate the classifier-v3 artifacts with label_encoders.json."
+            )
+
+        with open(label_encoders_path, "r") as f:
+            raw_label_encoders = json.load(f)
+
+        self.label_encoders = {
+            col: LabelEncoderView(classes) for col, classes in raw_label_encoders.items()
+        }
 
         self.model = MultiOutputClassifierV3(self.num_labels).to(self.device)
         self.model.load_state_dict(torch.load(os.path.join(MODEL_DIR, "model.pt"), map_location=self.device))

--- a/backend/tests/test_classifier_v3_json.py
+++ b/backend/tests/test_classifier_v3_json.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+
+import torch
+
+from backend.services import classifier_v3 as classifier_v3_module
+
+
+class DummyTokenizer:
+    def __call__(self, *args, **kwargs):
+        return DummyEncoding(
+            {
+                "input_ids": torch.tensor([[101, 102, 0, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 0, 0]]),
+            }
+        )
+
+
+class DummyEncoding(dict):
+    def to(self, device):
+        return self
+
+
+class DummyModel:
+    def __init__(self, logits):
+        self._logits = logits
+
+    def to(self, device):
+        return self
+
+    def load_state_dict(self, state_dict):
+        return None
+
+    def eval(self):
+        return None
+
+    def __call__(self, input_ids=None, attention_mask=None):
+        return self._logits
+
+
+def test_classifier_v3_loads_safe_label_encoders_json(tmp_path, monkeypatch):
+    model_dir = Path(tmp_path)
+    (model_dir / "model_config.json").write_text(
+        json.dumps(
+            {
+                "category": 3,
+                "sub_category": 3,
+                "Priority": 3,
+                "auto_resolve": 2,
+                "assigned_team": 2,
+            }
+        )
+    )
+    (model_dir / "label_encoders.json").write_text(
+        json.dumps(
+            {
+                "category": ["Access", "Network", "Software"],
+                "sub_category": ["Login", "VPN", "Crash"],
+                "Priority": ["Low", "High", "Critical"],
+                "auto_resolve": ["No", "Yes"],
+                "assigned_team": ["IAM Team", "Support"],
+            }
+        )
+    )
+
+    monkeypatch.setattr(classifier_v3_module, "MODEL_DIR", str(model_dir))
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "__init__",
+        lambda self, num_labels_per_output: None,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "to",
+        lambda self, device: self,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "load_state_dict",
+        lambda self, state_dict: None,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "eval",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.BertTokenizerFast,
+        "from_pretrained",
+        lambda *args, **kwargs: DummyTokenizer(),
+    )
+    monkeypatch.setattr(classifier_v3_module.torch, "load", lambda *args, **kwargs: {})
+    monkeypatch.setattr(classifier_v3_module.torch.cuda, "is_available", lambda: False)
+
+    service = classifier_v3_module.ClassifierServiceV3()
+    service.model = DummyModel(
+        {
+            "category": torch.tensor([[0.2, 0.3, 5.4]]),
+            "sub_category": torch.tensor([[0.1, 0.2, 6.0]]),
+            "Priority": torch.tensor([[0.1, 0.3, 7.0]]),
+            "auto_resolve": torch.tensor([[0.2, 3.0]]),
+            "assigned_team": torch.tensor([[0.1, 5.0]]),
+        }
+    )
+    service.tokenizer = DummyTokenizer()
+
+    result = service.predict("network vpn access issue")
+
+    assert result["category"]["prediction"] == "Software"
+    assert result["priority"]["prediction"] == "Critical"
+    assert result["assigned_team"]["prediction"] == "Support"
+    assert result["assigned_team"]["confidence"] > 0.9

--- a/backend/training/classifier_trainer_v3.py
+++ b/backend/training/classifier_trainer_v3.py
@@ -4,7 +4,6 @@ Upgraded to BERT-Base for maximum accuracy and power.
 """
 
 import os
-import pickle
 import json
 import numpy as np
 import pandas as pd
@@ -147,7 +146,9 @@ def train_v3():
     os.makedirs(SAVE_DIR, exist_ok=True)
     torch.save(model.state_dict(), os.path.join(SAVE_DIR, "model.pt"))
     tokenizer.save_pretrained(SAVE_DIR)
-    with open(os.path.join(SAVE_DIR, "label_encoders.pkl"), "wb") as f: pickle.dump(label_encoders, f)
+    label_encoder_payload = {col: le.classes_.tolist() for col, le in label_encoders.items()}
+    with open(os.path.join(SAVE_DIR, "label_encoders.json"), "w") as f:
+        json.dump(label_encoder_payload, f)
     with open(os.path.join(SAVE_DIR, "model_config.json"), "w") as f: json.dump(num_labels_per_output, f)
     print(f"\n[SUCCESS] V3 Power Model saved to {SAVE_DIR}")
 


### PR DESCRIPTION
Closes #3074\n\n## Summary\n- Replace unsafe pickle loading in ClassifierServiceV3 with a JSON-backed label encoder map\n- Update the V3 trainer to persist label encoders as label_encoders.json\n- Add a regression test that exercises the JSON load path\n\n## Validation\n- python3 -m pytest -p no:asyncio -q backend/tests/test_classifier_v3_json.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Label decoding now uses a safer JSON-based format, improving compatibility and reducing reliance on serialized artifacts.
  * Model outputs continue to map back to readable labels with the same prediction flow.

* **Bug Fixes**
  * Added clearer startup guidance when the required label encoder file is missing.
  * Expanded test coverage to verify label loading and prediction behavior with the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->