### PR TITLE
fix(config): load backend URL from environment variables

### DIFF
--- a/MobileApp/src/screens/user/AIProcessingScreen.js
+++ b/MobileApp/src/screens/user/AIProcessingScreen.js
@@ -14,9 +14,7 @@ import {
 import * as Haptics from 'expo-haptics';
 import axios from 'axios';
 import { decode } from 'base64-arraybuffer';
-
-const BACKEND_URL = 'https://ritesh19180-ai-helpdesk-api.hf.space';
-
+const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL || 'https://ritesh19180-ai-helpdesk-api.hf.space';
 // ─── Premium Neural Orbit Component ────────────────────────────────────────
 const NeuralOrbit = ({ radius, duration, color, opacity = 1 }) => {
   const rotateAnim = useRef(new Animated.Value(0)).current;


### PR DESCRIPTION
# Summary

This PR addresses Issue #3377 by removing the hardcoded production backend URL from `AIProcessingScreen.js` and replacing it with an environment-based configuration approach.

---

# Root Cause

The production backend URL was hardcoded directly as a string constant in the source code of `AIProcessingScreen.js`. This tightly coupled the mobile app to the production backend, hindering the ability to test against development or staging environments without modifying the source code.

---

# Solution

Updated the `BACKEND_URL` constant to fetch its value from `process.env.EXPO_PUBLIC_BACKEND_URL`, which is the standard way of handling environment variables in Expo applications. A fallback to the original URL has been kept to ensure the app continues to function seamlessly in development environments where the `.env` file might not yet be configured.

---

# Files Changed

* `MobileApp/src/screens/user/AIProcessingScreen.js`: 
  - Replaced the hardcoded string with `process.env.EXPO_PUBLIC_BACKEND_URL` and implemented the original URL as a fallback.

---

# Testing

* Build passed natively using standard Expo configs.
* Lint passed.
* Manual verification completed.

---

# Impact

* Breaking changes: No
* Performance impact: None
* Security impact: Positive (Reduces operational risk of testing builds against production infrastructure).
* Compatibility: Fully backward compatible due to the implemented fallback string.

---

# Checklist

* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
