### PR TITLE
fix(auth): apply rate limiting to authentication routes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1425,7 +1425,8 @@ class SignupBody(BaseModel):
     company: str | None = None
 
 @app.post("/auth/login")
-async def auth_login(body: LoginBody, response: Response):
+@limiter.limit("5/minute")
+async def auth_login(request: Request, body: LoginBody, response: Response):
     if not supabase:
         raise HTTPException(status_code=503, detail="Database connection offline")
     try:
@@ -1445,7 +1446,8 @@ async def auth_login(body: LoginBody, response: Response):
     return {"user": user_payload, "message": "Session cookies set"}
 
 @app.post("/auth/signup")
-async def auth_signup(body: SignupBody, response: Response):
+@limiter.limit("3/minute")
+async def auth_signup(request: Request, body: SignupBody, response: Response):
     if not supabase:
         raise HTTPException(status_code=503, detail="Database connection offline")
     metadata = {}


### PR DESCRIPTION
# Summary

This PR introduces necessary rate-limiting controls to the application's authentication endpoints (`/auth/login` and `/auth/signup`) using the existing `slowapi.Limiter` configuration. 

---

# Root Cause

The `slowapi` rate limiter was already set up and protecting AI inference routes, but critical authentication routes were lacking the `@limiter.limit` decorators. This left them vulnerable to automated brute-force attacks and credential stuffing, as there was no restriction on the number of attempts a single client could make.

---

# Solution

- Added `@limiter.limit("5/minute")` to the `POST /auth/login` endpoint.
- Added `@limiter.limit("3/minute")` to the `POST /auth/signup` endpoint.
- Injected the FastAPI `request: Request` object into the endpoint signatures, which is required by `slowapi` to determine the remote client IP.

---

# Files Changed

- `backend/main.py`
  - Modified `auth_login` to include request object and limit.
  - Modified `auth_signup` to include request object and limit.

---

# Testing

- Build passed.
- Python syntax check passed without errors.
- Manual verification completed (endpoints accept `Request` object seamlessly).

---

# Impact

- **Breaking changes:** No. The `request` object injection is handled automatically by FastAPI and does not change the external API contract.
- **Performance impact:** Negligible. Standard memory-backed sliding window evaluation.
- **Security impact:** **High Positive.** Mitigates brute force, password spraying, and automated account creation. 
- **Compatibility:** Fully compatible with existing React clients. 

---

# Checklist

- [x] Issue solved
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
