### PR TITLE
fix(#3228): implement Jaccard similarity text classification filter to block duplicate ticket submissions

### DIFF
--- a/backend/routers/tickets.py
+++ b/backend/routers/tickets.py
@@ -94,6 +94,33 @@ async def save_ticket(request_body: TicketSaveRequest, user: dict = Depends(get_
         logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
 
 
+        # ── Jaccard keyword duplicate gate (Issue #3228) ────────────────
+        # Fast pre-filter: check for near-duplicate submissions using
+        # keyword-based Jaccard similarity within a 24-hour window.
+        try:
+            from backend.services.jaccard_duplicate_filter import jaccard_filter
+            dup_text = (
+                (request_body.description or "").strip()
+                + " "
+                + (request_body.subject or "").strip()
+            ).strip()
+            if dup_text:
+                dup_check = jaccard_filter.check_duplicate(dup_text)
+                if dup_check.get("is_duplicate"):
+                    raise HTTPException(
+                        status_code=409,
+                        detail={
+                            "message": "Duplicate ticket detected",
+                            "duplicate_ticket_id": dup_check["duplicate_ticket_id"],
+                            "similarity": dup_check["similarity"],
+                        },
+                    )
+        except HTTPException:
+            raise
+        except Exception as jf_err:
+            logger.warning(f"Jaccard filter check skipped: {jf_err}")
+        # ── End Jaccard gate ──────────────────────────────────────────
+
         res = supabase.table("tickets").insert(final_data).execute()
         
         if not res.data:
@@ -109,6 +136,11 @@ async def save_ticket(request_body: TicketSaveRequest, user: dict = Depends(get_
         if duplicate_text:
             try:
                 duplicate_service.add_ticket(str(ticket_id), duplicate_text)
+                try:
+                    from backend.services.jaccard_duplicate_filter import jaccard_filter
+                    jaccard_filter.add_ticket(str(ticket_id), duplicate_text)
+                except Exception as jf_add_err:
+                    logger.warning(f"Failed to add ticket to Jaccard filter: {jf_add_err}")
             except Exception as index_error:
                 duplicate_indexed = False
                 duplicate_index_warning = "Duplicate index update failed."

--- a/backend/services/jaccard_duplicate_filter.py
+++ b/backend/services/jaccard_duplicate_filter.py
@@ -1,0 +1,256 @@
+"""
+JaccardDuplicateFilter — Keyword-based text classification filter (Issue #3228).
+
+Lightweight, zero-dependency duplicate gate that catches near-identical ticket
+submissions BEFORE the heavier semantic (embedding-based) DuplicateService runs.
+
+Algorithm:
+  1. Normalize text: lowercase, strip punctuation, remove stopwords.
+  2. Tokenize into a keyword set.
+  3. Compute Jaccard similarity: |A ∩ B| / |A ∪ B| against each cached ticket.
+  4. Only compare against tickets within the timeline window (default 24h).
+  5. Flag as duplicate if similarity >= threshold (default 0.85).
+
+Usage:
+    from backend.services.jaccard_duplicate_filter import jaccard_filter
+
+    jaccard_filter.add_ticket("ticket-123", "My printer is not working")
+    result = jaccard_filter.check_duplicate("Printer not working for me")
+    # → {"is_duplicate": True, "duplicate_ticket_id": "ticket-123", "similarity": 0.87}
+"""
+
+import re
+import datetime
+import logging
+import threading
+from collections import OrderedDict
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# English stopwords — common words that inflate similarity without meaning.
+# Kept minimal to avoid false negatives on short ticket texts.
+# ---------------------------------------------------------------------------
+STOPWORDS: frozenset[str] = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "need", "must",
+    "i", "me", "my", "we", "our", "you", "your", "he", "she", "it",
+    "they", "them", "his", "her", "its", "this", "that", "these", "those",
+    "am", "to", "of", "in", "for", "on", "with", "at", "by", "from",
+    "as", "into", "about", "between", "through", "after", "before",
+    "and", "but", "or", "nor", "not", "so", "if", "then", "than",
+    "very", "just", "also", "please", "thanks", "thank",
+})
+
+# Regex to strip non-alphanumeric characters (keeps spaces for splitting)
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+# Regex to collapse whitespace
+_SPACE_RE = re.compile(r"\s+")
+
+# Default configuration
+DEFAULT_THRESHOLD = 0.85
+DEFAULT_WINDOW_HOURS = 24
+MAX_CACHE_SIZE = 1000
+
+
+# ---------------------------------------------------------------------------
+# Text normalization
+# ---------------------------------------------------------------------------
+
+def normalize_text(text: str) -> str:
+    """Lowercase, strip punctuation, collapse whitespace."""
+    if not text:
+        return ""
+    result = text.lower()
+    result = _PUNCT_RE.sub(" ", result)
+    result = _SPACE_RE.sub(" ", result).strip()
+    return result
+
+
+def extract_keywords(text: str) -> set[str]:
+    """
+    Tokenize normalized text into a keyword set with stopwords removed.
+
+    Returns an empty set for blank/whitespace-only input.
+    """
+    normalized = normalize_text(text)
+    if not normalized:
+        return set()
+    tokens = normalized.split()
+    return {t for t in tokens if t not in STOPWORDS and len(t) >= 2}
+
+
+# ---------------------------------------------------------------------------
+# Jaccard similarity
+# ---------------------------------------------------------------------------
+
+def jaccard_similarity(set_a: set[str], set_b: set[str]) -> float:
+    """
+    Compute Jaccard similarity coefficient: |A ∩ B| / |A ∪ B|.
+
+    Returns 0.0 if either set is empty (no keywords → no match).
+    Returns 1.0 if both sets are empty (edge case: identical empty texts).
+    """
+    if not set_a and not set_b:
+        return 1.0
+    if not set_a or not set_b:
+        return 0.0
+    intersection = len(set_a & set_b)
+    union = len(set_a | set_b)
+    return intersection / union
+
+
+# ---------------------------------------------------------------------------
+# Cached ticket entry
+# ---------------------------------------------------------------------------
+
+class _TicketEntry:
+    """In-memory cache entry for a recently-registered ticket."""
+
+    __slots__ = ("ticket_id", "keywords", "created_at")
+
+    def __init__(self, ticket_id: str, keywords: set[str], created_at: datetime.datetime):
+        self.ticket_id = ticket_id
+        self.keywords = keywords
+        self.created_at = created_at
+
+
+# ---------------------------------------------------------------------------
+# JaccardDuplicateFilter
+# ---------------------------------------------------------------------------
+
+class JaccardDuplicateFilter:
+    """
+    In-memory keyword-based duplicate detector using Jaccard similarity.
+
+    Thread-safe, LRU-bounded cache of recent ticket keyword sets.
+    Designed to run as a fast pre-filter before the heavier semantic
+    DuplicateService (sentence-transformers / cosine similarity).
+    """
+
+    def __init__(self, max_cache_size: int = MAX_CACHE_SIZE):
+        self._cache: OrderedDict[str, _TicketEntry] = OrderedDict()
+        self._max_cache_size = max_cache_size
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+
+    def add_ticket(
+        self,
+        ticket_id: str,
+        text: str,
+        timestamp: Optional[datetime.datetime] = None,
+    ) -> None:
+        """
+        Register a ticket's text in the duplicate cache.
+
+        Args:
+            ticket_id:  Unique ticket identifier.
+            text:       Ticket description / subject text.
+            timestamp:  Creation time (defaults to now UTC).
+        """
+        keywords = extract_keywords(text)
+        created_at = timestamp or datetime.datetime.now(datetime.UTC)
+        entry = _TicketEntry(ticket_id, keywords, created_at)
+
+        with self._lock:
+            # If ticket already exists, move to end (LRU refresh)
+            if ticket_id in self._cache:
+                self._cache.move_to_end(ticket_id)
+            self._cache[ticket_id] = entry
+
+            # Evict oldest entries if cache exceeds max size
+            while len(self._cache) > self._max_cache_size:
+                self._cache.popitem(last=False)
+
+        logger.debug(
+            "[JaccardFilter] Cached ticket %s (%d keywords)",
+            ticket_id, len(keywords),
+        )
+
+    def remove_ticket(self, ticket_id: str) -> bool:
+        """
+        Remove a ticket from the duplicate cache.
+
+        Returns True if the ticket was found and removed.
+        """
+        with self._lock:
+            if ticket_id in self._cache:
+                del self._cache[ticket_id]
+                return True
+        return False
+
+    def check_duplicate(
+        self,
+        text: str,
+        threshold: float = DEFAULT_THRESHOLD,
+        window_hours: float = DEFAULT_WINDOW_HOURS,
+    ) -> dict:
+        """
+        Check if text is a duplicate of any recently-cached ticket.
+
+        Args:
+            text:          Incoming ticket text to check.
+            threshold:     Jaccard similarity threshold (0.0–1.0). Default 0.85.
+            window_hours:  Only compare against tickets created within this many
+                           hours. Default 24. Set to 0 for no time filtering.
+
+        Returns:
+            {
+                "is_duplicate": bool,
+                "duplicate_ticket_id": str | None,
+                "similarity": float,
+            }
+        """
+        query_keywords = extract_keywords(text)
+
+        if not query_keywords:
+            return {
+                "is_duplicate": False,
+                "duplicate_ticket_id": None,
+                "similarity": 0.0,
+            }
+
+        now = datetime.datetime.now(datetime.UTC)
+        best_score = 0.0
+        best_ticket_id = None
+
+        with self._lock:
+            for entry in self._cache.values():
+                # Timeline window filtering
+                if window_hours > 0:
+                    age_hours = (now - entry.created_at).total_seconds() / 3600
+                    if age_hours > window_hours:
+                        continue
+
+                score = jaccard_similarity(query_keywords, entry.keywords)
+                if score > best_score:
+                    best_score = score
+                    best_ticket_id = entry.ticket_id
+
+        is_dup = best_score >= threshold
+        return {
+            "is_duplicate": is_dup,
+            "duplicate_ticket_id": best_ticket_id if is_dup else None,
+            "similarity": round(best_score, 4),
+        }
+
+    @property
+    def cache_size(self) -> int:
+        """Current number of tickets in the cache."""
+        return len(self._cache)
+
+    def clear(self) -> None:
+        """Flush the entire cache."""
+        with self._lock:
+            self._cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — import and use directly
+# ---------------------------------------------------------------------------
+jaccard_filter = JaccardDuplicateFilter()

--- a/backend/tests/test_jaccard_duplicate_filter.py
+++ b/backend/tests/test_jaccard_duplicate_filter.py
@@ -1,0 +1,385 @@
+"""
+Test suite for Jaccard similarity duplicate filter — Issue #3228.
+
+Covers:
+  - Identical / near-duplicate text detection
+  - Different text passing through
+  - Empty / whitespace input handling
+  - Timeline window filtering
+  - Custom threshold sensitivity
+  - Stopword removal effects
+  - LRU cache eviction
+  - Add / remove ticket operations
+  - Jaccard math correctness
+  - Case insensitivity
+  - Punctuation normalization
+"""
+
+import datetime
+import pytest
+
+from backend.services.jaccard_duplicate_filter import (
+    JaccardDuplicateFilter,
+    extract_keywords,
+    jaccard_similarity,
+    normalize_text,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def service():
+    """Fresh JaccardDuplicateFilter instance for each test."""
+    return JaccardDuplicateFilter(max_cache_size=100)
+
+
+@pytest.fixture
+def populated_service(service):
+    """Service pre-loaded with a few tickets."""
+    service.add_ticket("TKT-001", "My printer is not working at all")
+    service.add_ticket("TKT-002", "Cannot login to the VPN from office laptop")
+    service.add_ticket("TKT-003", "Email server is down and not responding")
+    return service
+
+
+# ============================================================================
+# Test: Identical texts detected
+# ============================================================================
+
+
+class TestIdenticalTexts:
+
+    def test_exact_duplicate_detected(self, service):
+        service.add_ticket("TKT-001", "Printer not working")
+        result = service.check_duplicate("Printer not working")
+
+        assert result["is_duplicate"] is True
+        assert result["duplicate_ticket_id"] == "TKT-001"
+        assert result["similarity"] == 1.0
+
+    def test_same_text_different_casing(self, service):
+        service.add_ticket("TKT-001", "PRINTER NOT WORKING")
+        result = service.check_duplicate("printer not working")
+
+        assert result["is_duplicate"] is True
+        assert result["similarity"] == 1.0
+
+
+# ============================================================================
+# Test: Near-duplicate detection
+# ============================================================================
+
+
+class TestNearDuplicate:
+
+    def test_minor_word_change_detected(self, service):
+        service.add_ticket("TKT-001", "My printer is not working at all")
+        result = service.check_duplicate(
+            "The printer is not working anymore",
+            threshold=0.5,
+        )
+
+        assert result["is_duplicate"] is True
+        assert result["similarity"] >= 0.5
+
+    def test_reworded_same_issue(self, service):
+        service.add_ticket("TKT-001", "Cannot connect to wifi network")
+        result = service.check_duplicate(
+            "wifi network connection failing",
+            threshold=0.25,
+        )
+
+        assert result["is_duplicate"] is True
+        assert result["similarity"] >= 0.25
+
+
+# ============================================================================
+# Test: Different texts pass through
+# ============================================================================
+
+
+class TestDifferentTexts:
+
+    def test_unrelated_texts_not_flagged(self, populated_service):
+        result = populated_service.check_duplicate(
+            "How do I reset my password on the mobile app?"
+        )
+
+        assert result["is_duplicate"] is False
+        assert result["duplicate_ticket_id"] is None
+
+    def test_low_similarity_below_threshold(self, service):
+        service.add_ticket("TKT-001", "Printer paper jam error")
+        result = service.check_duplicate("Network latency during video calls")
+
+        assert result["is_duplicate"] is False
+        assert result["similarity"] < 0.5
+
+
+# ============================================================================
+# Test: Empty text handling
+# ============================================================================
+
+
+class TestEmptyTextHandling:
+
+    def test_empty_string_query(self, populated_service):
+        result = populated_service.check_duplicate("")
+
+        assert result["is_duplicate"] is False
+        assert result["similarity"] == 0.0
+
+    def test_whitespace_only_query(self, populated_service):
+        result = populated_service.check_duplicate("   \t\n  ")
+
+        assert result["is_duplicate"] is False
+        assert result["similarity"] == 0.0
+
+    def test_add_empty_text_ticket(self, service):
+        service.add_ticket("TKT-001", "")
+        assert service.cache_size == 1
+
+        result = service.check_duplicate("some query text")
+        assert result["is_duplicate"] is False
+
+    def test_stopwords_only_text(self, service):
+        """Text containing only stopwords yields an empty keyword set."""
+        service.add_ticket("TKT-001", "the is a an to for")
+        result = service.check_duplicate("is a the an")
+        assert result["is_duplicate"] is False
+
+
+# ============================================================================
+# Test: Timeline window filtering
+# ============================================================================
+
+
+class TestTimelineWindow:
+
+    def test_recent_ticket_within_window(self, service):
+        now = datetime.datetime.now(datetime.UTC)
+        service.add_ticket("TKT-001", "Printer broken", timestamp=now)
+        result = service.check_duplicate("Printer broken", window_hours=24)
+
+        assert result["is_duplicate"] is True
+
+    def test_old_ticket_outside_window(self, service):
+        old_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=48)
+        service.add_ticket("TKT-001", "Printer broken", timestamp=old_time)
+        result = service.check_duplicate("Printer broken", window_hours=24)
+
+        assert result["is_duplicate"] is False
+        assert result["duplicate_ticket_id"] is None
+
+    def test_zero_window_disables_filtering(self, service):
+        old_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=365)
+        service.add_ticket("TKT-001", "Printer broken", timestamp=old_time)
+        result = service.check_duplicate("Printer broken", window_hours=0)
+
+        assert result["is_duplicate"] is True
+
+    def test_boundary_exactly_at_window_edge(self, service):
+        """Ticket at exactly window_hours ago should be excluded (age > window)."""
+        edge_time = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=24, seconds=1)
+        service.add_ticket("TKT-001", "Printer broken", timestamp=edge_time)
+        result = service.check_duplicate("Printer broken", window_hours=24)
+
+        assert result["is_duplicate"] is False
+
+
+# ============================================================================
+# Test: Custom threshold
+# ============================================================================
+
+
+class TestCustomThreshold:
+
+    def test_strict_threshold_rejects_near_match(self, service):
+        service.add_ticket("TKT-001", "printer paper jam office desk")
+        result = service.check_duplicate(
+            "printer paper jam desk table chair",
+            threshold=0.95,
+        )
+
+        assert result["is_duplicate"] is False
+
+    def test_loose_threshold_accepts_partial_match(self, service):
+        service.add_ticket("TKT-001", "printer paper jam office")
+        result = service.check_duplicate(
+            "printer paper jam different location",
+            threshold=0.3,
+        )
+
+        assert result["is_duplicate"] is True
+
+
+# ============================================================================
+# Test: Stopword removal
+# ============================================================================
+
+
+class TestStopwordRemoval:
+
+    def test_stopwords_do_not_inflate_similarity(self):
+        kw1 = extract_keywords("I am having a very big problem with my printer")
+        kw2 = extract_keywords("The problem with the printer is serious")
+
+        # Without stopword removal these would share many more tokens
+        sim = jaccard_similarity(kw1, kw2)
+        assert sim < 1.0  # Not identical — only "problem" and "printer" overlap
+
+        # The shared keywords should be "problem" and "printer"
+        assert "problem" in kw1
+        assert "printer" in kw1
+        assert kw1 & kw2 == {"problem", "printer"}
+
+
+# ============================================================================
+# Test: Cache eviction
+# ============================================================================
+
+
+class TestCacheEviction:
+
+    def test_cache_respects_max_size(self):
+        service = JaccardDuplicateFilter(max_cache_size=5)
+
+        for i in range(10):
+            service.add_ticket(f"TKT-{i:03d}", f"Ticket number {i} about topic {i}")
+
+        assert service.cache_size == 5
+
+    def test_oldest_entries_evicted_first(self):
+        service = JaccardDuplicateFilter(max_cache_size=3)
+        service.add_ticket("TKT-001", "first ticket about printers")
+        service.add_ticket("TKT-002", "second ticket about network")
+        service.add_ticket("TKT-003", "third ticket about email")
+        service.add_ticket("TKT-004", "fourth ticket about vpn")
+
+        # TKT-001 should have been evicted
+        result = service.check_duplicate("first ticket about printers")
+        assert result["duplicate_ticket_id"] != "TKT-001"
+
+    def test_clear_empties_cache(self, populated_service):
+        assert populated_service.cache_size > 0
+        populated_service.clear()
+        assert populated_service.cache_size == 0
+
+
+# ============================================================================
+# Test: Add and remove ticket
+# ============================================================================
+
+
+class TestAddRemoveTicket:
+
+    def test_add_ticket_increases_cache(self, service):
+        assert service.cache_size == 0
+        service.add_ticket("TKT-001", "Test ticket")
+        assert service.cache_size == 1
+
+    def test_remove_ticket_decreases_cache(self, service):
+        service.add_ticket("TKT-001", "Test ticket")
+        removed = service.remove_ticket("TKT-001")
+
+        assert removed is True
+        assert service.cache_size == 0
+
+    def test_remove_nonexistent_returns_false(self, service):
+        removed = service.remove_ticket("NONEXISTENT")
+        assert removed is False
+
+    def test_removed_ticket_not_matched(self, service):
+        service.add_ticket("TKT-001", "Printer broken")
+        service.remove_ticket("TKT-001")
+        result = service.check_duplicate("Printer broken")
+
+        assert result["is_duplicate"] is False
+
+
+# ============================================================================
+# Test: Jaccard math correctness
+# ============================================================================
+
+
+class TestJaccardMath:
+
+    def test_identical_sets(self):
+        assert jaccard_similarity({"a", "b", "c"}, {"a", "b", "c"}) == 1.0
+
+    def test_disjoint_sets(self):
+        assert jaccard_similarity({"a", "b"}, {"c", "d"}) == 0.0
+
+    def test_partial_overlap(self):
+        # {a, b, c} ∩ {b, c, d} = {b, c} → 2
+        # {a, b, c} ∪ {b, c, d} = {a, b, c, d} → 4
+        # Jaccard = 2/4 = 0.5
+        assert jaccard_similarity({"a", "b", "c"}, {"b", "c", "d"}) == 0.5
+
+    def test_both_empty(self):
+        assert jaccard_similarity(set(), set()) == 1.0
+
+    def test_one_empty(self):
+        assert jaccard_similarity({"a"}, set()) == 0.0
+        assert jaccard_similarity(set(), {"a"}) == 0.0
+
+    def test_single_element_match(self):
+        assert jaccard_similarity({"a"}, {"a"}) == 1.0
+
+
+# ============================================================================
+# Test: Case insensitivity
+# ============================================================================
+
+
+class TestCaseInsensitivity:
+
+    def test_mixed_case_normalization(self):
+        kw1 = extract_keywords("Login Failed ERROR")
+        kw2 = extract_keywords("login failed error")
+
+        assert kw1 == kw2
+
+    def test_case_insensitive_duplicate_check(self, service):
+        service.add_ticket("TKT-001", "Login Failed Error")
+        result = service.check_duplicate("login failed error")
+
+        assert result["is_duplicate"] is True
+        assert result["similarity"] == 1.0
+
+
+# ============================================================================
+# Test: Punctuation normalization
+# ============================================================================
+
+
+class TestPunctuationNormalization:
+
+    def test_punctuation_stripped(self):
+        kw1 = extract_keywords("Can't login!")
+        kw2 = extract_keywords("cant login")
+
+        assert "login" in kw1
+        assert "login" in kw2
+        # "can't" → "can t" → {"can", "login"} vs {"cant", "login"}
+        # They share "login" at minimum
+        assert "login" in (kw1 & kw2)
+
+    def test_punctuation_insensitive_check(self, service):
+        service.add_ticket("TKT-001", "Printer---not...working!!!")
+        result = service.check_duplicate("printer not working")
+
+        assert result["is_duplicate"] is True
+        assert result["similarity"] == 1.0
+
+    def test_special_characters_removed(self):
+        text = "Error @#$% code: 500!!! on server"
+        normalized = normalize_text(text)
+
+        assert "@" not in normalized
+        assert "#" not in normalized
+        assert "!" not in normalized


### PR DESCRIPTION
### Description

This PR implements a keyword-based Jaccard similarity text classification filter to detect and block near-identical duplicate ticket submissions within configurable timeline windows (Issue #3228). 

To avoid any overlap or conflicts with the existing SentenceTransformers/embedding-based semantic `DuplicateService`, this is implemented as a standalone fast pre-filter module.

### Changes Made

1. **New standalone service (`backend/services/jaccard_duplicate_filter.py`)**:
   - Implements lowercase, punctuation-stripping, and stopword-filtering text normalization.
   - Computes Jaccard similarity coefficient `|A ∩ B| / |A ∪ B|` over keyword sets.
   - Restricts duplicate matching to a configurable timeline window (default 24h).
   - Features a thread-safe `OrderedDict` LRU cache bounded to 1,000 entries.

2. **Pre-insert gate (`backend/routers/tickets.py`)**:
   - Checks combined subject + description in the `save_ticket` endpoint before database insertion.
   - If a duplicate is found (similarity >= 0.85), returns a `409 Conflict` response preventing insertion.
   - Indexes successfully inserted tickets into the Jaccard cache.

3. **Comprehensive tests (`backend/tests/test_jaccard_duplicate_filter.py`)**:
   - Includes 35 passing tests checking exact matches, minor rewordings, boundary timeline windows, cache eviction, and normalized text edge cases.

### Verification

Tests run and pass successfully:
```bash
python -m pytest backend/tests/test_jaccard_duplicate_filter.py -v
