### PR TITLE
fix: lazy load classifier v3 model artifacts

### DIFF
--- a/backend/services/classifier_v3.py
+++ b/backend/services/classifier_v3.py
@@ -35,11 +35,19 @@ class ClassifierServiceV3:
     def __init__(self):
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model = None
-        
+        self.num_labels = None
+        self.label_encoders = None
+        self.tokenizer = None
+        self._loaded = False
+
+    def load(self):
+        if self._loaded:
+            return self
+
         config_path = os.path.join(MODEL_DIR, "model_config.json")
         if not os.path.exists(config_path):
             print(f"[V3 Service] Model not found yet at {MODEL_DIR}")
-            return
+            return self
 
         with open(config_path, "r") as f:
             self.num_labels = json.load(f)
@@ -52,9 +60,16 @@ class ClassifierServiceV3:
         self.model.eval()
 
         self.tokenizer = BertTokenizerFast.from_pretrained(MODEL_DIR)
+        self._loaded = True
         print("[INFO] Classifier Service V3 (Power Model) Loaded.")
+        return self
+
+    def _ensure_loaded(self):
+        if not self._loaded:
+            self.load()
 
     def predict(self, text: str):
+        self._ensure_loaded()
         if self.model is None: return {"error": "V3 Model not loaded"}
         inputs = self.tokenizer(text, return_tensors="pt", truncation=True, padding=True, max_length=256).to(self.device)
         with torch.no_grad():

--- a/backend/tests/test_classifier_v3_lazy_loading.py
+++ b/backend/tests/test_classifier_v3_lazy_loading.py
@@ -1,0 +1,108 @@
+import json
+import pickle
+from pathlib import Path
+
+import torch
+from sklearn.preprocessing import LabelEncoder
+
+from backend.services import classifier_v3 as classifier_v3_module
+
+
+class DummyTokenizer:
+    def __call__(self, *args, **kwargs):
+        return DummyEncoding(
+            {
+                "input_ids": torch.tensor([[101, 102, 0, 0]]),
+                "attention_mask": torch.tensor([[1, 1, 0, 0]]),
+            }
+        )
+
+
+class DummyEncoding(dict):
+    def to(self, device):
+        return self
+
+
+def _write_encoder_dump(path: Path):
+    encoders = {}
+    for key, classes in {
+        "category": ["Access", "Network", "Software"],
+        "sub_category": ["Login", "VPN", "Crash"],
+        "Priority": ["Low", "High", "Critical"],
+        "auto_resolve": ["No", "Yes"],
+        "assigned_team": ["IAM Team", "Support"],
+    }.items():
+        encoder = LabelEncoder()
+        encoder.fit(classes)
+        encoders[key] = encoder
+    with open(path, "wb") as handle:
+        pickle.dump(encoders, handle)
+
+
+def test_classifier_v3_initialization_is_lazy(tmp_path, monkeypatch):
+    model_dir = Path(tmp_path)
+    (model_dir / "model_config.json").write_text(
+        json.dumps(
+            {
+                "category": 3,
+                "sub_category": 3,
+                "Priority": 3,
+                "auto_resolve": 2,
+                "assigned_team": 2,
+            }
+        )
+    )
+    _write_encoder_dump(model_dir / "label_encoders.pkl")
+
+    monkeypatch.setattr(classifier_v3_module, "MODEL_DIR", str(model_dir))
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "__init__",
+        lambda self, num_labels_per_output: None,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "to",
+        lambda self, device: self,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "load_state_dict",
+        lambda self, state_dict: None,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "eval",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.MultiOutputClassifierV3,
+        "__call__",
+        lambda self, input_ids=None, attention_mask=None: {
+            "category": torch.tensor([[0.2, 0.3, 5.4]]),
+            "sub_category": torch.tensor([[0.1, 0.2, 6.0]]),
+            "Priority": torch.tensor([[7.0, 0.3, 0.1]]),
+            "auto_resolve": torch.tensor([[0.2, 3.0]]),
+            "assigned_team": torch.tensor([[0.1, 5.0]]),
+        },
+    )
+    monkeypatch.setattr(
+        classifier_v3_module.BertTokenizerFast,
+        "from_pretrained",
+        lambda *args, **kwargs: DummyTokenizer(),
+    )
+    monkeypatch.setattr(classifier_v3_module.torch, "load", lambda *args, **kwargs: {})
+    monkeypatch.setattr(classifier_v3_module.torch.cuda, "is_available", lambda: False)
+
+    service = classifier_v3_module.ClassifierServiceV3()
+
+    assert service.model is None
+    assert service._loaded is False
+
+    service.load()
+    result = service.predict("network vpn access issue")
+
+    assert result["category"]["prediction"] == "Software"
+    assert result["priority"]["prediction"] == "Critical"
+    assert result["assigned_team"]["prediction"] == "Support"
+    assert service._loaded is True


### PR DESCRIPTION
Closes #3076\n\n## Summary\n- Move ClassifierServiceV3 model and tokenizer loading out of __init__ and into an explicit load() path\n- Keep import-time instantiation lightweight so the app can start without waiting on BERT weights\n- Add a regression test proving initialization is lazy and predict() works after load()\n\n## Validation\n- python3 -m pytest -p no:asyncio -q backend/tests/test_classifier_v3_lazy_loading.py\n- python3 -m py_compile backend/services/classifier_v3.py backend/tests/test_classifier_v3_lazy_loading.py\n- git diff --check