### PR TITLE
Feature/issue 3380 tickets db persistence

### DIFF
--- a/backend/routers/tickets.py
+++ b/backend/routers/tickets.py
@@ -2,15 +2,45 @@
 import logging
 import hashlib
 import traceback
+from pydantic import BaseModel
 from fastapi import APIRouter, Depends, HTTPException
 from backend.auth_cookie import get_current_user
 from backend.dependencies import supabase, duplicate_service
-from backend.models import TicketSaveRequest, TicketRecord, TICKETS_DB
+from backend.schemas import TicketSaveRequest
 from backend.sanitization import sanitize_ticket_data
+
+# NOTE (Issue #3212 -> #3380): `TicketRecord` / `TICKETS_DB` previously
+# imported from `backend.models` did not exist anywhere in this codebase.
+# Issue #3212 temporarily stubbed them locally just to restore importability.
+# Issue #3380 replaces that stub entirely: the legacy in-memory endpoints
+# below (POST /tickets, PATCH /tickets/{id}) now persist to Supabase via the
+# same tested helpers used elsewhere in the app, instead of mutating a
+# process-local list that is not thread-safe and is wiped on every restart.
+from backend.services.supabase_utils import (
+    create_ticket as _supabase_create_ticket,
+    update_ticket as _supabase_update_ticket,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
+
+
+def _rollback_ticket_insert(ticket_id, log) -> bool:
+    """
+    Compensating rollback (Issue #3212): supabase-py has no native multi-table
+    transaction support, so a failure in a step AFTER the initial `tickets`
+    row insert (categorization/duplicate indexing, or the initial system
+    message) must be compensated for manually, or the ticket row is left as
+    an orphaned, inconsistent record with no messages/indexing.
+    """
+    try:
+        supabase.table("tickets").delete().eq("id", ticket_id).execute()
+        log.warning(f"Rolled back ticket insert for ticket_id={ticket_id} after downstream failure.")
+        return True
+    except Exception as rollback_error:
+        log.error(f"CRITICAL: Failed to roll back orphaned ticket_id={ticket_id}: {rollback_error}")
+        return False
 @router.get("")
 async def get_tickets(company_id: str | None = None, user: dict = Depends(get_current_user)):
     """Fetch persistent tickets from Supabase."""
@@ -128,46 +158,58 @@ async def save_ticket(request_body: TicketSaveRequest, user: dict = Depends(get_
             
         ticket_id = res.data[0]["id"]
 
-        duplicate_indexed = True
-        duplicate_index_warning = None
-        description_text = (request_body.description or "").strip()
-        subject_text = (request_body.subject or "").strip()
-        duplicate_text = description_text or subject_text
-        if duplicate_text:
-            try:
+        # Everything below this point has already written the `tickets` row.
+        # Issue #3212: if any of these subsequent steps fail, that row must
+        # be rolled back (deleted) rather than left as an orphaned record
+        # with no categorization index and no initial message.
+        try:
+            duplicate_indexed = True
+            duplicate_index_warning = None
+            description_text = (request_body.description or "").strip()
+            subject_text = (request_body.subject or "").strip()
+            duplicate_text = description_text or subject_text
+            if duplicate_text:
                 duplicate_service.add_ticket(str(ticket_id), duplicate_text)
                 try:
                     from backend.services.jaccard_duplicate_filter import jaccard_filter
                     jaccard_filter.add_ticket(str(ticket_id), duplicate_text)
                 except Exception as jf_add_err:
+                    # Auxiliary/secondary duplicate signal - soft-fail on its own,
+                    # unlike the primary duplicate_service call above.
                     logger.warning(f"Failed to add ticket to Jaccard filter: {jf_add_err}")
-            except Exception as index_error:
+            else:
                 duplicate_indexed = False
-                duplicate_index_warning = "Duplicate index update failed."
-                print(f"[WARNING] {duplicate_index_warning} ticket_id={ticket_id} error={index_error}")
-        else:
-            duplicate_indexed = False
-            duplicate_index_warning = "Duplicate index update skipped: no description or subject text was provided."
-            print(f"[WARNING] {duplicate_index_warning}")
-        
-        # Add initial system diagnostic message
-        msg = "Our Neural Engine has successfully triaged your issue and routed it to the designated team."
-        if final_data["auto_resolve"]:
-            msg = "AI Auto-Resolution active: A verified solution has been identified. Please review the attached resolution steps."
+                duplicate_index_warning = "Duplicate index update skipped: no description or subject text was provided."
+                print(f"[WARNING] {duplicate_index_warning}")
 
-        supabase.table("ticket_messages").insert({
-            "ticket_id": ticket_id,
-            "sender_id": "00000000-0000-0000-0000-000000000000", # System ID
-            "sender_name": "AI Assistant",
-            "sender_role": "admin",
-            "message": msg
-        }).execute()
-        
+            # Add initial system diagnostic message
+            msg = "Our Neural Engine has successfully triaged your issue and routed it to the designated team."
+            if final_data["auto_resolve"]:
+                msg = "AI Auto-Resolution active: A verified solution has been identified. Please review the attached resolution steps."
+
+            supabase.table("ticket_messages").insert({
+                "ticket_id": ticket_id,
+                "sender_id": "00000000-0000-0000-0000-000000000000", # System ID
+                "sender_name": "AI Assistant",
+                "sender_role": "admin",
+                "message": msg
+            }).execute()
+
+        except Exception as post_insert_error:
+            logger.error(f"Post-insert step failed for ticket_id={ticket_id}: {post_insert_error}")
+            _rollback_ticket_insert(ticket_id, logger)
+            raise HTTPException(
+                status_code=500,
+                detail="Failed to fully create ticket; the operation was rolled back. Please try again."
+            ) from post_insert_error
+
         response = {"status": "success", "ticket_id": ticket_id, "duplicate_indexed": duplicate_indexed}
         if duplicate_index_warning:
             response["duplicate_index_warning"] = duplicate_index_warning
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         traceback.print_exc()
         logger.error("Failed to create ticket", exc_info=e)
@@ -185,33 +227,47 @@ async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user
     return res.data
 
 
-@router.post("", response_model=TicketRecord)
-async def create_ticket(ticket: TicketRecord, user: dict = Depends(get_current_user)):
-    """Save a new ticket into the system."""
-    ticket_dict = sanitize_ticket_data(ticket.dict())
-    ticket = TicketRecord(**ticket_dict)
-    # Check for duplicates before adding
-    existing = next((t for t in TICKETS_DB if t.ticket_id == ticket.ticket_id), None)
-    if existing:
-        return existing
-        
-    TICKETS_DB.append(ticket)
-    print(f"[DB] Ticket #{ticket.ticket_id} created for user {ticket.owner_id}")
-    return ticket
+@router.post("")
+async def create_ticket(ticket: dict, user: dict = Depends(get_current_user)):
+    """
+    Persist a new ticket (Issue #3380).
+
+    Previously appended to an in-memory `TICKETS_DB` list - not thread-safe,
+    and every ticket created through this endpoint was silently lost on the
+    next restart/redeploy. Now delegates to the same tested Supabase
+    persistence layer (backend.services.supabase_utils) used elsewhere.
+
+    Accepts a generic dict body rather than the old rigid TicketRecord
+    schema (summary/owner_id/timeline/...) - no real caller of this endpoint
+    was found using that schema; field names should match the actual
+    `tickets` table columns (see POST /tickets/save for the canonical shape
+    used by the rest of the app).
+    """
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
+    sanitized = sanitize_ticket_data(ticket)
+    created = _supabase_create_ticket(supabase, sanitized)
+    if not created:
+        raise HTTPException(status_code=500, detail="Failed to create ticket.")
+    return created
 
 
-@router.patch("/{ticket_id}", response_model=TicketRecord)
+@router.patch("/{ticket_id}")
 async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
-    """Partially update a ticket's fields (e.g., status, viewed_at)."""
+    """
+    Partially update a ticket's fields (Issue #3380).
+
+    Previously mutated an in-memory `TICKETS_DB` list - now persists via
+    Supabase directly, matching the real `tickets` table used everywhere
+    else in the app.
+    """
+    if not supabase:
+        raise HTTPException(status_code=500, detail="Database connection not initialized")
+
     sanitized_updates = sanitize_ticket_data(updates)
-    for i, ticket in enumerate(TICKETS_DB):
-        if str(ticket.ticket_id) == str(ticket_id):
-            # Convert to dict, update, then back to model
-            ticket_dict = ticket.dict()
-            ticket_dict.update(sanitized_updates)
-            updated_ticket = TicketRecord(**ticket_dict)
-            TICKETS_DB[i] = updated_ticket
-            return updated_ticket
-    
-    raise HTTPException(status_code=404, detail="Ticket not found")
+    updated = _supabase_update_ticket(supabase, ticket_id, sanitized_updates)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return updated
 

--- a/backend/tests/test_ticket_creation_rollback.py
+++ b/backend/tests/test_ticket_creation_rollback.py
@@ -1,0 +1,281 @@
+"""
+Tests for transactional rollback behavior in POST /tickets/save (Issue #3212).
+
+Asserts that if a step occurring AFTER the initial `tickets` row insert fails
+(the duplicate/categorization indexing step, or the initial system message
+insert), the ticket row is rolled back (deleted) rather than left as an
+orphaned, inconsistent record - and the endpoint returns a 500 rather than a
+partial success.
+"""
+import sys
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import main
+from main import app, get_current_user
+from fastapi.testclient import TestClient
+
+client = TestClient(app)
+
+MOCK_USER = {
+    "id": "test-user-id-123",
+    "email": "test@example.com",
+    "user_metadata": {
+        "company_id": "test-company-id",
+        "company": "Test Company",
+        "role": "admin",
+    },
+}
+
+VALID_TICKET_PAYLOAD = {
+    "user_id": "test-user-id-123",
+    "subject": "Printer not working",
+    "description": "The office printer on floor 3 is jammed and will not print.",
+    "category": "Hardware",
+    "subcategory": "Printer",
+    "priority": "medium",
+    "assigned_team": "IT Support",
+    "status": "open",
+    "auto_resolve": False,
+    "is_duplicate": False,
+    "confidence": 0.92,
+    "sla_breach_at": "2026-07-05T00:00:00Z",
+    "metadata": {},
+    "routing_confidence": 0.9,
+}
+
+
+def mock_get_current_user():
+    return MOCK_USER
+
+
+@pytest.fixture(autouse=True)
+def override_auth():
+    app.dependency_overrides[get_current_user] = mock_get_current_user
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+class FakeSupabaseChain:
+    """
+    Minimal fluent-chain fake for supabase-py's table().insert()/.select()/
+    .delete().eq().execute() calls, configurable per table name so tests can
+    simulate an insert into `tickets` succeeding while a later insert into
+    `ticket_messages` (or the duplicate/categorization step) fails.
+    """
+
+    def __init__(self, table_name, responses, on_delete=None):
+        self.table_name = table_name
+        self._responses = responses
+        self._on_delete = on_delete
+        self._pending_op = None
+        self._is_single = False
+
+    def select(self, *a, **kw):
+        self._pending_op = "select"
+        return self
+
+    def insert(self, payload, *a, **kw):
+        self._pending_op = "insert"
+        self._payload = payload
+        return self
+
+    def delete(self, *a, **kw):
+        self._pending_op = "delete"
+        return self
+
+    def eq(self, *a, **kw):
+        return self
+
+    def single(self, *a, **kw):
+        self._is_single = True
+        return self
+
+    def order(self, *a, **kw):
+        return self
+
+    def execute(self):
+        if self._pending_op == "delete":
+            if self._on_delete:
+                self._on_delete(self.table_name)
+            result = MagicMock()
+            result.data = []
+            return result
+
+        response = self._responses.get(self.table_name)
+        if isinstance(response, Exception):
+            raise response
+
+        data = response
+        if self._is_single and isinstance(data, list):
+            data = data[0] if data else None
+
+        result = MagicMock()
+        result.data = data
+        return result
+
+
+def make_fake_supabase(responses, on_delete=None):
+    """responses: dict of table_name -> data (or an Exception instance to raise on execute())."""
+    fake = MagicMock()
+
+    def table_side_effect(table_name):
+        return FakeSupabaseChain(table_name, responses, on_delete=on_delete)
+
+    fake.table.side_effect = table_side_effect
+    return fake
+
+
+DEFAULT_PROFILE = [{"company_id": "test-company-id", "company": "Test Company"}]
+DEFAULT_TICKET_INSERT_RESULT = [{"id": "ticket-abc-123", **VALID_TICKET_PAYLOAD}]
+
+
+class TestTicketCreationRollback:
+    """Covers compensating rollback when a post-insert step fails."""
+
+    def test_happy_path_no_rollback(self):
+        """Successful creation never touches delete()."""
+        deleted_tables = []
+        fake_supabase = make_fake_supabase(
+            responses={
+                "profiles": DEFAULT_PROFILE,
+                "tickets": DEFAULT_TICKET_INSERT_RESULT,
+                "ticket_messages": [{"id": "msg-1"}],
+            },
+            on_delete=lambda table: deleted_tables.append(table),
+        )
+
+        with patch("backend.routers.tickets.supabase", fake_supabase), \
+             patch("backend.routers.tickets.duplicate_service") as fake_dup:
+            fake_dup.add_ticket.return_value = None
+            response = client.post(
+                "/tickets/save",
+                json=VALID_TICKET_PAYLOAD,
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+        assert deleted_tables == []
+
+    def test_rollback_when_categorization_indexing_fails(self):
+        """
+        If the categorization/duplicate-indexing step raises, the ticket row
+        that was already inserted must be rolled back (deleted), and the
+        endpoint must return a 500 rather than a partial success.
+        """
+        deleted_tables = []
+        fake_supabase = make_fake_supabase(
+            responses={
+                "profiles": DEFAULT_PROFILE,
+                "tickets": DEFAULT_TICKET_INSERT_RESULT,
+                "ticket_messages": [{"id": "msg-1"}],
+            },
+            on_delete=lambda table: deleted_tables.append(table),
+        )
+
+        with patch("backend.routers.tickets.supabase", fake_supabase), \
+             patch("backend.routers.tickets.duplicate_service") as fake_dup:
+            fake_dup.add_ticket.side_effect = RuntimeError("categorization model unavailable")
+            response = client.post(
+                "/tickets/save",
+                json=VALID_TICKET_PAYLOAD,
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+        assert response.status_code == 500
+        assert "roll" in response.json()["detail"].lower()
+        assert deleted_tables == ["tickets"], (
+            "Expected the orphaned ticket row to be rolled back via a delete() "
+            "on the tickets table"
+        )
+
+    def test_rollback_when_system_message_insert_fails(self):
+        """
+        If writing the initial system diagnostic message fails after the
+        ticket row was inserted, the ticket row must be rolled back too.
+        """
+        deleted_tables = []
+        fake_supabase = make_fake_supabase(
+            responses={
+                "profiles": DEFAULT_PROFILE,
+                "tickets": DEFAULT_TICKET_INSERT_RESULT,
+                "ticket_messages": RuntimeError("db connection dropped"),
+            },
+            on_delete=lambda table: deleted_tables.append(table),
+        )
+
+        with patch("backend.routers.tickets.supabase", fake_supabase), \
+             patch("backend.routers.tickets.duplicate_service") as fake_dup:
+            fake_dup.add_ticket.return_value = None
+            response = client.post(
+                "/tickets/save",
+                json=VALID_TICKET_PAYLOAD,
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+        assert response.status_code == 500
+        assert deleted_tables == ["tickets"]
+
+    def test_rollback_failure_is_logged_but_still_returns_500(self):
+        """
+        If the compensating delete() ITSELF fails (e.g. DB is genuinely down),
+        the endpoint must still surface a 500 rather than crash uncaught -
+        this is the worst case (an orphaned record persists) but the API
+        contract must remain intact.
+        """
+        def raise_on_delete(table):
+            raise RuntimeError("delete also failed")
+
+        fake_supabase = make_fake_supabase(
+            responses={
+                "profiles": DEFAULT_PROFILE,
+                "tickets": DEFAULT_TICKET_INSERT_RESULT,
+                "ticket_messages": RuntimeError("db connection dropped"),
+            },
+            on_delete=raise_on_delete,
+        )
+
+        with patch("backend.routers.tickets.supabase", fake_supabase), \
+             patch("backend.routers.tickets.duplicate_service") as fake_dup:
+            fake_dup.add_ticket.return_value = None
+            response = client.post(
+                "/tickets/save",
+                json=VALID_TICKET_PAYLOAD,
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+        assert response.status_code == 500
+
+    def test_duplicate_text_empty_skips_indexing_without_rollback(self):
+        """
+        A ticket with no subject/description text should skip indexing
+        gracefully (existing soft-skip behavior) and NOT trigger a rollback -
+        this is a deliberate no-op, not a failure.
+        """
+        deleted_tables = []
+        payload = {**VALID_TICKET_PAYLOAD, "subject": "", "description": ""}
+        fake_supabase = make_fake_supabase(
+            responses={
+                "profiles": DEFAULT_PROFILE,
+                "tickets": DEFAULT_TICKET_INSERT_RESULT,
+                "ticket_messages": [{"id": "msg-1"}],
+            },
+            on_delete=lambda table: deleted_tables.append(table),
+        )
+
+        with patch("backend.routers.tickets.supabase", fake_supabase), \
+             patch("backend.routers.tickets.duplicate_service") as fake_dup:
+            response = client.post(
+                "/tickets/save",
+                json=payload,
+                headers={"Authorization": "Bearer test-token"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["duplicate_indexed"] is False
+        assert deleted_tables == []
+        fake_dup.add_ticket.assert_not_called()


### PR DESCRIPTION
## Summary

This PR fixes two related backend issues in `backend/routers/tickets.py`:

- **Fixes #3212** — Ticket creation had no rollback safety: if a step after the initial `tickets` row insert failed (categorization/duplicate indexing, or writing the initial system message), the ticket row was left behind as an orphaned, inconsistent record with no compensating cleanup.
- **Fixes #3380** — `POST /tickets` and `PATCH /tickets/{ticket_id}` were reading/writing an in-memory `TICKETS_DB` Python list instead of the database. This is not thread-safe under concurrent requests and is wiped completely on every restart/redeploy - any ticket created through these two endpoints was silently and permanently lost outside the current process.

These are bundled in one PR because fixing #3380 properly required first fixing a blocking import bug in the same function that #3212 also needed resolved (see below) - splitting them would mean one PR breaks without the other.

## Blocking bug fixed along the way

`backend/routers/tickets.py` had:
```python
from backend.models import TicketSaveRequest, TicketRecord, TICKETS_DB
```
`backend/models` is an empty package (just a docstring) - none of these three names are exported from it. `TicketSaveRequest` actually lives in `backend/schemas.py`. `TicketRecord`/`TICKETS_DB` don't exist **anywhere** in the codebase. This meant the module - and therefore the whole app - could not be imported at all prior to this PR.

## Changes

**`backend/routers/tickets.py`**
- Fixed the import: `TicketSaveRequest` now correctly comes from `backend.schemas`.
- `save_ticket()`: post-insert steps (duplicate/categorization indexing via `duplicate_service`, the Jaccard filter, and the initial system message insert) are now wrapped in a try/except. On any failure, a new `_rollback_ticket_insert()` helper deletes the orphaned `tickets` row before raising a 500, instead of silently leaving a broken half-created ticket. Also added `except HTTPException: raise` before the outer generic exception handler so deliberate HTTPExceptions (403/404/503/500) aren't swallowed and rewritten into a generic 500.
- `create_ticket()` (`POST /tickets`) and `update_ticket()` (`PATCH /tickets/{id}`): rewritten to persist through `backend.services.supabase_utils.create_ticket()` / `update_ticket()` - the same tested Supabase persistence layer already used elsewhere in the app - instead of mutating an in-memory list.
  - These two endpoints now accept a generic `dict` body instead of the old rigid `TicketRecord` schema (`summary`/`owner_id`/`timeline`/`messages`). I searched the entire frontend, mobile app, and backend for real callers of these two endpoints and found none - the app's actual ticket-creation flow goes through `POST /tickets/save`. Preserving the old schema would mean guessing at a contract nothing currently uses; a generic dict matching the real `tickets` table columns (same shape as `/tickets/save`) is simpler and correct.

**`backend/tests/test_ticket_creation_rollback.py`** (new)
- `test_happy_path_no_rollback` - successful creation never triggers a delete.
- `test_rollback_when_categorization_indexing_fails` - duplicate/categorization indexing failure rolls back the ticket row and returns 500.
- `test_rollback_when_system_message_insert_fails` - system message insert failure rolls back the ticket row.
- `test_rollback_failure_is_logged_but_still_returns_500` - if the compensating delete itself fails, the endpoint still returns 500 rather than crashing uncaught.
- `test_duplicate_text_empty_skips_indexing_without_rollback` - confirms the existing soft-skip behavior (no subject/description text) is a deliberate no-op, not a failure path.

## Testing done
- `python3 -m py_compile backend/routers/tickets.py` - clean.
- Verified the module now imports successfully (previously failed with `ImportError`).
- Ran the new rollback test suite locally against a mocked Supabase client covering all five scenarios above.

## Out of scope / not included in this PR
- `backend/logger.py` is currently broken on `gssoc` HEAD with an unrelated `SyntaxError` (from a bad "conflict-free" auto-merge, commit `e1919ee9`). This blocks the backend from starting at all right now, independent of this PR. I patched around it locally only to be able to test this change, but did **not** include that fix here since it's unrelated - happy to open a separate PR for it if useful.
- No frontend changes were needed; no real caller of `POST /tickets`/`PATCH /tickets/{id}` was found in the app.