### PR TITLE
Feature/ssl auto renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,16 @@ npm install
 npm run dev
 ```
 
+### SSL/TLS Certificate Auto-Renewal
+For production deployments, ensure SSL/TLS certificates are auto-renewed. We provide a helper script for `certbot`:
+```bash
+sudo ./scripts/ssl_auto_renew.sh
+```
+You can add this script to your crontab to run periodically (e.g., weekly) for fully automated renewals:
+```bash
+0 0 * * 0 /path/to/HELPDESK.AI/scripts/ssl_auto_renew.sh >> /var/log/ssl_renew.log 2>&1
+```
+
 ---
 
 <h2 id="roadmap">🗺️ Roadmap</h2>

--- a/scripts/ssl_auto_renew.sh
+++ b/scripts/ssl_auto_renew.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Script to auto-renew SSL/TLS certificates using Certbot
+
+# Ensure script is run as root
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
+  exit
+fi
+
+echo "Starting SSL/TLS certificate auto-renewal process..."
+
+# Run certbot renew
+certbot renew --quiet --no-self-upgrade
+
+if [ $? -eq 0 ]; then
+    echo "Certificates successfully checked/renewed."
+    
+    # Reload web server (Nginx or Apache) to apply new certificates if they were renewed
+    if systemctl is-active --quiet nginx; then
+        echo "Reloading Nginx..."
+        systemctl reload nginx
+    elif systemctl is-active --quiet apache2; then
+        echo "Reloading Apache2..."
+        systemctl reload apache2
+    else
+        echo "No supported web server found running to reload."
+    fi
+else
+    echo "Error occurred during certificate renewal."
+    exit 1
+fi
+
+echo "Auto-renewal process complete."


### PR DESCRIPTION
# Summary
This PR addresses issue #3595 by introducing a standardized mechanism to handle SSL/TLS certificate auto-renewals in production, preventing unexpected downtime due to expired certificates.

---

# Root Cause
The project lacked a defined script or documentation for handling automatic SSL certificate renewals, which previously required manual setup and intervention.

---

# Solution
- Introduced a dedicated bash script (`ssl_auto_renew.sh`) that automates the `certbot renew` command.
- The script automatically handles web server reloads (Nginx/Apache2) to apply the renewed certificates.
- Updated the `README.md` to provide administrators with clear instructions on how to integrate this script into a crontab for continuous renewals.

---

# Files Changed
- **`scripts/ssl_auto_renew.sh`**: The automation script for Certbot.
- **`README.md`**: Added documentation on setting up the cron job for auto-renewal.

---

# Testing
- Build passed
- Lint passed
- Tests passed (No functional changes to the application code)
- Manual verification completed (Script syntax and logic verified)

---

# Impact
- **Breaking changes:** No
- **Performance impact:** None
- **Security impact:** Positive (Ensures certificates remain valid and encrypted communication is maintained).
- **Compatibility:** Backward compatible.

---

# Checklist
- [x] Issue solved
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No unrelated changes
- [x] Ready for review
