### PR TITLE
fix: add httponly flag to csrf token cookie for enhanced security

### DIFF
--- a/backend/csrf.py
+++ b/backend/csrf.py
@@ -61,6 +61,7 @@ def set_csrf_cookie(response: Response) -> str:
         value=token,
         max_age=CSRF_COOKIE_MAX_AGE,
         secure=True,
+        httponly=True,
         samesite="strict",
         path="/",
     )


### PR DESCRIPTION
## Summary

This PR strengthens the application's CSRF protection by configuring the CSRF token cookie with the `HttpOnly` flag where appropriate.

### Changes

- Added the `HttpOnly` attribute to the CSRF token cookie.
- Updated cookie configuration to improve security against client-side script access.
- Preserved existing cookie behavior and compatibility with the current authentication flow.

## Why

Without the `HttpOnly` flag, the CSRF token cookie can be accessed through JavaScript, increasing the potential impact of cross-site scripting (XSS) vulnerabilities. Restricting client-side access to sensitive cookies is a security best practice that helps reduce the attack surface.

Adding the `HttpOnly` attribute ensures the browser only sends the cookie with HTTP requests, preventing it from being read or modified by client-side scripts.

## Benefits

- Improves defense against XSS-based cookie theft.
- Aligns cookie configuration with security best practices.
- Reduces the exposure of sensitive authentication-related data.
- Enhances the overall security posture without affecting normal application behavior.

## Testing

- [x] Verified the CSRF cookie is issued with the `HttpOnly` attribute.
- [x] Confirmed existing CSRF protection continues to function correctly.
- [x] Verified authenticated requests continue to work as expected.
- [x] No breaking changes introduced.

## Notes

This is a focused security enhancement that only updates the CSRF cookie configuration. No application logic or authentication workflows were modified beyond the cookie attributes.