### PR TITLE
fix(security): add HTTP security headers middleware

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -366,6 +366,18 @@ app.add_middleware(
 )
 
 
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["Content-Security-Policy"] = "default-src 'self'; frame-ancestors 'none';"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+    return response
+
+
 # ---------------------------------------------------------------------------
 # Root & Health check
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
This PR addresses issue #3365 by adding essential HTTP security headers to all FastAPI responses to enable browser-based security protections.

---

# Root Cause
The FastAPI application was missing standard HTTP security headers (CSP, HSTS, etc.) within its middleware stack. This lack of explicit configuration exposed the application to potential defense-in-depth vulnerabilities such as XSS, MIME-sniffing, and clickjacking.

---

# Solution
A custom HTTP middleware (`add_security_headers`) was added to `backend/main.py` to intercept responses and inject the missing security headers before sending the response to the client.

---

# Files Changed
* `backend/main.py`
  * Added `@app.middleware("http")` to append `Content-Security-Policy`, `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Permissions-Policy` to the response headers.

---

# Testing
* Build passed
* Lint passed
* Tests passed (pytest: 59 passed)
* Manual verification completed

---

# Impact
* Breaking changes: No
* Performance impact: Negligible
* Security impact: **High** (Significantly hardens the application against client-side attacks)
* Compatibility: Fully compatible with existing functionality and endpoints

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
