### PR TITLE
require https for supabase urls

### DIFF
--- a/Frontend/src/lib/supabaseClient.js
+++ b/Frontend/src/lib/supabaseClient.js
@@ -1,28 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
+import { isLikelyValidAnonKey, isLikelyValidUrl } from './supabaseUrlValidation.js'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY
-
-const INVALID_MARKERS = new Set([
-	'your_supabase_url',
-	'your_project_url',
-	'your_supabase_anon_key',
-	'your_key',
-])
-
-const isLikelyValidUrl = (value) => {
-	if (!value || INVALID_MARKERS.has(value)) return false
-	try {
-		const parsed = new URL(value)
-		return parsed.protocol === 'https:' || parsed.protocol === 'http:'
-	} catch {
-		return false
-	}
-}
-
-const isLikelyValidAnonKey = (value) => {
-	return Boolean(value && !INVALID_MARKERS.has(value) && value.length > 20)
-}
 
 const disabledMessage =
 	'[Supabase] Client is disabled. Set valid VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in Frontend/.env and restart Vite.'

--- a/Frontend/src/lib/supabaseUrlValidation.js
+++ b/Frontend/src/lib/supabaseUrlValidation.js
@@ -1,0 +1,20 @@
+const INVALID_MARKERS = new Set([
+	'your_supabase_url',
+	'your_project_url',
+	'your_supabase_anon_key',
+	'your_key',
+])
+
+export const isLikelyValidUrl = (value) => {
+	if (!value || INVALID_MARKERS.has(value)) return false
+	try {
+		const parsed = new URL(value)
+		return parsed.protocol === 'https:'
+	} catch {
+		return false
+	}
+}
+
+export const isLikelyValidAnonKey = (value) => {
+	return Boolean(value && !INVALID_MARKERS.has(value) && value.length > 20)
+}

--- a/Frontend/tests/test_supabase_url_validation.js
+++ b/Frontend/tests/test_supabase_url_validation.js
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict'
+import { isLikelyValidUrl } from '../src/lib/supabaseUrlValidation.js'
+
+assert.equal(isLikelyValidUrl('https://example.supabase.co'), true)
+assert.equal(isLikelyValidUrl('http://example.supabase.co'), false)
+assert.equal(isLikelyValidUrl('your_supabase_url'), false)
+
+console.log('supabase url validation checks passed')


### PR DESCRIPTION
Closes #2910

## What changed
- Moved Supabase URL validation into a small pure helper.
- Rejected plain `http://` URLs so the client only initializes over HTTPS.
- Added a regression check for HTTPS, HTTP, and placeholder values.

## Why
Allowing `http://` can send JWTs and session data over plaintext, which is unsafe for production Supabase connections.

## Validation
- node Frontend/tests/test_supabase_url_validation.js
- node --check Frontend/src/lib/supabaseClient.js Frontend/src/lib/supabaseUrlValidation.js
- git diff --check