### PR TITLE
chore: stop tracking local cache and editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ node_modules/
 dist/
 .vercel
 *.local
+.npm-cache/
+.npm/
+.vscode/
+!.vscode/extensions.json
 
 # Docs / Artifacts
 docs/helpdesk*.pdf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/Scripts/python.exe",
-  "python.analysis.extraPaths": [
-    "${workspaceFolder}/backend"
-  ]
-}


### PR DESCRIPTION
## Summary
- remove tracked `.npm-cache` and `.vscode/settings.json` machine-local artifacts
- ignore npm cache, `.npm/`, and `.vscode/` while allowing a shared `extensions.json` later if maintainers want it

Closes #3321

## Validation
- git diff --check
- verified tracked local artifacts were removed from the index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files for local caches and editor workspace settings.
  * Kept the shared editor extensions list available while excluding other local editor configuration.
  * Removed a workspace-specific Python setup from editor settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->