### PR TITLE
scope ticket routes by company

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -59,6 +59,11 @@ from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
+from backend.services.ticket_access import (
+    filter_ticket_updates,
+    require_company_id,
+    ticket_belongs_to_company,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +167,7 @@ class Message(BaseModel):
 class TicketRecord(BaseModel):
     ticket_id: str
     owner_id: str
+    company_id: str | None = None
     summary: str
     category: str
     subcategory: str
@@ -189,6 +195,19 @@ class HealthResponse(BaseModel):
 class ReadinessResponse(BaseModel):
     status: str
     checks: dict[str, bool]
+
+
+class TicketUpdateRequest(BaseModel):
+    status: str | None = None
+    assigned_team: str | None = None
+    assigned_agent_id: str | None = None
+    priority: str | None = None
+    category: str | None = None
+    subcategory: str | None = None
+    metadata: dict | None = None
+    timeline: dict | None = None
+    last_user_viewed_at: str | None = None
+    updated_at: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -540,11 +559,15 @@ async def get_tickets(company_id: str | None = None):
     """Fetch persistent tickets from Supabase."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    try:
+        company_id = require_company_id(company_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
-    if company_id:
-        query = query.eq("company_id", company_id)
-        
+    query = query.eq("company_id", company_id)
+
     res = query.execute()
     return res.data
 
@@ -603,8 +626,6 @@ async def save_ticket(request_body: TicketSaveRequest):
 
         user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
         logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
-
-
         res = supabase.table("tickets").insert(final_data).execute()
         
         if not res.data:
@@ -652,12 +673,24 @@ async def save_ticket(request_body: TicketSaveRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/tickets/{ticket_id}")
-async def get_ticket_by_id(ticket_id: str):
+async def get_ticket_by_id(ticket_id: str, company_id: str | None = None):
     """Fetch single persistent ticket."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
-    res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
+
+    try:
+        company_id = require_company_id(company_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    res = (
+        supabase.table("tickets")
+        .select("*")
+        .eq("id", ticket_id)
+        .eq("company_id", company_id)
+        .single()
+        .execute()
+    )
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return res.data
@@ -666,6 +699,9 @@ async def get_ticket_by_id(ticket_id: str):
 @app.post("/tickets", response_model=TicketRecord)
 async def create_ticket(ticket: TicketRecord):
     """Save a new ticket into the system."""
+    if not ticket.company_id:
+        raise HTTPException(status_code=400, detail="company_id is required")
+
     # Check for duplicates before adding
     existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
     if existing:
@@ -677,17 +713,26 @@ async def create_ticket(ticket: TicketRecord):
 
 
 @app.patch("/tickets/{ticket_id}", response_model=TicketRecord)
-async def update_ticket(ticket_id: str, updates: dict):
+async def update_ticket(ticket_id: str, updates: TicketUpdateRequest, company_id: str | None = None):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
+    try:
+        company_id = require_company_id(company_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    safe_updates = filter_ticket_updates(updates.dict(exclude_unset=True))
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):
+            if not ticket_belongs_to_company(ticket.company_id, company_id):
+                raise HTTPException(status_code=404, detail="Ticket not found")
+
             # Convert to dict, update, then back to model
             ticket_dict = ticket.dict()
-            ticket_dict.update(updates)
+            ticket_dict.update(safe_updates)
             updated_ticket = TicketRecord(**ticket_dict)
             TICKETS_DB[i] = updated_ticket
             return updated_ticket
-    
+
     raise HTTPException(status_code=404, detail="Ticket not found")
 
 
@@ -1208,4 +1253,3 @@ async def auth_logout(response: Response):
 @app.get("/auth/me")
 async def auth_me(user: dict = Depends(get_current_user)):
     return {"user": user}
-

--- a/backend/services/ticket_access.py
+++ b/backend/services/ticket_access.py
@@ -1,0 +1,54 @@
+"""Helpers for scoping and sanitizing ticket access."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+ALLOWED_TICKET_UPDATE_FIELDS = frozenset(
+    {
+        "status",
+        "assigned_team",
+        "assigned_agent_id",
+        "priority",
+        "category",
+        "subcategory",
+        "metadata",
+        "timeline",
+        "last_user_viewed_at",
+        "updated_at",
+    }
+)
+
+
+def normalize_company_id(company_id: str | None) -> str | None:
+    """Return a trimmed company id or None when the value is empty."""
+    if company_id is None:
+        return None
+
+    normalized = str(company_id).strip()
+    return normalized or None
+
+
+def require_company_id(company_id: str | None, *, context: str = "company_id") -> str:
+    """Validate that a tenant id is present."""
+    normalized = normalize_company_id(company_id)
+    if not normalized:
+        raise ValueError(f"{context} is required")
+    return normalized
+
+
+def filter_ticket_updates(updates: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep only explicitly allowed ticket fields."""
+    sanitized: dict[str, Any] = {}
+    for field in ALLOWED_TICKET_UPDATE_FIELDS:
+        if field in updates and updates[field] is not None:
+            sanitized[field] = updates[field]
+    return sanitized
+
+
+def ticket_belongs_to_company(ticket_company_id: str | None, company_id: str | None) -> bool:
+    """Check whether a ticket row belongs to the requested company."""
+    normalized_company_id = require_company_id(company_id)
+    normalized_ticket_company_id = normalize_company_id(ticket_company_id)
+    return normalized_ticket_company_id == normalized_company_id

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend test package."""

--- a/backend/tests/test_ticket_access.py
+++ b/backend/tests/test_ticket_access.py
@@ -1,0 +1,52 @@
+import unittest
+
+from backend.services.ticket_access import (
+    filter_ticket_updates,
+    normalize_company_id,
+    require_company_id,
+    ticket_belongs_to_company,
+)
+
+
+class TicketAccessTests(unittest.TestCase):
+    def test_normalize_company_id_strips_whitespace(self):
+        self.assertEqual(normalize_company_id("  acme-123  "), "acme-123")
+
+    def test_require_company_id_rejects_blank_values(self):
+        with self.assertRaises(ValueError):
+            require_company_id("   ")
+
+    def test_filter_ticket_updates_blocks_tenant_and_owner_fields(self):
+        updates = {
+            "status": "resolved",
+            "assigned_team": "support",
+            "assigned_agent_id": "agent-9",
+            "priority": "high",
+            "category": "billing",
+            "company_id": "evil-tenant",
+            "owner_id": "someone-else",
+            "ticket_id": "patched-id",
+            "metadata": {"resolved_at": "2026-06-29T00:00:00Z"},
+            "unexpected": "should-not-appear",
+        }
+
+        sanitized = filter_ticket_updates(updates)
+
+        self.assertEqual(sanitized["status"], "resolved")
+        self.assertEqual(sanitized["assigned_team"], "support")
+        self.assertEqual(sanitized["assigned_agent_id"], "agent-9")
+        self.assertEqual(sanitized["priority"], "high")
+        self.assertEqual(sanitized["category"], "billing")
+        self.assertEqual(sanitized["metadata"], {"resolved_at": "2026-06-29T00:00:00Z"})
+        self.assertNotIn("company_id", sanitized)
+        self.assertNotIn("owner_id", sanitized)
+        self.assertNotIn("ticket_id", sanitized)
+        self.assertNotIn("unexpected", sanitized)
+
+    def test_ticket_belongs_to_company_matches_trimmed_ids(self):
+        self.assertTrue(ticket_belongs_to_company("  acme-123  ", "acme-123"))
+        self.assertFalse(ticket_belongs_to_company("acme-123", "beta-456"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3051

## What changed
- Require company_id on ticket persistence and lookup routes.
- Scope GET /tickets and GET /tickets/{ticket_id} to the requested company.
- Replace open-ended ticket patching with an allowlisted update schema.
- Send company_id from the ticket tracking flow.

## Why
The ticket routes were returning and mutating records without tenant scoping, which allowed cross-company access and arbitrary field updates.

## Validation
- python3 -m unittest backend.tests.test_ticket_access
- python3 -m py_compile backend/main.py backend/services/ticket_access.py backend/tests/test_ticket_access.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket actions now respect company scope, so ticket lists, lookups, and edits only apply to the correct tenant.
  * Ticket creation now requires a company identifier.
  * Ticket update requests now support a typed payload with only approved fields being applied.

* **Bug Fixes**
  * Improved validation to reject blank company identifiers and prevent cross-company ticket access or updates.
  * Tightened ticket matching so whitespace differences no longer affect results.

* **Tests**
  * Added coverage for company ID normalization, validation, field filtering, and tenant matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->