### PR TITLE
fix: move mobile backend URL into Expo config

### DIFF
--- a/MobileApp/app.json
+++ b/MobileApp/app.json
@@ -44,6 +44,7 @@
       "url": "https://u.expo.dev/a5830464-58a7-4737-9cc9-e5ecad2e4acf"
     },
     "extra": {
+      "backendUrl": "https://ritesh19180-ai-helpdesk-api.hf.space",
       "eas": {
         "projectId": "a5830464-58a7-4737-9cc9-e5ecad2e4acf"
       }

--- a/MobileApp/src/screens/user/AIProcessingScreen.js
+++ b/MobileApp/src/screens/user/AIProcessingScreen.js
@@ -5,6 +5,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation, useRoute } from '@react-navigation/native';
+import Constants from 'expo-constants';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import { 
@@ -14,7 +15,10 @@ import {
 import * as Haptics from 'expo-haptics';
 import axios from 'axios';
 
-const BACKEND_URL = 'https://ritesh19180-ai-helpdesk-api.hf.space';
+const BACKEND_URL =
+  Constants.expoConfig?.extra?.backendUrl ||
+  Constants.manifest2?.extra?.expoClient?.extra?.backendUrl ||
+  'https://ritesh19180-ai-helpdesk-api.hf.space';
 
 const AIProcessingScreen = () => {
   const navigation = useNavigation();


### PR DESCRIPTION
## Summary
- move the mobile AI processing backend URL into Expo `extra` config
- read the backend URL from `expo-constants` instead of hardcoding it in the screen
- keep the existing production URL as a fallback so the screen still works when config is missing

Closes #3377

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now uses a configurable backend endpoint for AI ticket analysis, making the service connection more flexible across environments.
* **Bug Fixes**
  * Improved backend request handling by adding a fallback connection path if the primary app configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->