### PR TITLE
add dashboard loading skeletons

### DIFF
--- a/Frontend/src/admin/pages/AdminAnalytics.jsx
+++ b/Frontend/src/admin/pages/AdminAnalytics.jsx
@@ -6,13 +6,18 @@ import {
 import {
     BarChart3, PieChart as PieChartIcon, LineChart as LineChartIcon,
     TrendingUp, Users, ShieldCheck, Zap, AlertCircle, Clock, Activity,
-    Layers, Inbox, User, Loader2, Bot, Star, Target
+    Layers, Inbox, User, Bot, Star, Target
 } from 'lucide-react';
 import { supabase } from "../../lib/supabaseClient";
 import StatCard from '../components/StatCard';
 import { Card, CardContent } from "../../components/ui/card";
 import useAuthStore from "../../store/authStore";
 import { formatTimelineDate } from "../../utils/dateUtils";
+import {
+    ChartSkeleton,
+    DashboardHeaderSkeleton,
+    StatCardsSkeleton,
+} from "../../components/shared/DashboardSkeletons";
 
 const COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#a855f7', '#ec4899'];
 
@@ -156,9 +161,19 @@ const AdminAnalytics = () => {
 
     // Removed tab state - moving to single dashboard layout
     if (loading) return (
-        <div className="flex flex-col items-center justify-center min-h-[400px]">
-            <Loader2 className="w-10 h-10 text-indigo-600 animate-spin mb-4" />
-            <p className="text-slate-400 font-black uppercase tracking-widest italic text-center">Crunching mission data analytics...</p>
+        <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '80px' }} className="space-y-10 -m-6 p-6 md:-m-10 md:p-10 animate-in fade-in duration-700">
+            <DashboardHeaderSkeleton />
+            <StatCardsSkeleton />
+            <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">
+                <div className="lg:col-span-8 space-y-10">
+                    <ChartSkeleton titleWidth="w-56" chartHeight="h-[20rem]" />
+                    <ChartSkeleton titleWidth="w-52" chartHeight="h-[18rem]" />
+                </div>
+                <div className="lg:col-span-4 space-y-10">
+                    <ChartSkeleton titleWidth="w-44" chartHeight="h-[20rem]" />
+                    <ChartSkeleton titleWidth="w-40" chartHeight="h-[18rem]" />
+                </div>
+            </div>
         </div>
     );
 

--- a/Frontend/src/admin/pages/AdminDashboard.jsx
+++ b/Frontend/src/admin/pages/AdminDashboard.jsx
@@ -6,6 +6,11 @@ import useAuthStore from "../../store/authStore";
 import { supabase } from "../../lib/supabaseClient";
 import StatCard from "../components/StatCard";
 import TicketTable from "../components/TicketTable";
+import {
+    ChartSkeleton,
+    DashboardHeaderSkeleton,
+    StatCardsSkeleton,
+} from "../../components/shared/DashboardSkeletons";
 import { formatTimelineDate } from "../../utils/dateUtils";
 
 // Inline SVG icon components
@@ -110,6 +115,23 @@ const AdminDashboard = () => {
             { name: 'Duplicate Detection', status: 'Active', latency: 'Optimal' },
         ];
     }, [tickets]);
+
+    if (isLoading) {
+        return (
+            <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '40px' }} className="space-y-10 -m-6 p-6 md:-m-10 md:p-10">
+                <DashboardHeaderSkeleton />
+                <StatCardsSkeleton />
+                <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">
+                    <div className="lg:col-span-8">
+                        <ChartSkeleton titleWidth="w-56" chartHeight="h-[28rem]" />
+                    </div>
+                    <div className="lg:col-span-4">
+                        <ChartSkeleton titleWidth="w-44" chartHeight="h-[28rem]" />
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div style={{ background: '#f8faf9', minHeight: '100vh', paddingBottom: '40px' }} className="space-y-10 -m-6 p-6 md:-m-10 md:p-10">

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -25,6 +25,7 @@ import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
 import { formatFullTimestamp, formatTimelineDate } from "../../utils/dateUtils";
+import { DashboardHeaderSkeleton, TicketTableSkeleton } from "../../components/shared/DashboardSkeletons";
 
 const AdminTickets = () => {
     const navigate = useNavigate();
@@ -205,6 +206,15 @@ const AdminTickets = () => {
         if (conf >= 0.5) return 'bg-amber-500';
         return 'bg-red-500';
     };
+
+    if (loading) {
+        return (
+            <div className="space-y-8 animate-in fade-in duration-700">
+                <DashboardHeaderSkeleton />
+                <TicketTableSkeleton rows={6} />
+            </div>
+        );
+    }
 
     return (
         <div className="space-y-8 animate-in fade-in duration-700">

--- a/Frontend/src/components/shared/DashboardSkeletons.jsx
+++ b/Frontend/src/components/shared/DashboardSkeletons.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+const SkeletonBlock = ({ className = '', style }) => (
+    <div
+        className={`relative overflow-hidden bg-slate-100/90 animate-pulse ${className}`}
+        style={style}
+    >
+    </div>
+);
+
+export const DashboardHeaderSkeleton = () => (
+    <div className="space-y-3">
+        <SkeletonBlock className="h-9 w-72 rounded-2xl" />
+        <SkeletonBlock className="h-4 w-96 rounded-full" />
+    </div>
+);
+
+export const StatCardsSkeleton = ({ count = 4 }) => (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {Array.from({ length: count }).map((_, index) => (
+            <div key={index} className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-3 flex-1">
+                        <SkeletonBlock className="h-3 w-28 rounded-full" />
+                        <SkeletonBlock className="h-8 w-20 rounded-2xl" />
+                    </div>
+                    <SkeletonBlock className="h-12 w-12 rounded-2xl" />
+                </div>
+                <SkeletonBlock className="h-3 w-3/4 rounded-full" />
+            </div>
+        ))}
+    </div>
+);
+
+export const DashboardPanelSkeleton = ({ titleWidth = 'w-44', rows = 4, rowHeights = ['h-4', 'h-4', 'h-4'] }) => (
+    <div className="rounded-[1.75rem] border border-slate-200 bg-white shadow-sm p-6 space-y-6">
+        <SkeletonBlock className={`h-4 ${titleWidth} rounded-full`} />
+        <div className="space-y-4">
+            {Array.from({ length: rows }).map((_, index) => (
+                <div key={index} className="flex items-center gap-4">
+                    {rowHeights.map((height, idx) => (
+                        <SkeletonBlock key={idx} className={`${height} flex-1 rounded-full`} />
+                    ))}
+                </div>
+            ))}
+        </div>
+    </div>
+);
+
+export const ChartSkeleton = ({ titleWidth = 'w-48', chartHeight = 'h-72' }) => (
+    <div className="rounded-[1.75rem] border border-slate-200 bg-white shadow-sm p-6 space-y-6">
+        <SkeletonBlock className={`h-4 ${titleWidth} rounded-full`} />
+        <SkeletonBlock className={`${chartHeight} w-full rounded-[1.5rem]`} />
+    </div>
+);
+
+export const TicketTableSkeleton = ({ rows = 6 }) => (
+    <div className="rounded-2xl border border-gray-100 bg-white shadow-sm overflow-hidden p-6 w-full">
+        <div className="space-y-6">
+            <div className="flex items-center gap-4 border-b border-gray-50 pb-4">
+                <SkeletonBlock className="h-4 w-12 rounded-full" />
+                <SkeletonBlock className="h-4 w-32 rounded-full" />
+                <SkeletonBlock className="h-4 w-20 rounded-full" />
+            </div>
+            {Array.from({ length: rows }).map((_, index) => (
+                <div key={index} className="flex items-center gap-6 py-2">
+                    <SkeletonBlock className="h-5 w-16 rounded-md shrink-0" />
+                    <SkeletonBlock className="h-5 flex-1 max-w-[300px] rounded-md" />
+                    <SkeletonBlock className="h-6 w-24 rounded-md shrink-0" />
+                    <SkeletonBlock className="h-6 w-20 rounded-full shrink-0" />
+                    <SkeletonBlock className="h-5 w-16 rounded-md shrink-0" />
+                    <SkeletonBlock className="h-8 w-24 rounded-md shrink-0 hidden sm:block" />
+                </div>
+            ))}
+        </div>
+    </div>
+);
+
+export const MyTicketsSkeleton = () => (
+    <div className="space-y-6">
+        <div className="rounded-xl border border-gray-100 bg-white shadow-sm p-4 flex flex-col md:flex-row gap-4">
+            <SkeletonBlock className="h-10 flex-1 rounded-lg" />
+            <div className="flex items-center gap-3">
+                <SkeletonBlock className="h-10 w-36 rounded-lg" />
+                <SkeletonBlock className="h-10 w-36 rounded-lg" />
+            </div>
+        </div>
+        <TicketTableSkeleton rows={5} />
+    </div>
+);

--- a/Frontend/src/user/pages/MyTickets.jsx
+++ b/Frontend/src/user/pages/MyTickets.jsx
@@ -12,6 +12,7 @@ import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import TicketStatusBadge from "../components/TicketStatusBadge";
 import { formatTimelineDate, getTimeZoneAbbr } from "../../utils/dateUtils";
+import { MyTicketsSkeleton } from "../../components/shared/DashboardSkeletons";
 import {
     Tooltip,
     TooltipContent,
@@ -178,38 +179,7 @@ function MyTickets() {
             {/* Main Content */}
 
             {loading ? (
-                <Card className="border border-gray-100 rounded-2xl bg-white shadow-sm overflow-hidden p-6 w-full">
-                    <div className="space-y-6">
-                        <style>{`@keyframes shimmer{100%{transform:translateX(100%)}}`}</style>
-                        <div className="flex items-center gap-4 border-b border-gray-50 pb-4">
-                            <div className="h-4 w-12 bg-slate-100 rounded relative overflow-hidden"><div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" /></div>
-                            <div className="h-4 w-32 bg-slate-100 rounded relative overflow-hidden"><div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" /></div>
-                            <div className="h-4 w-20 bg-slate-100 rounded relative overflow-hidden"><div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" /></div>
-                        </div>
-                        {[...Array(6)].map((_, i) => (
-                            <div key={i} className="flex items-center gap-6 py-2">
-                                <div className="h-5 w-16 bg-slate-100 rounded-md relative overflow-hidden shrink-0">
-                                    <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" />
-                                </div>
-                                <div className="h-5 flex-1 bg-slate-100 rounded-md relative overflow-hidden max-w-[300px]">
-                                    <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" />
-                                </div>
-                                <div className="h-6 w-24 bg-slate-100 rounded-md relative overflow-hidden shrink-0">
-                                    <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" />
-                                </div>
-                                <div className="h-6 w-20 bg-slate-100 rounded-full relative overflow-hidden shrink-0">
-                                    <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" />
-                                </div>
-                                <div className="h-5 w-16 bg-slate-100 rounded-md relative overflow-hidden shrink-0">
-                                    <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" />
-                                </div>
-                                <div className="h-8 w-24 bg-slate-100 rounded-md relative overflow-hidden shrink-0 hidden sm:block">
-                                    <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/60 to-transparent animate-[shimmer_1.5s_infinite]" />
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </Card>
+            <MyTicketsSkeleton />
             ) : error ? (
                 <Card className="p-8 border-red-100 bg-red-50/50 rounded-2xl flex flex-col items-center text-center">
                     <AlertCircle className="w-12 h-12 text-red-500 mb-4" />


### PR DESCRIPTION
Closes #2801

## What changed
- Added reusable loading skeleton components for dashboards and ticket lists.
- Replaced blank/spinner-first loading states in Admin Dashboard, Admin Analytics, Admin Tickets, and My Tickets.
- Kept dimensions close to the final UI so content replacement feels stable and less jarring.

## Why
The dashboard surfaces were loading in a way that created empty spaces and abrupt content shifts. Skeletons make the app feel responsive while data is still fetching.

## Validation
- npm --prefix Frontend install --ignore-scripts --no-audit --no-fund
- npm --prefix Frontend run build
- git diff --check