### PR TITLE
feat: implement routing guards for authenticated routes

### DIFF
--- a/Frontend/src/routes/AppRoutes.jsx
+++ b/Frontend/src/routes/AppRoutes.jsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import ProtectedRoute, { AdminRoute } from './ProtectedRoute';
 
 // ─── Skeleton Loaders ───────────────────────────────────────────────────────
 
@@ -77,7 +78,7 @@ const AppRoutes = () => (
     <>
         <AIAssistant />
         <Routes>
-        {/* Auth routes */}
+        {/* Auth routes — public */}
         <Route path="/login" element={
             <LazyRoute><Login /></LazyRoute>
         } />
@@ -85,44 +86,44 @@ const AppRoutes = () => (
             <LazyRoute><Register /></LazyRoute>
         } />
 
-        {/* Admin routes - all lazy loaded */}
+        {/* Admin routes — protected, require admin role */}
         <Route path="/admin" element={
-            <LazyRoute><AdminDashboard /></LazyRoute>
+            <AdminRoute><LazyRoute><AdminDashboard /></LazyRoute></AdminRoute>
         } />
         <Route path="/admin/tickets" element={
-            <LazyRoute fallback={<TableSkeleton />}><AdminTickets /></LazyRoute>
+            <AdminRoute><LazyRoute fallback={<TableSkeleton />}><AdminTickets /></LazyRoute></AdminRoute>
         } />
         <Route path="/admin/ticket/:ticket_id" element={
-            <LazyRoute><AdminTicketDetail /></LazyRoute>
+            <AdminRoute><LazyRoute><AdminTicketDetail /></LazyRoute></AdminRoute>
         } />
         <Route path="/admin/analytics" element={
-            <LazyRoute><AdminAnalytics /></LazyRoute>
+            <AdminRoute><LazyRoute><AdminAnalytics /></LazyRoute></AdminRoute>
         } />
         <Route path="/admin/settings" element={
-            <LazyRoute><AdminSettings /></LazyRoute>
+            <AdminRoute><LazyRoute><AdminSettings /></LazyRoute></AdminRoute>
         } />
         <Route path="/admin/users" element={
-            <LazyRoute fallback={<TableSkeleton />}><AdminUsers /></LazyRoute>
+            <AdminRoute><LazyRoute fallback={<TableSkeleton />}><AdminUsers /></LazyRoute></AdminRoute>
         } />
         <Route path="/admin/knowledge" element={
-            <LazyRoute><AdminKnowledge /></LazyRoute>
+            <AdminRoute><LazyRoute><AdminKnowledge /></LazyRoute></AdminRoute>
         } />
 
-        {/* User routes - all lazy loaded */}
+        {/* User routes — protected, any authenticated user */}
         <Route path="/dashboard" element={
-            <LazyRoute><UserDashboard /></LazyRoute>
+            <ProtectedRoute><LazyRoute><UserDashboard /></LazyRoute></ProtectedRoute>
         } />
         <Route path="/tickets" element={
-            <LazyRoute fallback={<TableSkeleton />}><UserTickets /></LazyRoute>
+            <ProtectedRoute><LazyRoute fallback={<TableSkeleton />}><UserTickets /></LazyRoute></ProtectedRoute>
         } />
         <Route path="/tickets/:id" element={
-            <LazyRoute><UserTicketDetail /></LazyRoute>
+            <ProtectedRoute><LazyRoute><UserTicketDetail /></LazyRoute></ProtectedRoute>
         } />
         <Route path="/ticket-tracking" element={
-            <LazyRoute><TicketTracking /></LazyRoute>
+            <ProtectedRoute><LazyRoute><TicketTracking /></LazyRoute></ProtectedRoute>
         } />
         <Route path="/profile" element={
-            <LazyRoute><UserProfile /></LazyRoute>
+            <ProtectedRoute><LazyRoute><UserProfile /></LazyRoute></ProtectedRoute>
         } />
         <Route path="/about" element={
             <LazyRoute><AboutUs /></LazyRoute>

--- a/Frontend/src/routes/ProtectedRoute.jsx
+++ b/Frontend/src/routes/ProtectedRoute.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import useAuthStore from '../store/authStore';
+
+/**
+ * ProtectedRoute — Client-side routing guard that prevents
+ * unauthenticated users and wrong-role users from accessing
+ * private routes.
+ *
+ * Security model:
+ *   1. Auth state (Supabase session) is checked client-side first.
+ *   2. Role is ALWAYS verified against the database via verifyServerRole(),
+ *      never read from localStorage or Zustand persisted state.
+ *   3. While the session check is in-flight, a loading skeleton is shown
+ *      (no flash of redirect).
+ *
+ * Usage:
+ *   <ProtectedRoute><AdminDashboard /></ProtectedRoute>
+ *   <ProtectedRoute requiredRole="admin"><AdminSettings /></ProtectedRoute>
+ */
+
+const ADMIN_ROLES = ['admin', 'super_admin', 'master_admin'];
+
+const GuardSkeleton = () => (
+    <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+        <div className="animate-pulse text-gray-400 text-sm">Verifying access…</div>
+    </div>
+);
+
+const ProtectedRoute = ({ children, requiredRole }) => {
+    const location = useLocation();
+    const user = useAuthStore((s) => s.user);
+    const profile = useAuthStore((s) => s.profile);
+    const isCheckingSession = useAuthStore((s) => s.isCheckingSession);
+    const verifyServerRole = useAuthStore((s) => s.verifyServerRole);
+
+    const [roleVerified, setRoleVerified] = useState(!requiredRole);
+    const [roleAllowed, setRoleAllowed] = useState(true);
+
+    // Verify role against the database whenever the user changes
+    useEffect(() => {
+        if (!requiredRole || !user) {
+            setRoleVerified(true);
+            setRoleAllowed(true);
+            return;
+        }
+
+        let cancelled = false;
+
+        const check = async () => {
+            const allowed = await verifyServerRole(user.id);
+            if (!cancelled) {
+                setRoleVerified(true);
+                setRoleAllowed(allowed);
+            }
+        };
+
+        check();
+
+        return () => { cancelled = true; };
+    }, [user, requiredRole, verifyServerRole]);
+
+    // Still checking session — show skeleton (no redirect flash)
+    if (isCheckingSession) {
+        return <GuardSkeleton />;
+    }
+
+    // Not authenticated — redirect to login, preserve intended destination
+    if (!user) {
+        return <Navigate to="/login" state={{ from: location }} replace />;
+    }
+
+    // Role required but not yet verified — keep skeleton
+    if (requiredRole && !roleVerified) {
+        return <GuardSkeleton />;
+    }
+
+    // Authenticated but wrong role — redirect to their dashboard
+    if (requiredRole && !roleAllowed) {
+        return <Navigate to="/dashboard" replace />;
+    }
+
+    return children;
+};
+
+/**
+ * AdminRoute — Convenience wrapper for admin-only routes.
+ * Checks that the user has an admin role in the database.
+ */
+export const AdminRoute = ({ children }) => (
+    <ProtectedRoute requiredRole="admin">
+        {children}
+    </ProtectedRoute>
+);
+
+export default ProtectedRoute;

--- a/Frontend/src/routes/__tests__/ProtectedRoute.test.jsx
+++ b/Frontend/src/routes/__tests__/ProtectedRoute.test.jsx
@@ -1,0 +1,172 @@
+/**
+ * @vitest-environment jsdom
+ */
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+// ─── Mock components ────────────────────────────────────────────────────────
+
+const DashboardPage = () => <div data-testid="dashboard">Dashboard</div>;
+const AdminPage = () => <div data-testid="admin">Admin Panel</div>;
+const LoginPage = () => <div data-testid="login">Login Page</div>;
+
+// ─── Mock useAuthStore ──────────────────────────────────────────────────────
+
+const mockGetState = vi.fn();
+
+vi.mock('../../store/authStore', () => {
+    const useAuthStore = (selector) => {
+        const state = mockGetState();
+        return typeof selector === 'function' ? selector(state) : state;
+    };
+    return { default: useAuthStore };
+});
+
+// Now import the component — the mock is in place
+import ProtectedRoute, { AdminRoute } from '../ProtectedRoute';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const renderProtected = (initialEntries = ['/protected']) =>
+    render(
+        <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/dashboard" element={<DashboardPage />} />
+                <Route path="/protected" element={
+                    <ProtectedRoute><DashboardPage /></ProtectedRoute>
+                } />
+                <Route path="/admin" element={
+                    <AdminRoute><AdminPage /></AdminRoute>
+                } />
+            </Routes>
+        </MemoryRouter>
+    );
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('ProtectedRoute', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetState.mockReturnValue({
+            user: null,
+            profile: null,
+            isCheckingSession: false,
+            verifyServerRole: vi.fn().mockResolvedValue(false),
+        });
+    });
+
+    it('shows loading skeleton while checking session', () => {
+        mockGetState.mockReturnValue({
+            user: null,
+            profile: null,
+            isCheckingSession: true,
+            verifyServerRole: vi.fn(),
+        });
+
+        renderProtected(['/protected']);
+
+        expect(screen.getByText(/verifying access/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('dashboard')).not.toBeInTheDocument();
+    });
+
+    it('redirects to /login when not authenticated', async () => {
+        mockGetState.mockReturnValue({
+            user: null,
+            profile: null,
+            isCheckingSession: false,
+            verifyServerRole: vi.fn(),
+        });
+
+        renderProtected(['/protected']);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('login')).toBeInTheDocument();
+        });
+    });
+
+    it('renders children when authenticated (no role required)', async () => {
+        mockGetState.mockReturnValue({
+            user: { id: 'user-1', email: 'test@example.com' },
+            profile: { id: 'user-1', role: 'user', status: 'active' },
+            isCheckingSession: false,
+            verifyServerRole: vi.fn(),
+        });
+
+        renderProtected(['/protected']);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dashboard')).toBeInTheDocument();
+        });
+    });
+
+    it('redirects to /login when not authenticated (admin route)', async () => {
+        mockGetState.mockReturnValue({
+            user: null,
+            profile: null,
+            isCheckingSession: false,
+            verifyServerRole: vi.fn(),
+        });
+
+        renderProtected(['/admin']);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('login')).toBeInTheDocument();
+        });
+    });
+
+    it('verifies admin role against database, not local state', async () => {
+        const verifyServerRole = vi.fn().mockResolvedValue(true);
+
+        mockGetState.mockReturnValue({
+            user: { id: 'admin-1', email: 'admin@example.com' },
+            profile: { id: 'admin-1', role: 'admin', status: 'active' },
+            isCheckingSession: false,
+            verifyServerRole,
+        });
+
+        renderProtected(['/admin']);
+
+        await waitFor(() => {
+            expect(verifyServerRole).toHaveBeenCalledWith('admin-1');
+            expect(screen.getByTestId('admin')).toBeInTheDocument();
+        });
+    });
+
+    it('redirects non-admin users away from admin routes', async () => {
+        const verifyServerRole = vi.fn().mockResolvedValue(false);
+
+        mockGetState.mockReturnValue({
+            user: { id: 'user-1', email: 'user@example.com' },
+            profile: { id: 'user-1', role: 'user', status: 'active' },
+            isCheckingSession: false,
+            verifyServerRole,
+        });
+
+        renderProtected(['/admin']);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('dashboard')).toBeInTheDocument();
+            expect(screen.queryByTestId('admin')).not.toBeInTheDocument();
+        });
+    });
+
+    it('shows loading skeleton while role is being verified', () => {
+        const verifyServerRole = vi.fn().mockReturnValue(new Promise(() => {}));
+
+        mockGetState.mockReturnValue({
+            user: { id: 'user-1', email: 'user@example.com' },
+            profile: { id: 'user-1', role: 'user', status: 'active' },
+            isCheckingSession: false,
+            verifyServerRole,
+        });
+
+        renderProtected(['/admin']);
+
+        expect(screen.getByText(/verifying access/i)).toBeInTheDocument();
+        expect(screen.queryByTestId('admin')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

Adds client-side routing guards to prevent unauthenticated access and role escalation for both admin and user routes.

Closes #3218

## Changes

### New: `ProtectedRoute` component (`Frontend/src/routes/ProtectedRoute.jsx`)
- Checks Supabase session client-side for instant UX feedback
- **Always verifies role against the database** via `verifyServerRole()` — never trusts localStorage or Zustand persisted state
- Shows a loading skeleton while session/role checks are in-flight (no redirect flash)
- Unauthenticated users are redirected to `/login` with their intended destination preserved in `state.from`
- `AdminRoute` convenience wrapper for admin-only routes

### Updated: `AppRoutes.jsx`
- All admin routes (`/admin/*`) wrapped with `<AdminRoute>`
- All user routes (`/dashboard`, `/tickets`, `/profile`, `/ticket-tracking`) wrapped with `<ProtectedRoute>`
- Public routes (`/login`, `/register`, `/about`) remain unprotected

### New: Unit tests (`Frontend/src/routes/__tests__/ProtectedRoute.test.jsx`)
7 passing tests covering:
- Loading skeleton during session check
- Redirect to /login when unauthenticated
- Child rendering when authenticated
- Admin route access control (database verification)
- Non-admin redirect from admin routes
- Loading skeleton during role verification

## Security Model
1. Client-side session check → fast UX
2. **Server-side role verification** → prevents local role tampering
3. Loading state → no flash of wrong content
4. Destination preservation → smooth post-login redirect