### PR TITLE
fix(critical): invalid syntax — try without except in backend/database.py

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -14,11 +14,14 @@ try:
     from backend.config import settings
     url = settings.SUPABASE_URL
     key = settings.SUPABASE_SERVICE_KEY
-    if not url or not key:
+    if url and key:
+        supabase = create_client(url, key)
+    else:
         logger.error("SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
         supabase = None
-else:
-    logger.error("SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
+except Exception:
+    logger.error("Failed to initialize Supabase client")
+    supabase = None
 
 def get_system_settings(company_id: str) -> dict:
     defaults = {


### PR DESCRIPTION
## Description

The `try` block in `backend/database.py:12` had no matching `except` clause, only an invalid `else:` — this is a Python syntax error that blocks the module from being imported entirely.

## Root Cause

The original code attempted:

```python
try:
    from supabase import create_client, Client
    from backend.config import settings
    url = settings.SUPABASE_URL
    key = settings.SUPABASE_SERVICE_KEY
    if not url or not key:
        logger.error("SUPABASE_URL or SUPABASE_SERVICE_KEY not set")
        supabase = None
else:
    logger.error("SUPABASE_URL or SUPABASE_SERVICE_KEY not set in backend/.env")
```

The `else` clause is not valid without an `except` or `finally` clause, causing a `SyntaxError` on any attempt to import the module.

## Fix

Restructured the block so the Supabase client is only initialized when both `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` are present, with proper `try/except` handling for both import failures and missing credentials.

## Impact

- **Before**: `import backend.database` raises `SyntaxError` — impossible to start the application
- **After**: Supabase client is created with proper error handling; module can be imported without errors
