### PR TITLE
fix(ui): improve error messages for better user experience

### DIFF
--- a/Frontend/src/legacy_ui/Submit.jsx
+++ b/Frontend/src/legacy_ui/Submit.jsx
@@ -63,7 +63,7 @@ function Submit() {
     e.preventDefault();
 
     if (!issue.trim() || !title.trim()) {
-      setError("Please provide a title and describe your issue before submitting.");
+      setError("Please provide a title and describe your issue before submitting the ticket.");
       return;
     }
 
@@ -95,7 +95,7 @@ function Submit() {
 
       navigate("/ai-understanding");
     } catch (_err) {
-      setError("AI Analysis failed. Please try again.");
+      setError("AI Analysis failed. We couldn't analyze the issue right now. Please try again in a moment.");
       setLoading(false);
     }
   };

--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -84,7 +84,7 @@ function AdminSignup() {
     const nextStep = () => {
         if (step === 1) {
             if (!formData.fullName || !formData.email || !formData.password || !formData.confirmPassword) {
-                setError("Please fill in all required personal information.");
+                setError("Please fill in all the required personal information fields.");
                 return;
             }
             const pwError = validatePassword(formData.password);
@@ -98,7 +98,7 @@ function AdminSignup() {
             }
         } else if (step === 2) {
             if (!formData.companyName || !formData.companySize || !formData.industry || !formData.country) {
-                setError("Please fill in all required company details.");
+                setError("Please fill in all the required company detail fields.");
                 return;
             }
         }
@@ -116,7 +116,7 @@ function AdminSignup() {
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (!formData.agreedToTerms || !formData.isAuthorized) {
-            setError("You must agree to the terms and authorize company registration.");
+            setError("Please agree to the terms and authorize company registration to continue.");
             return;
         }
 

--- a/Frontend/src/pages/ForgotPassword.jsx
+++ b/Frontend/src/pages/ForgotPassword.jsx
@@ -61,7 +61,7 @@ function ForgotPassword() {
             setStep(2);
         } catch (err) {
             console.error("Password reset error:", err);
-            setError(err.message || "An error occurred. Please try again.");
+            setError(err.message || "Something went wrong on our end. Please try again in a few moments.");
         } finally {
             setLoading(false);
         }
@@ -74,7 +74,7 @@ function ForgotPassword() {
             return;
         }
         if (timerExpired) {
-            setError("Your code has expired. Please request a new one.");
+            setError("Your reset code has expired. Please request a new one.");
             return;
         }
 
@@ -93,7 +93,7 @@ function ForgotPassword() {
             setMessage("Code verified. Please enter your new password.");
         } catch (err) {
             console.error("OTP verification error:", err);
-            setError("Invalid or expired code. Please check your email and try again.");
+            setError("That code is invalid or expired. Please check your email and try again.");
         } finally {
             setLoading(false);
         }

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -37,7 +37,7 @@ function Login() {
   const handleLogin = async (e) => {
     e.preventDefault();
     if (!email || !password) {
-      setError("Please enter your email and password");
+      setError("Please enter your email and password to log in.");
       return;
     }
 
@@ -81,7 +81,7 @@ function Login() {
   const handleMagicLink = async (e) => {
     e.preventDefault();
     if (!email) {
-      setError("Please enter your email address");
+      setError("Please enter your email address to reset your password.");
       return;
     }
 

--- a/Frontend/src/pages/MasterAdminLogin.jsx
+++ b/Frontend/src/pages/MasterAdminLogin.jsx
@@ -43,7 +43,7 @@ function MasterAdminLogin() {
             const { user: authUser } = await login(email, password);
 
             if (!authUser) {
-                setError("Authentication failed. Please check your credentials.");
+                setError("Login failed. Please double-check your email and password.");
                 return;
             }
 
@@ -57,13 +57,13 @@ function MasterAdminLogin() {
 
             if (profileError || !dbProfile) {
                 await logout();
-                setError("Access denied. No profile found for this account.");
+                setError("Access denied. We couldn't find a profile for this account.");
                 return;
             }
 
             if (dbProfile.role !== "master_admin") {
                 await logout();
-                setError("Access denied. This portal is restricted.");
+                setError("Access denied. This portal is restricted to Master Administrators only.");
                 return;
             }
 

--- a/Frontend/src/pages/ResetPassword.jsx
+++ b/Frontend/src/pages/ResetPassword.jsx
@@ -26,11 +26,11 @@ function ResetPassword() {
     const handleSubmit = async (e) => {
         e.preventDefault();
         if (password.length < 8) {
-            setError("Password must be at least 8 characters long");
+            setError("Your password must be at least 8 characters long for security.");
             return;
         }
         if (password !== confirmPassword) {
-            setError("Passwords do not match");
+            setError("The passwords you entered do not match. Please try again.");
             return;
         }
 

--- a/Frontend/src/pages/Signup.jsx
+++ b/Frontend/src/pages/Signup.jsx
@@ -113,12 +113,12 @@ function Signup() {
     };
 
     if (!email || !password || !confirmPassword || !fullName) {
-      setError("All fields are required.");
+      setError("Oops! All fields are required to create an account.");
       return;
     }
 
     if (!selectedCompany) {
-      setError("Please select your company.");
+      setError("Please select a company to associate with your account.");
       return;
     }
 

--- a/Frontend/src/user/components/CSATModal.jsx
+++ b/Frontend/src/user/components/CSATModal.jsx
@@ -43,7 +43,7 @@ export default function CSATModal({ ticketId, onSubmit, onDismiss }) {
             setSubmitted(true);
             setTimeout(() => { onSubmit?.(selected); }, 1800);
         } catch (err) {
-            setError('Failed to submit. Please try again.');
+            setError("We couldn't submit your rating. Please check your internet connection and try again.");
             console.error(err);
         } finally {
             setLoading(false);

--- a/Frontend/src/user/pages/CreateTicket.jsx
+++ b/Frontend/src/user/pages/CreateTicket.jsx
@@ -133,7 +133,7 @@ const CreateTicket = () => {
         const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
         
         if (!SpeechRecognition) {
-            setError("Speech recognition is not supported in this browser.");
+            setError("Speech recognition is not supported in this browser. Please try using a modern browser like Chrome or Edge.");
             return;
         }
 
@@ -222,7 +222,7 @@ const CreateTicket = () => {
 
         } catch (err) {
             console.error("Microphone access denied:", err);
-            setError("Could not access microphone. Please ensure permissions are granted.");
+            setError("We couldn't access your microphone. Please check your browser settings and grant microphone permissions to use voice input.");
         }
     };
 
@@ -270,7 +270,7 @@ const CreateTicket = () => {
             setError('');
             processOCR(selected);
         } else if (selected) {
-            setError('Please upload only PNG or JPG images.');
+            setError("Invalid image format. Please upload only PNG or JPG images.");
         }
     };
 
@@ -359,7 +359,7 @@ const CreateTicket = () => {
         } else {
             // Manual mode: validate textarea
             if (!issue.trim()) {
-                setError('Please describe your issue first.');
+                setError("Oops! You need to describe your issue before submitting the ticket.");
                 return;
             }
         }
@@ -417,7 +417,7 @@ const CreateTicket = () => {
 
         } catch (err) {
             console.error(err);
-            setError('Failed to submit ticket. Please try again later.');
+            setError("We couldn't submit your ticket right now. Please check your internet connection and try again.");
         } finally {
             setIsLoading(false);
         }


### PR DESCRIPTION
# Summary
This PR addresses issue #3608 by improving generic error messages across the application to be more user-friendly and actionable.

---

# Root Cause
The previous error messages used standard fallback strings (e.g., "Failed to submit ticket. Please try again later.", "An error occurred."). These messages were too vague, leaving users confused about why an action failed and what steps they could take to resolve it (such as checking microphone permissions, internet connectivity, or specific field requirements).

---

# Solution
I reviewed the `setError` states in the frontend components and replaced generic fallback text with clearer, friendlier, and more descriptive instructions. These new messages guide users on exact resolutions, improving the overall UX and accessibility without altering any functional logic.

---

# Files Changed
* `Frontend/src/user/pages/CreateTicket.jsx`: Enhanced mic, browser, image format, and ticket submission error states.
* `Frontend/src/user/components/CSATModal.jsx`: Added actionable advice for submission failures.
* `Frontend/src/pages/Signup.jsx` & `Frontend/src/pages/AdminSignup.jsx`: Improved validation error feedback.
* `Frontend/src/pages/ResetPassword.jsx` & `Frontend/src/pages/ForgotPassword.jsx`: Clarified token expiration and password mismatches.
* `Frontend/src/pages/MasterAdminLogin.jsx` & `Frontend/src/pages/Login.jsx`: Enhanced invalid credentials and unauthorized access messages.
* `Frontend/src/legacy_ui/Submit.jsx`: Made AI analysis and input validation messages clearer.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (syntactical changes only, no logic altered).

---

# Impact
* Breaking changes: No
* Performance impact: None
* Security impact: None
* Compatibility: Fully backward compatible

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review
