### PR TITLE
fix(a11y): add global focus indicators for interactive elements

### DIFF
--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -46,6 +46,10 @@
     @apply bg-[#f6f8f7] text-slate-900 dark:bg-gray-900 dark:text-white;
   }
 
+  :focus-visible {
+    @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+  }
+
   .dark {
     background-color: #111827;
     color: #f9fafb;


### PR DESCRIPTION
# Summary
This PR addresses issue #3606 by fixing missing focus indicators for interactive elements globally to improve accessibility and the overall UI/UX.

---
# Root Cause
The system lacked a global fallback for interactive element focus states. Due to this gap, components that did not explicitly define focus utility classes suffered from missing or inconsistent focus indicators, impairing keyboard navigation and accessibility standards.

---
# Solution
Added a global `:focus-visible` rule within Tailwind's `@layer base` in `index.css`. This leverages existing design tokens (`ring-ring`, `ring-offset-background`) to present a consistent, robust focus indicator when elements receive keyboard focus, leaving mouse-click focus untouched.

---
# Files Changed
* `Frontend/src/index.css` - Added the global fallback focus styles for interactive elements in the base layer.

---
# Testing
* Dependencies installed successfully.
* Build tools executed successfully.
* Validated focus indicator behavior against Tailwind base configuration.

---
# Impact
* Breaking changes: No
* Performance impact: None
* Security impact: None
* Compatibility: Vastly improves accessibility and keyboard navigation across all modern browsers.

---
# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
