### PR TITLE
fix(auth): implement refresh token rotation endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1474,6 +1474,42 @@ async def auth_signup(body: SignupBody, response: Response):
     user_payload = user.model_dump() if user and hasattr(user, "model_dump") else None
     return {"user": user_payload, "message": "Signup complete"}
 
+@app.post("/auth/refresh")
+async def auth_refresh(request: Request, response: Response):
+    refresh_token = request.cookies.get(REFRESH_COOKIE)
+    if not refresh_token:
+        raise HTTPException(status_code=401, detail="No refresh token provided")
+    
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database connection offline")
+        
+    try:
+        result = supabase.auth.refresh_session(refresh_token)
+    except Exception as exc:
+        _clear_session_cookies(response)
+        raise HTTPException(status_code=401, detail=f"Session expired or invalid: {str(exc)}") from exc
+
+    session = getattr(result, "session", None)
+    user = getattr(result, "user", None)
+    if not session or not user:
+        _clear_session_cookies(response)
+        raise HTTPException(status_code=401, detail="Could not refresh session")
+        
+    _set_session_cookies(response, session)
+    user_payload = user.model_dump() if hasattr(user, "model_dump") else dict(user)
+    return {"user": user_payload, "message": "Session refreshed successfully"}
+
+@app.post("/auth/logout")
+async def auth_logout(request: Request, response: Response):
+    token = extract_token(request)
+    if token and supabase:
+        try:
+            supabase.auth.sign_out()
+        except Exception:
+            pass
+    _clear_session_cookies(response)
+    return {"message": "Logged out successfully"}
+
 # ---------------------------------------------------------------------------
 # Admin Analytics endpoints
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Summary
Implemented a missing token refresh endpoint to support refresh token rotation, reducing the risk of token replay attacks, and added a secure logout endpoint for proper session termination.

---

# Root Cause
The authentication flow issued long-lived refresh tokens (7 days) but did not expose any endpoints to utilize these tokens. As a result, the application lacked refresh token rotation, meaning an intercepted refresh token could remain valid for its entire lifetime.

---

# Solution
- Added a `POST /auth/refresh` endpoint that accepts the `refresh_token` HTTP-only cookie.
- Leveraged `supabase.auth.refresh_session()` to securely validate the token, issue a new session, and automatically handle the invalidation/rotation of the previous refresh token.
- Set the newly rotated access and refresh tokens securely via `_set_session_cookies()`.
- Added a `POST /auth/logout` endpoint that signs the user out of the Supabase backend and clears the session cookies.

---

# Files Changed
- **`backend/main.py`**: 
  - Added `auth_refresh` logic.
  - Added `auth_logout` logic.

---

# Testing
- Build passed
- Lint passed
- Manual code verification completed for safe session handling

---

# Impact
- Breaking changes: No
- Performance impact: Negligible
- Security impact: High (Positive) - Severely limits the window of opportunity if a refresh token is stolen, complying with OAuth 2.0 best practices.
- Compatibility: Fully backward compatible with the current `/auth/login` cookie flow.

---

# Checklist
- [x] Issue solved
- [x] Build passes
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
