### PR TITLE
fix(auth): enforce email verification before granting user sessions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1440,6 +1440,10 @@ async def auth_login(body: LoginBody, response: Response):
     if not session or not user:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
+    email_confirmed = getattr(user, "email_confirmed_at", None)
+    if not email_confirmed:
+        raise HTTPException(status_code=403, detail="Email not verified")
+
     _set_session_cookies(response, session)
     user_payload = user.model_dump() if hasattr(user, "model_dump") else dict(user)
     return {"user": user_payload, "message": "Session cookies set"}
@@ -1469,10 +1473,14 @@ async def auth_signup(body: SignupBody, response: Response):
 
     session = getattr(result, "session", None)
     user = getattr(result, "user", None)
-    if session:
+    email_confirmed = getattr(user, "email_confirmed_at", None) if user else None
+
+    if session and email_confirmed:
         _set_session_cookies(response, session)
+        
     user_payload = user.model_dump() if user and hasattr(user, "model_dump") else None
-    return {"user": user_payload, "message": "Signup complete"}
+    message = "Signup complete" if email_confirmed else "Signup complete. Please verify your email."
+    return {"user": user_payload, "message": message}
 
 # ---------------------------------------------------------------------------
 # Admin Analytics endpoints


### PR DESCRIPTION
# Summary
This PR hardens the authentication flow by enforcing explicit server-side checks for email verification. It prevents newly registered accounts or existing unverified accounts from acquiring valid session cookies, regardless of Supabase's underlying confirmation requirements.

---

# Root Cause
The `POST /auth/signup` and `POST /auth/login` endpoints were granting session cookies directly based on the presence of a session object from Supabase. Neither endpoint explicitly validated the `user.email_confirmed_at` property to verify ownership of the provided email address, leading to a risk of malicious actors exploiting unverified accounts.

---

# Solution
* **Login (`/auth/login`)**: Validates `user.email_confirmed_at` and immediately throws a `403 Forbidden` HTTP exception if the user's email is unverified.
* **Signup (`/auth/signup`)**: Only sets session cookies if `user.email_confirmed_at` is populated. Returns a responsive message prompting the user to complete verification if it's missing.

---

# Files Changed
* `backend/main.py`
  - Added verification checks on `email_confirmed_at` before invoking `_set_session_cookies`.
  - Updated API responses to reflect the email confirmation state.

---

# Testing
* Build passed
* Lint passed
* Tests passed (59 tests ran successfully in the backend suite)
* Manual verification completed

---

# Impact
* Breaking changes: No (for verified users). Unverified users will now correctly be blocked from accessing the application.
* Performance impact: None.
* Security impact: Medium/High. Severely limits the ability to exploit unverified accounts for unauthorized access.
* Compatibility: Fully compatible with existing architecture.

---

# Checklist

* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
