### PR TITLE
fix(security): add rate limiting to authentication endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1425,7 +1425,8 @@ class SignupBody(BaseModel):
     company: str | None = None
 
 @app.post("/auth/login")
-async def auth_login(body: LoginBody, response: Response):
+@limiter.limit("5/minute")
+async def auth_login(request: Request, body: LoginBody, response: Response):
     if not supabase:
         raise HTTPException(status_code=503, detail="Database connection offline")
     try:
@@ -1445,7 +1446,8 @@ async def auth_login(body: LoginBody, response: Response):
     return {"user": user_payload, "message": "Session cookies set"}
 
 @app.post("/auth/signup")
-async def auth_signup(body: SignupBody, response: Response):
+@limiter.limit("5/minute")
+async def auth_signup(request: Request, body: SignupBody, response: Response):
     if not supabase:
         raise HTTPException(status_code=503, detail="Database connection offline")
     metadata = {}


### PR DESCRIPTION
# Summary
The authentication endpoints (`/auth/login` and `/auth/signup`) were previously missing rate-limiting controls, leaving the application vulnerable to brute-force attacks, credential stuffing, and account enumeration.

# Root Cause
The `slowapi` rate limiter was successfully applied to other endpoints (e.g., `/ai/analyze_ticket`) but was omitted from the login and signup routes. Without a request cap, an attacker could send unlimited requests to these endpoints without being throttled.

# Solution
I applied the existing `slowapi` limiter to the authentication endpoints with a conservative limit of 5 requests per minute per IP. The FastAPI `Request` dependency was also added to the endpoint signatures, as it is required by the limiter's IP resolution (`get_remote_address`).

# Files Changed
* `backend/main.py`: 
  - Added `@limiter.limit("5/minute")` to `auth_login` and `auth_signup`.
  - Added `request: Request` to both function signatures.

# Testing
* Build passed
* Lint passed
* Code verified (FastAPI request injection and slowapi decorator implementation confirmed).
* Manual verification completed

# Impact
* Breaking changes: No
* Performance impact: Negligible overhead from the rate limiter.
* Security impact: High. Mitigates brute-force attacks and credential stuffing on auth endpoints.
* Compatibility: Fully compatible with existing auth workflows.

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
