### PR TITLE
[BOUNTY] Add /health/system endpoint with load and memory metrics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,6 +13,7 @@ import traceback
 import warnings
 import logging
 import hashlib
+import platform
 from contextlib import asynccontextmanager
 
 # Suppress harmless PyTorch CPU pin_memory warning
@@ -184,6 +185,18 @@ class HealthResponse(BaseModel):
     status: str
     classifier_loaded: bool
     ner_loaded: bool
+
+
+class SystemHealthResponse(BaseModel):
+    status: str
+    load_average_1m: float | None = None
+    load_average_5m: float | None = None
+    load_average_15m: float | None = None
+    memory_total_bytes: int | None = None
+    memory_available_bytes: int | None = None
+    memory_used_percent: float | None = None
+    cpu_count: int | None = None
+    platform: str
 
 
 class ReadinessResponse(BaseModel):
@@ -379,6 +392,45 @@ async def health_check():
         status="ok",
         classifier_loaded=classifier_service._loaded,
         ner_loaded=ner_service._loaded,
+    )
+
+
+@app.get("/health/system", response_model=SystemHealthResponse)
+async def health_system():
+    """Return basic CPU load averages and memory metrics for monitoring integrations."""
+    load_1m = load_5m = load_15m = None
+    try:
+        load_1m, load_5m, load_15m = os.getloadavg()
+    except (AttributeError, OSError):
+        pass
+
+    mem_total = mem_avail = mem_pct = None
+    cpu_count = os.cpu_count()
+    try:
+        import psutil
+
+        vm = psutil.virtual_memory()
+        mem_total = vm.total
+        mem_avail = vm.available
+        mem_pct = round(vm.percent, 2)
+        if load_1m is None and hasattr(psutil, "getloadavg"):
+            try:
+                load_1m, load_5m, load_15m = psutil.getloadavg()
+            except (AttributeError, OSError):
+                pass
+    except ImportError:
+        pass
+
+    return SystemHealthResponse(
+        status="ok",
+        load_average_1m=load_1m,
+        load_average_5m=load_5m,
+        load_average_15m=load_15m,
+        memory_total_bytes=mem_total,
+        memory_available_bytes=mem_avail,
+        memory_used_percent=mem_pct,
+        cpu_count=cpu_count,
+        platform=platform.system(),
     )
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ easyocr
 slowapi>=0.1.9
 supabase==2.22.4
 storage3==2.22.4
+psutil>=5.9.0

--- a/backend/tests/test_health_system.py
+++ b/backend/tests/test_health_system.py
@@ -1,0 +1,32 @@
+"""Tests for /health/system monitoring endpoint."""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+def test_health_system_returns_metrics():
+    r = client.get("/health/system")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ok"
+    assert "platform" in data
+    assert data["cpu_count"] is None or data["cpu_count"] >= 1
+
+
+def test_health_system_memory_fields_when_psutil_available():
+    r = client.get("/health/system")
+    data = r.json()
+    try:
+        import psutil  # noqa: F401
+    except ImportError:
+        return
+    assert data["memory_total_bytes"] is not None
+    assert data["memory_available_bytes"] is not None
+    assert data["memory_used_percent"] is not None


### PR DESCRIPTION
Fixes #3210

- GET /health/system returns load averages and memory stats
- psutil for cross-platform memory metrics
- tests in backend/tests/test_health_system.py

Made with [Cursor](https://cursor.com)