### PR TITLE
make classifier loading thread-safe

### DIFF
--- a/backend/services/classifier_service.py
+++ b/backend/services/classifier_service.py
@@ -6,6 +6,7 @@ Priority and other fields are derived from the category mapping.
 
 import os
 import json
+import threading
 import torch
 import torch.nn.functional as F
 from transformers import DistilBertTokenizerFast, DistilBertForSequenceClassification
@@ -51,36 +52,41 @@ class ClassifierService:
         self.id2label = None
         self.label2id = None
         self._loaded = False
+        self._load_lock = threading.Lock()
 
     def load(self):
         """Load model, tokenizer, and label mappings from disk."""
         if self._loaded:
             return
 
-        abs_dir = os.path.abspath(SAVE_DIR)
+        with self._load_lock:
+            if self._loaded:
+                return
 
-        if not os.path.exists(os.path.join(abs_dir, "model.safetensors")):
-            raise FileNotFoundError(
-                f"Classifier model not found at {abs_dir}. "
-                "Please ensure model files are present."
-            )
+            abs_dir = os.path.abspath(SAVE_DIR)
 
-        # Load label mappings
-        with open(os.path.join(abs_dir, "id2label.json"), "r") as f:
-            self.id2label = json.load(f)
-        with open(os.path.join(abs_dir, "label2id.json"), "r") as f:
-            self.label2id = json.load(f)
+            if not os.path.exists(os.path.join(abs_dir, "model.safetensors")):
+                raise FileNotFoundError(
+                    f"Classifier model not found at {abs_dir}. "
+                    "Please ensure model files are present."
+                )
 
-        # Load tokenizer
-        self.tokenizer = DistilBertTokenizerFast.from_pretrained(abs_dir)
+            # Load label mappings
+            with open(os.path.join(abs_dir, "id2label.json"), "r") as f:
+                self.id2label = json.load(f)
+            with open(os.path.join(abs_dir, "label2id.json"), "r") as f:
+                self.label2id = json.load(f)
 
-        # Load model
-        self.model = DistilBertForSequenceClassification.from_pretrained(abs_dir)
-        self.model.to(DEVICE)
-        self.model.eval()
+            # Load tokenizer
+            self.tokenizer = DistilBertTokenizerFast.from_pretrained(abs_dir)
 
-        self._loaded = True
-        print("Classifier loaded successfully")
+            # Load model
+            self.model = DistilBertForSequenceClassification.from_pretrained(abs_dir)
+            self.model.to(DEVICE)
+            self.model.eval()
+
+            self._loaded = True
+            print("Classifier loaded successfully")
 
     def predict(self, text: str) -> dict:
         """

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend test package."""

--- a/backend/tests/test_classifier_service_threadsafe.py
+++ b/backend/tests/test_classifier_service_threadsafe.py
@@ -1,0 +1,64 @@
+import json
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from backend.services.classifier_service import ClassifierService
+
+
+class _FakeModel:
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+
+class _FakeTokenizer:
+    def __call__(self, *args, **kwargs):
+        return {"input_ids": [], "attention_mask": []}
+
+
+class ClassifierServiceThreadSafetyTests(unittest.TestCase):
+    def test_load_only_initializes_once_under_concurrency(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model_dir = Path(tmpdir)
+            (model_dir / "model.safetensors").write_text("stub", encoding="utf-8")
+            (model_dir / "id2label.json").write_text(json.dumps({"0": "Access | Login Failure"}), encoding="utf-8")
+            (model_dir / "label2id.json").write_text(json.dumps({"Access | Login Failure": 0}), encoding="utf-8")
+
+            tokenizer_calls = []
+            model_calls = []
+
+            def fake_tokenizer_from_pretrained(path):
+                tokenizer_calls.append(path)
+                time.sleep(0.05)
+                return _FakeTokenizer()
+
+            def fake_model_from_pretrained(path):
+                model_calls.append(path)
+                time.sleep(0.05)
+                return _FakeModel()
+
+            service = ClassifierService()
+
+            with patch("backend.services.classifier_service.SAVE_DIR", str(model_dir)), \
+                 patch("backend.services.classifier_service.DistilBertTokenizerFast.from_pretrained", side_effect=fake_tokenizer_from_pretrained), \
+                 patch("backend.services.classifier_service.DistilBertForSequenceClassification.from_pretrained", side_effect=fake_model_from_pretrained):
+
+                threads = [threading.Thread(target=service.load) for _ in range(8)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+            self.assertTrue(service._loaded)
+            self.assertEqual(len(tokenizer_calls), 1)
+            self.assertEqual(len(model_calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3068

## What changed
- Added a load lock to `ClassifierService` with double-checked locking.
- Ensured heavy tokenizer/model initialization only happens once under concurrency.
- Added a unit test that exercises concurrent startup calls against the same service instance.

## Why
The classifier service could initialize multiple times when concurrent requests hit a cold server at the same time, which creates avoidable CPU and memory spikes.

## Validation
- python3 -m unittest backend.tests.test_classifier_service_threadsafe
- python3 -m py_compile backend/services/classifier_service.py backend/tests/test_classifier_service_threadsafe.py
- git diff --check