### PR TITLE
Fix biometric authentication fallback loop locks on iOS

### DIFF
--- a/MobileApp/src/utils/biometrics.js
+++ b/MobileApp/src/utils/biometrics.js
@@ -46,6 +46,11 @@ export const authenticateUser = async () => {
       return { success: false, error: 'cancelled' };
     }
 
+    // User chose fallback (e.g. Use PIN) — stop immediately, do NOT retry
+    if (result.error === 'user_fallback') {
+      return { success: false, error: 'user_fallback' };
+    }
+
     // Device lockout — biometrics disabled by OS, stop immediately
     if (
       result.error === 'lockout' ||

--- a/MobileApp/src/utils/biometrics.test.js
+++ b/MobileApp/src/utils/biometrics.test.js
@@ -51,6 +51,17 @@ describe('authenticateUser', () => {
     expect(LocalAuthentication.authenticateAsync).toHaveBeenCalledTimes(1);
   });
 
+  it('stops immediately on user_fallback — no retry', async () => {
+    LocalAuthentication.authenticateAsync.mockResolvedValue({
+      success: false,
+      error: 'user_fallback',
+    });
+    const result = await authenticateUser();
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('user_fallback');
+    expect(LocalAuthentication.authenticateAsync).toHaveBeenCalledTimes(1);
+  });
+
   it('stops immediately on lockout — no retry', async () => {
     LocalAuthentication.authenticateAsync.mockResolvedValue({
       success: false,


### PR DESCRIPTION
Fixes #3222

Fix biometric authentication fallback loop locks on iOS in the mobile app code.
