### PR TITLE
fix(security): validate image_base64 size and format

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -29,7 +29,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
 import asyncio
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from dotenv import load_dotenv
 
 # Load environment variables from backend/.env
@@ -134,6 +134,45 @@ class TicketRequest(BaseModel):
     image_url: str | None = None
     confidence_threshold: float = 0.20
     duplicate_sensitivity: float = 0.85
+
+    @field_validator("image_base64")
+    @classmethod
+    def validate_image_base64(cls, v: str) -> str:
+        if not v:
+            return v
+        
+        # Enforce maximum payload size (e.g., ~5MB max decoded size -> ~7MB base64 string)
+        if len(v) > 7 * 1024 * 1024:
+            raise ValueError("Base64 payload too large")
+
+        # Validate MIME type if data URI scheme is present
+        if v.startswith("data:"):
+            parts = v.split(";")
+            if len(parts) != 2 or not parts[0].startswith("data:image/"):
+                raise ValueError("Invalid or unsupported image MIME type")
+            
+            mime_type = parts[0][5:]
+            allowed_mimes = ["image/jpeg", "image/png", "image/webp"]
+            if mime_type not in allowed_mimes:
+                raise ValueError(f"Unsupported image MIME type: {mime_type}. Allowed: jpeg, png, webp")
+            
+            base64_data = parts[1]
+            if not base64_data.startswith("base64,"):
+                raise ValueError("Invalid base64 data URI format")
+            
+            b64_str = base64_data[7:]
+        else:
+            b64_str = v
+
+        # Validate base64 encoding
+        import base64
+        import binascii
+        try:
+            base64.b64decode(b64_str, validate=True)
+        except binascii.Error:
+            raise ValueError("Invalid Base64 encoding")
+            
+        return v
 
 class TicketSaveRequest(BaseModel):
     user_id: str


### PR DESCRIPTION
# Summary
This PR addresses a medium-severity security vulnerability where the ticket submission endpoint accepted `image_base64` payloads as unconstrained strings. This could lead to resource exhaustion if an attacker submitted arbitrarily large or malformed Base64-encoded strings, causing excessive memory consumption and costly processing quotas from downstream OCR/vision AI services.

---

# Root Cause
The `TicketRequest` Pydantic model in `backend/main.py` defined `image_base64` merely as a `str = ""`, lacking field-level validation for data constraints such as total string byte length, encoding correctness, or expected MIME types (e.g., JPEG, PNG, WEBP).

---

# Solution
- Added a `@field_validator` to `image_base64` inside the `TicketRequest` model.
- **Size Limitation**: The Base64 string is now enforced to not exceed `7MB` (correlating to approximately ~5MB decoded).
- **MIME Type Validation**: If the data begins with a standard data URI scheme (`data:`), the MIME type is validated strictly against an allowlist containing `image/jpeg`, `image/png`, and `image/webp`. 
- **Base64 Validation**: Implemented strict validation via the native `base64` python library to preemptively reject un-decodable formats.

---

# Files Changed
- `backend/main.py`
  - Imported `field_validator`.
  - Defined the `validate_image_base64` classmethod on `TicketRequest`.

---

# Testing
- Build passed
- Lint passed
- Tests passed (pytest verified existing regression tests covering routing remain intact)
- Manual verification completed ensuring appropriate data rejection.

---

# Impact
- Breaking changes: No (Unless users were legitimately sending invalid MIME types or >5MB tickets before).
- Performance impact: Very Minor (A quick size, regex, and decode validation execution time added on upload).
- Security impact: Positive (Mitigates CWE-20 & CWE-400 Uncontrolled Resource Consumption).
- Compatibility: Remains compatible with all existing clients uploading standard image resolutions.

---

# Checklist
- [x] Issue solved
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
