### PR TITLE
Feature/issue 3390 request logging middleware

### DIFF
--- a/backend/middleware/request_logging.py
+++ b/backend/middleware/request_logging.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Applies changes for GitHub issue #3390 (missing structured request/response
+logging middleware). Run from the ROOT of your HELPDESK.AI repo:
+
+    python3 apply_request_logging_middleware.py
+
+It creates:
+  - backend/middleware/request_logging.py
+
+And edits:
+  - main.py   (wires up RequestLoggingMiddleware + the existing, previously
+               unwired RequestIDMiddleware from backend/middleware/request_id.py)
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(".").resolve()
+
+
+def replace_once(path: Path, old: str, new: str, label: str) -> bool:
+    if not path.exists():
+        print(f"[SKIP] {label}: file not found at {path}")
+        return False
+    text = path.read_text(encoding="utf-8")
+    count = text.count(old)
+    if count == 0:
+        print(f"[FAIL] {label}: anchor text not found in {path}. No changes made for this edit.")
+        return False
+    if count > 1:
+        print(f"[WARN] {label}: anchor text found {count} times in {path}; replacing the FIRST occurrence only.")
+        text = text.replace(old, new, 1)
+    else:
+        text = text.replace(old, new)
+    path.write_text(text, encoding="utf-8")
+    print(f"[OK]   {label}: applied to {path}")
+    return True
+
+
+def write_new_file(path: Path, content: str, label: str) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        print(f"[SKIP] {label}: {path} already exists, not overwriting.")
+        return False
+    path.write_text(content, encoding="utf-8")
+    print(f"[OK]   {label}: created {path}")
+    return True
+
+
+REQUEST_LOGGING_MIDDLEWARE_CONTENT = '''"""
+Structured Request/Response Logging Middleware (Issue #3390).
+
+Logs every request/response cycle as a single structured JSON log line via
+backend.logger's JSONFormatter, replacing the scattered print() statements
+used throughout individual handlers for this purpose.
+
+Usage in main.py - ordering matters (see add_request_logging_middleware()
+docstring below):
+
+    from backend.middleware.request_logging import add_request_logging_middleware
+    from backend.middleware.request_id import add_request_id_middleware
+    add_request_logging_middleware(app)
+    add_request_id_middleware(app)
+"""
+
+import logging
+import time
+
+from fastapi import FastAPI, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from backend.middleware.request_id import get_request_id
+
+logger = logging.getLogger("backend.request")
+
+
+def _client_ip(request: Request) -> str:
+    """
+    Prefer a proxy-forwarded IP if present (common behind nginx/load
+    balancers/CDNs), falling back to the direct connection IP.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """
+    Emits one structured JSON log entry per request, containing the metadata
+    called for in Issue #3390: HTTP method, path, status code, latency,
+    client IP, and a correlation/request ID.
+
+    Deliberately does NOT log headers, query params, or body content, since
+    those routinely carry credentials/PII (Authorization headers, tokens,
+    cookies, form data, API keys) - omitting them entirely is safer than
+    maintaining a masking list that could miss something.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.perf_counter()
+        request_id = get_request_id(request)
+        client_ip = _client_ip(request)
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = round((time.perf_counter() - start) * 1000, 2)
+            logger.exception(
+                "Unhandled exception during request",
+                extra={"context": {
+                    "request_id": request_id,
+                    "method": request.method,
+                    "path": request.url.path,
+                    "client_ip": client_ip,
+                    "latency_ms": duration_ms,
+                    "status_code": 500,
+                }},
+            )
+            raise
+
+        duration_ms = round((time.perf_counter() - start) * 1000, 2)
+        log_level = logging.WARNING if response.status_code >= 400 else logging.INFO
+        logger.log(
+            log_level,
+            "request handled",
+            extra={"context": {
+                "request_id": request_id,
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "latency_ms": duration_ms,
+                "client_ip": client_ip,
+            }},
+        )
+        response.headers["X-Response-Time-Ms"] = str(duration_ms)
+        return response
+
+
+def add_request_logging_middleware(app: FastAPI) -> None:
+    """
+    Attach RequestLoggingMiddleware to the FastAPI app.
+
+    IMPORTANT ordering: call this BEFORE add_request_id_middleware(app).
+    Starlette wraps middleware so the LAST one added ends up OUTERMOST
+    (runs first on the way in, last on the way out) - RequestIDMiddleware
+    needs to run first so request.state.request_id is already set by the
+    time this middleware reads it via get_request_id().
+    """
+    app.add_middleware(RequestLoggingMiddleware)
+'''
+
+
+def main():
+    ok_count = 0
+    total = 0
+
+    # -------------------------------------------------------------
+    # New file: the middleware itself
+    # -------------------------------------------------------------
+    total += 1
+    ok_count += write_new_file(
+        ROOT / "backend" / "middleware" / "request_logging.py",
+        REQUEST_LOGGING_MIDDLEWARE_CONTENT,
+        label="create backend/middleware/request_logging.py",
+    )
+
+    # -------------------------------------------------------------
+    # main.py: wire up both RequestLoggingMiddleware AND the existing,
+    # previously-unwired RequestIDMiddleware.
+    # -------------------------------------------------------------
+    main_py = ROOT / "main.py"
+
+    total += 1
+    ok_count += replace_once(
+        main_py,
+        old="""app.add_middleware(PayloadLimitMiddleware)
+app.add_middleware(CSRFTokenMiddleware)
+app.include_router(metrics_router.router)""",
+        new="""app.add_middleware(PayloadLimitMiddleware)
+app.add_middleware(CSRFTokenMiddleware)
+
+# Issue #3390: centralized structured request/response logging, replacing
+# scattered print() statements. Ordering matters here - RequestIDMiddleware
+# must be added AFTER (so it becomes the outer layer and sets
+# request.state.request_id before RequestLoggingMiddleware reads it).
+# RequestIDMiddleware already existed in backend/middleware/request_id.py
+# but was never actually wired into the app.
+from backend.middleware.request_logging import add_request_logging_middleware
+from backend.middleware.request_id import add_request_id_middleware
+add_request_logging_middleware(app)
+add_request_id_middleware(app)
+
+app.include_router(metrics_router.router)""",
+        label="main.py: wire up request logging + request ID middleware",
+    )
+
+    print()
+    print(f"Applied {ok_count}/{total} changes successfully.")
+    if ok_count != total:
+        print("Some changes FAILED - see [FAIL]/[SKIP] lines above.")
+        sys.exit(1)
+    else:
+        print("All changes applied. Run `git status` and `git diff` to review before committing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -26,8 +26,19 @@ app.add_middleware(SecurityHeadersMiddleware)
 app.include_router(upload_router.router)
 app.add_middleware(PayloadLimitMiddleware)
 app.add_middleware(CSRFTokenMiddleware)
-app.include_router(metrics_router.router)
 
+# Issue #3390: centralized structured request/response logging, replacing
+# scattered print() statements. Ordering matters here - RequestIDMiddleware
+# must be added AFTER (so it becomes the outer layer and sets
+# request.state.request_id before RequestLoggingMiddleware reads it).
+# RequestIDMiddleware already existed in backend/middleware/request_id.py
+# but was never actually wired into the app.
+from backend.middleware.request_logging import add_request_logging_middleware
+from backend.middleware.request_id import add_request_id_middleware
+add_request_logging_middleware(app)
+add_request_id_middleware(app)
+
+app.include_router(metrics_router.router)
 from backend.config import settings
 
 # Initialize Supabase client


### PR DESCRIPTION
## Summary

Fixes #3390 — adds centralized, structured request/response logging middleware so every request produces one consistent JSON log line, instead of the scattered `print()` statements used throughout individual handlers.

## What's included

**`backend/middleware/request_logging.py` (new)**
- `RequestLoggingMiddleware` — wraps every request/response cycle and emits a single structured JSON log entry (via `backend.logger`'s `JSONFormatter`) containing:
  - `method`, `path`, `status_code`, `latency_ms`, `client_ip`, `request_id`
- Logs at `INFO` for successful requests, `WARNING` for 4xx/5xx responses, and `ERROR` (with full traceback) if an unhandled exception propagates out of the route handler - still re-raises afterward so existing exception handling behavior is unchanged.
- Adds an `X-Response-Time-Ms` response header as a bonus (visible to clients/monitoring, not just logs).
- **Sensitive data handling:** deliberately does **not** log headers, query params, or request/response bodies at all, rather than trying to maintain a masking list for `Authorization`/`Cookie`/API keys/tokens that could miss something in the future. Exclusion by design is safer than an incomplete allow/deny list.

**`main.py`**
- Wires up `RequestLoggingMiddleware`.
- Also wires up `RequestIDMiddleware` (`backend/middleware/request_id.py`) - this already existed, fully implemented, but was **never actually registered** with the FastAPI app. `RequestLoggingMiddleware` depends on it for the `request_id` field, so I connected both.
- Middleware registration order matters: Starlette wraps middleware so the *last*-added one runs *first* on the way in. `RequestIDMiddleware` is added after `RequestLoggingMiddleware` so it becomes the outer layer, setting `request.state.request_id` before the logging middleware reads it. This is documented in both files' docstrings.

## Testing done

Since `main.py` currently fails to import on `gssoc` for reasons entirely unrelated to this change (see note below), I verified the middleware in isolation: built a standalone FastAPI app with both middlewares wired up the same way as `main.py`, and drove it with `TestClient`.

Confirmed:
- `X-Request-ID` and `X-Response-Time-Ms` headers present on every response
- A successful `GET` produces a structured `INFO` log with all expected fields
- A route that raises produces a structured `ERROR` log with the full traceback and the same context fields (`request_id`, `method`, `path`, `client_ip`, `latency_ms`), and the response still correctly returns `500`

## Note for reviewers - pre-existing, unrelated breakage

`main.py` also does `from backend.payload_middleware import PayloadLimitMiddleware`, but `backend/payload_middleware.py` does not exist anywhere in this repository. This blocks `main.py` from importing at all, independent of this PR - it's the same category of issue as the broken `backend.models` exports and the `backend/logger.py` syntax error found while working on #3212/#3380/#3214. Not fixed here since it's out of scope for this issue; flagging so CI failures unrelated to this diff aren't mistaken for something this PR broke.



Note for reviewers: `Backend CI / Backend Lint (ruff)` and `Unified CI / Backend (ruff + pytest)` are failing due to pre-existing syntax errors in `backend/database.py` (an invalid `try`/`else` with no `except`) and `backend/logger.py` (unterminated string literal), both unrelated to this diff - this PR only touches `main.py` and the new `backend/middleware/request_logging.py`. These are part of a broader pattern of independent breakage on `gssoc` I've been tracking across a few PRs; happy to file a consolidated bug report if useful.