### PR TITLE
fix: add security headers middleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from backend.services.classifier_service import ClassifierService
 from backend.services.classifier_v2 import classifier_v2
 from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
+from backend.security_middleware import SecurityHeadersMiddleware
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
@@ -247,6 +248,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(SecurityHeadersMiddleware)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/security_middleware.py
+++ b/backend/security_middleware.py
@@ -1,0 +1,27 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "base-uri 'self'; "
+            "frame-ancestors 'none'; "
+            "object-src 'none'; "
+            "script-src 'self' https://cdn.tailwindcss.com; "
+            "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.tailwindcss.com; "
+            "font-src 'self' https://fonts.gstatic.com; "
+            "img-src 'self' data: https:; "
+            "connect-src 'self' https:;"
+        )
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+        )
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+        return response

--- a/backend/tests/test_security_middleware.py
+++ b/backend/tests/test_security_middleware.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.security_middleware import SecurityHeadersMiddleware
+
+
+def test_security_headers_middleware_adds_browser_protections():
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers["content-security-policy"].startswith("default-src 'self'")
+    assert response.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"
+    assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["permissions-policy"] == "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+    assert response.headers["cross-origin-opener-policy"] == "same-origin"


### PR DESCRIPTION
Closes #2892\n\n## Summary\n- Add a SecurityHeadersMiddleware that attaches CSP, HSTS, clickjacking, MIME-sniffing, referrer, permissions, and COOP/CORP protections\n- Register the middleware in FastAPI so every response gets the headers\n- Add a regression test that verifies the header set on a simple app route\n\n## Validation\n- python3 -m pytest -p no:asyncio -q backend/tests/test_security_middleware.py\n- python3 -m py_compile backend/main.py backend/security_middleware.py backend/tests/test_security_middleware.py\n- git diff --check