### PR TITLE
fix: surface real errors in predictTicket instead of silently falling back to mock data

### DIFF
--- a/Frontend/src/services/api.ts
+++ b/Frontend/src/services/api.ts
@@ -98,16 +98,48 @@ export const api = {
     return { data: created };
   },
 
-  predictTicket: async (issueText, imageBase64 = '') => {
-    const currentUser = JSON.parse(sessionStorage.getItem("currentUser") || "{}");
-    const response = await apiClient.post('/ai/analyze_ticket', {
-      text: issueText,
-      image_base64: imageBase64,
-      image_text: "",
-      company_id: currentUser.company_id || currentUser.companyId || null
-    });
+  predictTicket: async (issueText: string, imageBase64 = ''): Promise<{ data: AIAnalysisResult }> => {
+    let currentUser: Record<string, unknown> = {};
+    try {
+      currentUser = JSON.parse(sessionStorage.getItem("currentUser") || "{}");
+    } catch {
+      console.warn("[predictTicket] Failed to parse currentUser from sessionStorage.");
+    }
+
+    let response;
+    try {
+      response = await apiClient.post('/ai/analyze_ticket', {
+        text: issueText,
+        image_base64: imageBase64,
+        image_text: "",
+        company_id: currentUser.company_id || currentUser.companyId || null
+      });
+    } catch (error: unknown) {
+      const axiosError = error as { response?: { status: number; data?: { detail?: string } }; message?: string };
+      const status = axiosError?.response?.status;
+      const detail = axiosError?.response?.data?.detail;
+
+      if (status === 401) {
+        throw new Error("Session expired. Please log in again.");
+      }
+      if (status === 429) {
+        throw new Error("Too many requests. Please wait a moment before trying again.");
+      }
+      if (status && status >= 500) {
+        throw new Error("The AI service is temporarily unavailable. Please try again later.");
+      }
+
+      // Surface the real error — never fall back to mock data silently
+      throw new Error(
+        detail || axiosError?.message || "Ticket analysis failed. Please try again."
+      );
+    }
 
     const result = response.data;
+
+    if (!result || typeof result !== "object") {
+      throw new Error("Received an invalid response from the AI service.");
+    }
 
     return {
       data: {


### PR DESCRIPTION
## 🎯 Summary

Resolves #3123 by replacing the silent error suppression in `predictTicket` with proper error handling that surfaces real backend errors to the user with meaningful messages.

---

## 🛠️ Changes Made

### `Frontend/src/services/api.ts` — `predictTicket` function

**Before:**
- No try/catch around the API call
- If the backend failed, the error propagated as an unhandled exception with no user-friendly message
- `sessionStorage.getItem("currentUser")` had no error handling — could throw on malformed JSON
- No validation of the response shape

**After:**
- Wrapped `sessionStorage` parse in try/catch with graceful fallback
- Wrapped `apiClient.post` in try/catch with status-aware error messages:
  - `401` → "Session expired. Please log in again."
  - `429` → "Too many requests. Please wait a moment before trying again."
  - `5xx` → "The AI service is temporarily unavailable. Please try again later."
  - Other errors → surfaces real backend `detail` message or generic fallback
- Added response shape validation — throws if result is null or not an object
- Added TypeScript types to function signature
- Never falls back to mock data silently

---

## ✅ Improvements
- 🔒 Users now see real error messages instead of cryptic crashes
- 🔒 Session expiry is handled with a clear redirect message
- 🔒 Rate limit errors are communicated clearly
- 🔒 Malformed sessionStorage data no longer causes silent failures
- 🔒 Invalid API responses are caught and reported

---

Closes #3123