### PR TITLE
fix: migrate classifier v2 label encoders to json

### DIFF
--- a/backend/services/classifier_v2.py
+++ b/backend/services/classifier_v2.py
@@ -1,13 +1,20 @@
 import os
 import torch
 import torch.nn as nn
-import pickle
 import json
 from transformers import DistilBertTokenizerFast, DistilBertModel
 
 # Paths
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MODEL_DIR = os.path.join(BASE_DIR, "models", "classifier-v2")
+
+
+class LabelEncoderView:
+    def __init__(self, classes):
+        self.classes_ = list(classes)
+
+    def inverse_transform(self, values):
+        return [self.classes_[int(value)] for value in values]
 
 # We must use the exact same class definition as trainer_v2
 class MultiOutputClassifierV2(nn.Module):
@@ -42,8 +49,19 @@ class ClassifierServiceV2:
             self.num_labels = json.load(f)
 
         # 2. Load Encoders
-        with open(os.path.join(MODEL_DIR, "label_encoders.pkl"), "rb") as f:
-            self.label_encoders = pickle.load(f)
+        label_encoders_path = os.path.join(MODEL_DIR, "label_encoders.json")
+        if not os.path.exists(label_encoders_path):
+            raise FileNotFoundError(
+                f"Missing safe label encoder artifact at {label_encoders_path}. "
+                "Regenerate the classifier-v2 artifacts with label_encoders.json."
+            )
+
+        with open(label_encoders_path, "r") as f:
+            raw_label_encoders = json.load(f)
+
+        self.label_encoders = {
+            col: LabelEncoderView(classes) for col, classes in raw_label_encoders.items()
+        }
 
         # 3. Load Model
         self.model = MultiOutputClassifierV2(self.num_labels).to(self.device)

--- a/backend/tests/test_classifier_v2_json.py
+++ b/backend/tests/test_classifier_v2_json.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+
+import torch
+
+from backend.services import classifier_v2 as classifier_v2_module
+
+
+class DummyTokenizer:
+    def __call__(self, *args, **kwargs):
+        return DummyEncoding(
+            {
+                "input_ids": torch.tensor([[101, 102, 0, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 0, 0]]),
+            }
+        )
+
+
+class DummyEncoding(dict):
+    def to(self, device):
+        return self
+
+
+class DummyModel:
+    def __init__(self, logits):
+        self._logits = logits
+
+    def to(self, device):
+        return self
+
+    def load_state_dict(self, state_dict):
+        return None
+
+    def eval(self):
+        return None
+
+    def __call__(self, input_ids=None, attention_mask=None):
+        return self._logits
+
+
+def test_classifier_v2_loads_safe_label_encoders_json(tmp_path, monkeypatch):
+    model_dir = Path(tmp_path)
+    (model_dir / "model_config.json").write_text(
+        json.dumps(
+            {
+                "category": 3,
+                "sub_category": 3,
+                "Priority": 3,
+                "auto_resolve": 2,
+                "assigned_team": 2,
+            }
+        )
+    )
+    (model_dir / "label_encoders.json").write_text(
+        json.dumps(
+            {
+                "category": ["Access", "Network", "Software"],
+                "sub_category": ["Login", "VPN", "Crash"],
+                "Priority": ["Low", "High", "Critical"],
+                "auto_resolve": ["No", "Yes"],
+                "assigned_team": ["IAM Team", "Support"],
+            }
+        )
+    )
+
+    monkeypatch.setattr(classifier_v2_module, "MODEL_DIR", str(model_dir))
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "__init__",
+        lambda self, num_labels_per_output: None,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "to",
+        lambda self, device: self,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "load_state_dict",
+        lambda self, state_dict: None,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "eval",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.DistilBertTokenizerFast,
+        "from_pretrained",
+        lambda *args, **kwargs: DummyTokenizer(),
+    )
+    monkeypatch.setattr(classifier_v2_module.torch, "load", lambda *args, **kwargs: {})
+    monkeypatch.setattr(classifier_v2_module.torch.cuda, "is_available", lambda: False)
+
+    service = classifier_v2_module.ClassifierServiceV2()
+    service.model = DummyModel(
+        {
+            "category": torch.tensor([[0.2, 0.3, 5.4]]),
+            "sub_category": torch.tensor([[0.1, 0.2, 6.0]]),
+            "Priority": torch.tensor([[0.1, 0.3, 7.0]]),
+            "auto_resolve": torch.tensor([[0.2, 3.0]]),
+            "assigned_team": torch.tensor([[0.1, 5.0]]),
+        }
+    )
+    service.tokenizer = DummyTokenizer()
+
+    result = service.predict("network vpn access issue")
+
+    assert result["category"]["prediction"] == "Software"
+    assert result["priority"]["prediction"] == "Critical"
+    assert result["assigned_team"]["prediction"] == "Support"
+    assert result["assigned_team"]["confidence"] > 0.9


### PR DESCRIPTION
Closes #3070\n\n## Summary\n- Replace unsafe pickle loading in ClassifierServiceV2 with a JSON-backed label encoder map\n- Add a regression test that exercises the safe JSON load path\n\n## Validation\n- python3 -m pytest -p no:asyncio -q backend/tests/test_classifier_v2_json.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The classification service now loads label mappings from a safer JSON-based artifact.
  * Prediction results continue to be converted back into readable labels for each output field.

* **Bug Fixes**
  * Improved startup behavior by failing clearly when the label-mapping file is missing.
  * Kept label names consistent, including the `Priority` field mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->