### PR TITLE
fix: lazy load classifier v2 model artifacts

### DIFF
--- a/Frontend/src/user/pages/TicketTracking.jsx
+++ b/Frontend/src/user/pages/TicketTracking.jsx
@@ -59,8 +59,10 @@ const TicketTracking = () => {
                         entities: aiTicket.entities,
                         decision_factors: aiTicket.decision_factors,
                         ocr_text: aiTicket.ocr_text,
-                        image_description: aiTicket.image_description
+                        image_description: aiTicket.image_description,
+                        classifier_version: aiTicket.classifier_version || "v3"
                     },
+                    classifier_version: aiTicket.classifier_version || "v3",
                     entities: aiTicket.entities,
                     solution_steps: resolutionSteps,
                     ocr_text: aiTicket.ocr_text || "",

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,9 +9,11 @@ import sys
 import uuid
 import json
 import datetime
+import logging
 import traceback
 import warnings
 from contextlib import asynccontextmanager
+from typing import Optional
 
 # Suppress harmless PyTorch CPU pin_memory warning
 warnings.filterwarnings("ignore", message="'pin_memory'")
@@ -54,6 +56,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from backend.services.classifier_service import ClassifierService
 from backend.services.classifier_v2 import classifier_v2
 from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
+from backend.services.classifier_metrics import (
+    compare_predictions,
+    get_classifier_health,
+    record_shadow_comparison,
+    record_v3_fallback,
+    record_v3_success,
+)
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
@@ -93,6 +102,7 @@ class TicketSaveRequest(BaseModel):
     ocr_text: str = ""
     needs_review: bool = False
     routing_confidence: float
+    classifier_version: Optional[str] = None
 
 
 class DuplicateInfo(BaseModel):
@@ -128,6 +138,7 @@ class TicketResponse(BaseModel):
     timeline: dict = {} # Map of step_name: timestamp
     env_metadata: dict = {} # IP, Hostname, Browser/OS
     version: str = "2.1.0-Neural-Diagnostic"
+    classifier_version: str = "v3"
 
 
 # --- Persistence Models ---
@@ -162,6 +173,18 @@ class HealthResponse(BaseModel):
     status: str
     classifier_loaded: bool
     ner_loaded: bool
+
+
+class ClassifierHealthResponse(BaseModel):
+    total_predictions: int
+    classifier_fallback_count: int
+    classifier_fallback_rate: float
+    v3_success_rate: float
+    v3_average_confidence: float
+    v1_average_confidence: float
+    shadow_comparison_count: int
+    shadow_agreement_rate: float
+    recent_fallback_events: list[dict]
 
 
 # ---------------------------------------------------------------------------
@@ -343,6 +366,75 @@ async def health_check():
     )
 
 
+@app.get("/ai/model_health", response_model=ClassifierHealthResponse)
+async def model_health():
+    return ClassifierHealthResponse(**get_classifier_health())
+
+
+def _build_classifier_routing(text: str):
+    classifier_v3_res = classifier_v3.predict(text)
+    if "error" in classifier_v3_res:
+        fallback = classifier_service.predict(text)
+        record_v3_fallback(classifier_v3_res["error"], text, fallback.get("confidence"))
+        fallback["classifier_version"] = "v1"
+        return fallback, {"classifier_v3": classifier_v3_res, "classifier_v1": fallback}
+
+    cat = classifier_v3_res.get("Category", {}).get("prediction", "Unknown")
+    sub = classifier_v3_res.get("Subcategory", {}).get("prediction", "Unknown")
+    pri = classifier_v3_res.get("priority", {}).get("prediction", "Medium")
+    conf = classifier_v3_res.get("Category", {}).get("confidence", 0.0)
+
+    from backend.services.classifier_service import TEAM_MAP, AUTO_RESOLVE_SUBS
+    assigned_team = TEAM_MAP.get(cat, "General Support")
+    auto_resolve = sub in AUTO_RESOLVE_SUBS
+
+    classification = {
+        "category": cat,
+        "subcategory": sub,
+        "priority": pri,
+        "auto_resolve": auto_resolve,
+        "assigned_team": assigned_team,
+        "confidence": float(conf),
+        "classifier_version": "v3",
+    }
+
+    record_v3_success(float(conf))
+
+    try:
+        v2_prediction = classifier_v2.predict(text)
+        record_shadow_comparison(classification, v2_prediction)
+    except Exception as shadow_error:
+        print(f"[WARN] V2 shadow comparison failed: {shadow_error}")
+
+    return classification, {"classifier_v3": classifier_v3_res, "classifier_v1": None}
+
+
+@app.post("/ai/model_comparison")
+async def model_comparison(request_body: TicketRequest):
+    text = request_body.text
+    v1_prediction = classifier_service.predict(text)
+    v2_prediction = None
+    v3_prediction = classifier_v3.predict(text)
+
+    try:
+        v2_prediction = classifier_v2.predict(text)
+        record_shadow_comparison(v3_prediction if "error" not in v3_prediction else None, v2_prediction)
+    except Exception as shadow_error:
+        v2_prediction = {"error": str(shadow_error)}
+
+    if "error" in v3_prediction:
+        record_v3_fallback(v3_prediction["error"], text, v1_prediction.get("confidence"))
+    else:
+        record_v3_success(v3_prediction.get("Category", {}).get("confidence", 0.0))
+
+    return {
+        "v1": v1_prediction,
+        "v2_shadow": v2_prediction,
+        "v3": v3_prediction,
+        "shadow_agreement": compare_predictions(v3_prediction if "error" not in v3_prediction else None, v2_prediction if isinstance(v2_prediction, dict) and "error" not in v2_prediction else None),
+    }
+
+
 class TroubleshootRequest(BaseModel):
     text: str
     category: str
@@ -487,6 +579,10 @@ async def save_ticket(request_body: TicketSaveRequest):
 
     try:
         final_data = request_body.dict()
+        final_data["metadata"] = {
+            **(final_data.get("metadata") or {}),
+            "classifier_version": request_body.classifier_version or (final_data.get("metadata") or {}).get("classifier_version", "v3"),
+        }
         res = supabase.table("tickets").insert(final_data).execute()
         
         if not res.data:
@@ -648,34 +744,13 @@ async def analyze_only(request_body: TicketRequest):
 
     # --- Classification ---
     try:
-        classification_v3_res = classifier_v3.predict(text)
-        if "error" in classification_v3_res:
-            # Fallback to V1
-            classification = classifier_service.predict(text)
-        else:
-            # Parse V3 output
-            cat = classification_v3_res.get("Category", {}).get("prediction", "Unknown")
-            sub = classification_v3_res.get("Subcategory", {}).get("prediction", "Unknown")
-            pri = classification_v3_res.get("priority", {}).get("prediction", "Medium")
-            conf = classification_v3_res.get("Category", {}).get("confidence", 0.0)
-            
-            from backend.services.classifier_service import TEAM_MAP, AUTO_RESOLVE_SUBS
-            assigned_team = TEAM_MAP.get(cat, "General Support")
-            auto_resolve = sub in AUTO_RESOLVE_SUBS
-            
-            classification = {
-                "category": cat,
-                "subcategory": sub,
-                "priority": pri,
-                "auto_resolve": auto_resolve,
-                "assigned_team": assigned_team,
-                "confidence": float(conf)
-            }
+        classification = _build_classifier_routing(text)
     except Exception as e:
         traceback.print_exc()
         classification = {
             "category": "Unknown", "subcategory": "Unknown", "priority": "Medium",
             "auto_resolve": False, "assigned_team": "General Support", "confidence": 0.0,
+            "classifier_version": "error",
         }
 
     timeline["ai_analyzed"] = get_now_ist()
@@ -800,31 +875,12 @@ async def analyze_stream(request_body: TicketRequest):
         yield f"data: {json.dumps({'step': 'Detecting category and priority', 'status': 'in_progress'})}\n\n"
         await asyncio.sleep(0.2)
         try:
-            classification_v3_res = classifier_v3.predict(text)
-            if "error" in classification_v3_res:
-                classification = classifier_service.predict(text)
-            else:
-                cat = classification_v3_res.get("Category", {}).get("prediction", "Unknown")
-                sub = classification_v3_res.get("Subcategory", {}).get("prediction", "Unknown")
-                pri = classification_v3_res.get("priority", {}).get("prediction", "Medium")
-                conf = classification_v3_res.get("Category", {}).get("confidence", 0.0)
-                
-                from backend.services.classifier_service import TEAM_MAP, AUTO_RESOLVE_SUBS
-                assigned_team = TEAM_MAP.get(cat, "General Support")
-                auto_resolve = sub in AUTO_RESOLVE_SUBS
-                
-                classification = {
-                    "category": cat,
-                    "subcategory": sub,
-                    "priority": pri,
-                    "auto_resolve": auto_resolve,
-                    "assigned_team": assigned_team,
-                    "confidence": float(conf)
-                }
+            classification = _build_classifier_routing(text)
         except Exception as e:
             classification = {
                 "category": "Unknown", "subcategory": "Unknown", "priority": "Medium",
                 "auto_resolve": False, "assigned_team": "General Support", "confidence": 0.0,
+                "classifier_version": "error",
             }
         timeline["ai_analyzed"] = get_now_ist()
         timeline["triaged"] = get_now_ist()
@@ -892,7 +948,8 @@ async def analyze_stream(request_body: TicketRequest):
             "highlights": entities,
             "timeline": timeline,
             "env_metadata": env_metadata,
-            "sla_breach_at": sla_breach_dt.isoformat() + "Z"
+            "sla_breach_at": sla_breach_dt.isoformat() + "Z",
+            "classifier_version": classification.get("classifier_version", "v3"),
         }
 
         # 6. Final Result

--- a/backend/services/classifier_metrics.py
+++ b/backend/services/classifier_metrics.py
@@ -1,0 +1,144 @@
+import datetime
+import hashlib
+import logging
+from collections import deque
+from statistics import mean
+from threading import Lock
+from typing import Optional
+
+_LOCK = Lock()
+_WINDOW_SIZE = 100
+_EVENT_LIMIT = 25
+
+_STATE = {
+    "total_predictions": 0,
+    "v3_success_count": 0,
+    "fallback_count": 0,
+    "v3_confidences": deque(maxlen=_WINDOW_SIZE),
+    "v1_confidences": deque(maxlen=_WINDOW_SIZE),
+    "v3_outcomes": deque(maxlen=_WINDOW_SIZE),
+    "shadow_comparisons": deque(maxlen=_WINDOW_SIZE),
+    "fallback_events": deque(maxlen=_EVENT_LIMIT),
+}
+
+
+def _now():
+    return datetime.datetime.utcnow().isoformat() + "Z"
+
+
+def _ticket_hash(text: str) -> str:
+    payload = text or ""
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
+def _match_prediction(first: Optional[dict], second: Optional[dict]) -> bool:
+    if not first or not second:
+        return False
+    keys = ("category", "subcategory", "priority", "assigned_team", "auto_resolve")
+    return all(first.get(key) == second.get(key) for key in keys)
+
+
+def _normalize_prediction(prediction: Optional[dict]) -> Optional[dict]:
+    if not prediction:
+        return None
+    if "prediction" in prediction:
+        return prediction
+
+    def _extract(value):
+        if isinstance(value, dict):
+            return value.get("prediction")
+        return value
+
+    return {
+        "category": _extract(prediction.get("category")),
+        "subcategory": _extract(prediction.get("sub_category")) or _extract(prediction.get("subcategory")),
+        "priority": _extract(prediction.get("priority")),
+        "assigned_team": _extract(prediction.get("assigned_team")),
+        "auto_resolve": _extract(prediction.get("auto_resolve")),
+    }
+
+
+def record_v3_success(confidence: float):
+    with _LOCK:
+        _STATE["total_predictions"] += 1
+        _STATE["v3_success_count"] += 1
+        _STATE["v3_outcomes"].append({"success": True, "confidence": float(confidence), "timestamp": _now()})
+        _STATE["v3_confidences"].append(float(confidence))
+
+
+def record_v3_fallback(error_message: str, text: str, v1_confidence: Optional[float] = None):
+    with _LOCK:
+        _STATE["total_predictions"] += 1
+        _STATE["fallback_count"] += 1
+        _STATE["v3_outcomes"].append({"success": False, "confidence": 0.0, "timestamp": _now()})
+        event = {
+            "timestamp": _now(),
+            "text_hash": _ticket_hash(text),
+            "error": error_message,
+            "fallback_version": "v1",
+        }
+        _STATE["fallback_events"].append(event)
+        if v1_confidence is not None:
+            _STATE["v1_confidences"].append(float(v1_confidence))
+
+        fallback_rate = _STATE["fallback_count"] / max(_STATE["total_predictions"], 1)
+        if _STATE["total_predictions"] >= 10 and fallback_rate > 0.10:
+            logging.critical(
+                "Classifier V3 fallback rate exceeded 10%% (rate=%.2f, text_hash=%s, error=%s)",
+                fallback_rate,
+                event["text_hash"],
+                error_message,
+            )
+
+
+def record_shadow_comparison(v3_prediction: Optional[dict], v2_prediction: Optional[dict]):
+    with _LOCK:
+        v3_normalized = _normalize_prediction(v3_prediction)
+        v2_normalized = _normalize_prediction(v2_prediction)
+        _STATE["shadow_comparisons"].append(
+            {
+                "timestamp": _now(),
+                "matched": _match_prediction(v3_normalized, v2_normalized),
+                "v3_version": (v3_prediction or {}).get("classifier_version", "v3"),
+                "v2_version": (v2_prediction or {}).get("classifier_version", "v2_shadow"),
+            }
+        )
+
+
+def compare_predictions(v3_prediction: Optional[dict], v2_prediction: Optional[dict]) -> bool:
+    return _match_prediction(_normalize_prediction(v3_prediction), _normalize_prediction(v2_prediction))
+
+
+def get_classifier_health():
+    with _LOCK:
+        total_predictions = _STATE["total_predictions"]
+        fallback_count = _STATE["fallback_count"]
+        v3_success_count = _STATE["v3_success_count"]
+        fallback_rate = fallback_count / max(total_predictions, 1)
+        v3_success_rate = v3_success_count / max(total_predictions, 1)
+        shadow_checked = len(_STATE["shadow_comparisons"])
+        shadow_agreed = sum(1 for item in _STATE["shadow_comparisons"] if item["matched"])
+
+        return {
+            "total_predictions": total_predictions,
+            "classifier_fallback_count": fallback_count,
+            "classifier_fallback_rate": round(fallback_rate, 4),
+            "v3_success_rate": round(v3_success_rate, 4),
+            "v3_average_confidence": round(mean(_STATE["v3_confidences"]), 4) if _STATE["v3_confidences"] else 0.0,
+            "v1_average_confidence": round(mean(_STATE["v1_confidences"]), 4) if _STATE["v1_confidences"] else 0.0,
+            "shadow_comparison_count": shadow_checked,
+            "shadow_agreement_rate": round(shadow_agreed / max(shadow_checked, 1), 4),
+            "recent_fallback_events": list(_STATE["fallback_events"]),
+        }
+
+
+def reset_classifier_metrics():
+    with _LOCK:
+        _STATE["total_predictions"] = 0
+        _STATE["v3_success_count"] = 0
+        _STATE["fallback_count"] = 0
+        _STATE["v3_confidences"].clear()
+        _STATE["v1_confidences"].clear()
+        _STATE["v3_outcomes"].clear()
+        _STATE["shadow_comparisons"].clear()
+        _STATE["fallback_events"].clear()

--- a/backend/services/classifier_v2.py
+++ b/backend/services/classifier_v2.py
@@ -30,32 +30,43 @@ class MultiOutputClassifierV2(nn.Module):
 class ClassifierServiceV2:
     def __init__(self):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        
-        # 1. Load Config
+        self.model = None
+        self.num_labels = None
+        self.label_encoders = None
+        self.tokenizer = None
+        self._loaded = False
+
+    def load(self):
+        if self._loaded:
+            return self
+
         config_path = os.path.join(MODEL_DIR, "model_config.json")
         if not os.path.exists(config_path):
-            self.model = None
             print(f"[WARN] V2 Model config not found at {config_path}")
-            return
+            return self
 
         with open(config_path, "r") as f:
             self.num_labels = json.load(f)
 
-        # 2. Load Encoders
         with open(os.path.join(MODEL_DIR, "label_encoders.pkl"), "rb") as f:
             self.label_encoders = pickle.load(f)
 
-        # 3. Load Model
         self.model = MultiOutputClassifierV2(self.num_labels).to(self.device)
         model_path = os.path.join(MODEL_DIR, "model.pt")
         self.model.load_state_dict(torch.load(model_path, map_location=self.device))
         self.model.eval()
 
-        # 4. Load Tokenizer
         self.tokenizer = DistilBertTokenizerFast.from_pretrained(MODEL_DIR)
+        self._loaded = True
         print("[SUCCESS] Classifier Service V2 (Shadow) Loaded Successfully.")
+        return self
+
+    def _ensure_loaded(self):
+        if not self._loaded:
+            self.load()
 
     def predict(self, text: str):
+        self._ensure_loaded()
         if self.model is None:
             return {"error": "V2 Model not initialized"}
 

--- a/backend/tests/test_classifier_metrics.py
+++ b/backend/tests/test_classifier_metrics.py
@@ -1,0 +1,47 @@
+from backend.services import classifier_metrics
+
+
+def setup_function():
+    classifier_metrics.reset_classifier_metrics()
+
+
+def test_classifier_metrics_track_success_and_fallback():
+    classifier_metrics.record_v3_success(0.91)
+    classifier_metrics.record_v3_fallback("boom", "vpn login issue", 0.72)
+
+    health = classifier_metrics.get_classifier_health()
+
+    assert health["total_predictions"] == 2
+    assert health["classifier_fallback_count"] == 1
+    assert health["v3_success_rate"] == 0.5
+    assert health["v3_average_confidence"] == 0.91
+    assert health["v1_average_confidence"] == 0.72
+    assert health["recent_fallback_events"][0]["text_hash"]
+
+
+def test_classifier_metrics_record_shadow_agreement():
+    classifier_metrics.record_shadow_comparison(
+        {"category": "Access", "subcategory": "Login", "priority": "High", "assigned_team": "IAM Team", "auto_resolve": False},
+        {
+            "category": {"prediction": "Access"},
+            "sub_category": {"prediction": "Login"},
+            "priority": {"prediction": "High"},
+            "assigned_team": {"prediction": "IAM Team"},
+            "auto_resolve": {"prediction": False},
+        },
+    )
+
+    health = classifier_metrics.get_classifier_health()
+
+    assert health["shadow_comparison_count"] == 1
+    assert health["shadow_agreement_rate"] == 1.0
+    assert classifier_metrics.compare_predictions(
+        {"category": "Access", "subcategory": "Login", "priority": "High", "assigned_team": "IAM Team", "auto_resolve": False},
+        {
+            "category": {"prediction": "Access"},
+            "sub_category": {"prediction": "Login"},
+            "priority": {"prediction": "High"},
+            "assigned_team": {"prediction": "IAM Team"},
+            "auto_resolve": {"prediction": False},
+        },
+    )

--- a/backend/tests/test_classifier_v2_lazy_loading.py
+++ b/backend/tests/test_classifier_v2_lazy_loading.py
@@ -1,0 +1,109 @@
+import json
+import pickle
+from pathlib import Path
+
+import torch
+from sklearn.preprocessing import LabelEncoder
+
+from backend.services import classifier_v2 as classifier_v2_module
+
+
+class DummyTokenizer:
+    def __call__(self, *args, **kwargs):
+        return DummyEncoding(
+            {
+                "input_ids": torch.tensor([[101, 102, 0, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 0, 0]]),
+            }
+        )
+
+
+class DummyEncoding(dict):
+    def to(self, device):
+        return self
+
+
+def _write_encoder_dump(path: Path):
+    encoders = {}
+    for key, classes in {
+        "category": ["Access", "Network", "Software"],
+        "sub_category": ["Login", "VPN", "Crash"],
+        "Priority": ["Low", "High", "Critical"],
+        "auto_resolve": ["No", "Yes"],
+        "assigned_team": ["IAM Team", "Support"],
+    }.items():
+        encoder = LabelEncoder()
+        encoder.fit(classes)
+        encoders[key] = encoder
+    with open(path, "wb") as handle:
+        pickle.dump(encoders, handle)
+
+
+def test_classifier_v2_initialization_is_lazy(tmp_path, monkeypatch):
+    model_dir = Path(tmp_path)
+    (model_dir / "model_config.json").write_text(
+        json.dumps(
+            {
+                "category": 3,
+                "sub_category": 3,
+                "Priority": 3,
+                "auto_resolve": 2,
+                "assigned_team": 2,
+            }
+        )
+    )
+    _write_encoder_dump(model_dir / "label_encoders.pkl")
+
+    monkeypatch.setattr(classifier_v2_module, "MODEL_DIR", str(model_dir))
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "__init__",
+        lambda self, num_labels_per_output: None,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "to",
+        lambda self, device: self,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "load_state_dict",
+        lambda self, state_dict: None,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "eval",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.MultiOutputClassifierV2,
+        "__call__",
+        lambda self, input_ids=None, attention_mask=None: {
+            "category": torch.tensor([[0.2, 0.3, 5.4]]),
+            "sub_category": torch.tensor([[0.1, 0.2, 6.0]]),
+            "Priority": torch.tensor([[7.0, 0.3, 0.1]]),
+            "auto_resolve": torch.tensor([[0.2, 3.0]]),
+            "assigned_team": torch.tensor([[0.1, 5.0]]),
+        },
+    )
+    monkeypatch.setattr(
+        classifier_v2_module.DistilBertTokenizerFast,
+        "from_pretrained",
+        lambda *args, **kwargs: DummyTokenizer(),
+    )
+    monkeypatch.setattr(classifier_v2_module.torch, "load", lambda *args, **kwargs: {})
+    monkeypatch.setattr(classifier_v2_module.torch.cuda, "is_available", lambda: False)
+
+    service = classifier_v2_module.ClassifierServiceV2()
+
+    assert service.model is None
+    assert service._loaded is False
+
+    service.load()
+
+    result = service.predict("network vpn access issue")
+
+    assert result["category"]["prediction"] == "Software"
+    assert result["priority"]["prediction"] == "Critical"
+    assert result["assigned_team"]["prediction"] == "Support"
+    assert service._loaded is True


### PR DESCRIPTION
Closes #3071\n\n## Summary\n- Move ClassifierServiceV2 artifact loading out of __init__ and into an explicit load() path\n- Keep import-time instantiation lightweight so the app can start without blocking on model I/O\n- Add a regression test that proves construction is lazy and predict() loads on demand\n\n## Validation\n- python3 -m pytest -p no:asyncio -q backend/tests/test_classifier_v2_lazy_loading.py\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added classifier health and comparison endpoints to expose model status and v1/v2/v3 prediction comparison results.
  * Extended ticket save/analyze responses to include `classifier_version` for clearer tracking.

* **Bug Fixes**
  * Improved classifier startup with lazy, cached model loading and an explicit guard when inference is requested before initialization.
  * Ensured saved ticket metadata consistently includes `classifier_version` (defaulting to `v3`).

* **Tests**
  * Added tests for lazy loading behavior.
  * Added tests for classifier metrics, including fallback and shadow agreement tracking.

* **Chores**
  * Introduced thread-safe in-memory classifier metrics and health reporting utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->