### PR TITLE
fix(security): restrict CORS wildcard methods and headers

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -361,8 +361,18 @@ app.add_middleware(
         "http://localhost:3000",
     ],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=[
+        "GET",
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE",
+        "OPTIONS"
+    ],
+    allow_headers=[
+        "Authorization",
+        "Content-Type"
+    ],
 )
 
 


### PR DESCRIPTION
# Summary
This PR restricts the CORS configuration in the backend middleware to prevent wildcard usage for HTTP methods and headers when credentialed requests are enabled.

---

# Root Cause
The `CORSMiddleware` was previously configured with `allow_methods=["*"]` and `allow_headers=["*"]` alongside `allow_credentials=True`. This overly permissive setup violates the principle of least privilege, granting unnecessarily broad permissions to trusted origins and increasing the application's attack surface in the event of an origin compromise or misconfiguration.

---

# Solution
The CORS configuration was restricted to explicitly define the allowed capabilities:
- **Methods:** Restricted to `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS`.
- **Headers:** Restricted to `Authorization` and `Content-Type`.

---

# Files Changed
- `backend/main.py` - Updated `allow_methods` and `allow_headers` properties in `CORSMiddleware`.

---

# Testing
- Build passed
- Lint passed
- Tests passed (No existing functionality was broken by limiting to standard API methods/headers)
- Manual verification completed

---

# Impact
- Breaking changes: No (Unless undocumented custom headers/methods were previously relied upon)
- Performance impact: None
- Security impact: Positive (Reduces cross-origin attack surface, adheres to OWASP guidelines)
- Compatibility: High

---

# Checklist
- [x] Issue solved
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
