### PR TITLE
fix(critical): corrupted _coerce_level function and missing get_logger in backend/logger.py

### DIFF
--- a/backend/logger.py
+++ b/backend/logger.py
@@ -25,6 +25,7 @@ import os
 import sys
 import json
 from datetime import datetime
+from typing import Union
 
 class JSONFormatter(logging.Formatter):
     """
@@ -71,12 +72,18 @@ _DEFAULT_LEVEL = logging.INFO
 
 
 def _coerce_level(value: Union[str, int, None]) -> int:
-    """Normalise a level spec into a stdlib numeric level.
+    if value is None:
+        return logging.INFO
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        if value.isdigit():
+            return int(value)
+        level = getattr(logging, value.upper(), None)
+        if isinstance(level, int):
+            return level
+    return logging.INFO
 
-    Accepts upper/lower/stdlib names ("debug", "WARNING", ...) and integer
-    strings ("10"). Falls back to INFO on anything unrecognised so a typo in
-    configuration never silences production logs unexpectedly.
-    """
-    Returns a configured standard logger.
-    """
+
+def get_logger(name: str) -> logging.Logger:
     return logging.getLogger(name)


### PR DESCRIPTION
## Description

The `_coerce_level` function in `backend/logger.py` had a corrupted body that would fail at runtime, and the `get_logger` entry point advertised in the module docstring was entirely missing.

## Root Cause

The function body was corrupted during refactoring:

```python
def _coerce_level(value: Union[str, int, None]) -> int:
    """Normalise a level spec into a stdlib numeric level.
    ...
    """
    Returns a configured standard logger.
    """
    return logging.getLogger(name)
```

- The docstring's closing `"""` on line 79 was followed by orphaned text (`Returns a configured standard logger.`) and an unclosed `"""`
- The function returned `logging.getLogger(name)` where `name` was undefined
- `Union` was used in the type annotation but never imported
- The `get_logger` function — documented as the module's single public entry point — was never defined

## Fix

1. Added the missing `Union` import from `typing`
2. Replaced the corrupted body with proper level coercion logic (accepts `str`, `int`, or `None`, falls back to `INFO`)
3. Added the `get_logger(name)` function

## Impact

- **Before**: Calling `_coerce_level` would raise `NameError` on `name`, and `get_logger` was missing entirely
- **After**: Both functions work correctly; level coercion handles all documented input formats
