### PR TITLE
fix(core): remove redundant ImportError from exception handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,7 +54,7 @@ try:
         supabase = None
     else:
         supabase = create_client(url, key)
-except (ImportError, Exception) as e:
+except Exception as e:
     print(f"[WARNING] Supabase initialization failed: {e}")
     supabase = None
     Client = None


### PR DESCRIPTION
# Summary
This PR simplifies the exception handling block in the Supabase client initialization by removing a redundant exception type specification.

---

# Root Cause
The codebase was using `except (ImportError, Exception) as e:` during the initialization of the Supabase client. Because `ImportError` inherits from `Exception`, specifying it alongside `Exception` in the tuple provided no additional behavior and was functionally redundant.

---

# Solution
Replaced the `except (ImportError, Exception) as e:` statement with a simpler `except Exception as e:`. This maintains the exact same error-catching behavior while improving code readability and maintainability.

---

# Files Changed
* `backend/main.py`
  * Simplified exception catching in the Supabase initialization block by removing the redundant `ImportError` from the tuple.

---

# Testing
* Build passed
* Lint passed (code compiles with zero syntax issues)
* Manual verification completed (ensured the logic remains identical to the previous implementation)

---

# Impact
* Breaking changes: No
* Performance impact: None
* Security impact: None
* Compatibility: 100% backward compatible

---

# Checklist

* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
