### PR TITLE
security: add global exception handler to prevent error leakage

### DIFF
--- a/backend/tests/test_global_exception_handler.py
+++ b/backend/tests/test_global_exception_handler.py
@@ -1,0 +1,58 @@
+"""
+Tests for the application-wide global exception handler.
+
+The handler converts any unhandled exception into a generic, leak-free 500
+JSON response while logging the real traceback server-side with a correlation
+``error_id``. This prevents internal error details (file paths, stack frames,
+secret values) from leaking to API clients.
+"""
+import os
+
+# Allow the app to import without models / real Supabase credentials.
+os.environ.setdefault("ALLOW_DEGRADED_STARTUP", "1")
+os.environ.setdefault("SUPABASE_URL", "https://placeholder.supabase.co")
+os.environ.setdefault("SUPABASE_SERVICE_KEY", "placeholder_key")
+
+from fastapi.testclient import TestClient
+
+from main import app
+from backend.auth.tenant_middleware import security_manager
+
+
+def _raise_unhandled():
+    # Simulates an unexpected runtime failure inside a dependency.
+    raise RuntimeError("SECRET-INTERNAL-DETAIL-MUST-NOT-LEAK")
+
+
+def test_global_exception_handler_sanitizes_500():
+    """An unhandled exception must become a generic, leak-free 500."""
+    app.dependency_overrides[security_manager.get_current_user_profile] = _raise_unhandled
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/tickets")
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body.get("status") == "error"
+        assert body.get("error_id")
+        # Internal exception details must never reach the client.
+        assert "SECRET-INTERNAL-DETAIL-MUST-NOT-LEAK" not in resp.text
+        assert "Traceback" not in resp.text
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_public_health_still_200():
+    """Registering the handler must not break normal routes."""
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json().get("status") == "ok"
+
+
+def test_explicit_http_exceptions_are_preserved():
+    """Intentional HTTPException details remain available to clients."""
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/api/security/audit")
+    # No auth -> 401/403 from the dependency, not a generic 500.
+    assert resp.status_code in (401, 403)
+    assert resp.status_code != 500

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from fastapi import FastAPI, Request, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html
@@ -61,6 +62,37 @@ app.include_router(weekly_digest.router)
 async def health_check():
     """Public health / readiness probe — no authentication required."""
     return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Global exception handler (prevents internal error leakage)
+# ---------------------------------------------------------------------------
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    """Return a sanitized 500 response for any unhandled exception.
+
+    The real traceback is logged server-side with a correlation ``error_id``
+    so operators can investigate without exposing implementation details to
+    clients (closes the "error leakage" gap flagged for admin.py).
+    """
+    error_id = uuid.uuid4().hex
+    logger.error(
+        "Unhandled exception [%s] on %s %s: %s",
+        error_id,
+        request.method,
+        request.url.path,
+        exc,
+        exc_info=True,
+    )
+    return JSONResponse(
+        status_code=500,
+        content={
+            "status": "error",
+            "message": "An unexpected internal error occurred. The incident has been logged.",
+            "error_id": error_id,
+        },
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Adds a centralized global exception handler to the FastAPI app (`main.py`, root) so that any unhandled exception returns a generic, leak-free `500` JSON response instead of exposing stack traces / internal details to clients.

## Why
Closes the app-wide "error leakage" gap (previously flagged for `admin.py` in #2884 but never applied globally). Leaking tracebacks aids attackers and harms operator trust.

## How
- `@app.exception_handler(Exception)` logs the real traceback server-side with a correlation `error_id` and returns `{status, message, error_id}`.
- Intentional `HTTPException`s (e.g. `403 Admins only`, `403 User ID spoofing detected`) are preserved — only unexpected `Exception`s are sanitized.
- Adds `backend/tests/test_global_exception_handler.py` (sanitized 500, health still 200, HTTP exceptions preserved).

## Verification
- New test file passes `ruff check backend/`.
- Handler behavior verified via FastAPI `TestClient` (`raise_server_exceptions=False`): unhandled `RuntimeError` -> `500` with no leakage; `/health` -> `200`; `/api/security/audit` without auth -> `401/403`.
- Line endings normalized to LF to keep the diff focused.

## Notes
- Targets the `gssoc` branch per CONTRIBUTING.md.
- Out of scope: a latent `create_client` NameError at `main.py:38` (only triggers when Supabase init runs with real creds and `ALLOW_DEGRADED_STARTUP` off) — flagged separately.
