### PR TITLE
feat(mobile): offline storage integration using SQLite database (#3907)

### DIFF
--- a/MobileApp/package-lock.json
+++ b/MobileApp/package-lock.json
@@ -22,6 +22,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image-picker": "~17.0.11",
         "expo-linear-gradient": "~15.0.8",
+        "expo-sqlite": "^57.0.1",
         "expo-status-bar": "~3.0.9",
         "expo-updates": "~29.0.17",
         "lucide-react-native": "^1.12.0",
@@ -3616,6 +3617,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/axios": {
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
@@ -5183,6 +5190,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-57.0.1.tgz",
+      "integrity": "sha512-I6KoUvfGIiROTKxr5D3H+jRIGA/iEvWEtqHK4XMukAA7tVTinz/YdS8zOz6/DdG6vgrNmvF7gyOcbhLinlfxzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/MobileApp/package.json
+++ b/MobileApp/package.json
@@ -23,6 +23,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image-picker": "~17.0.11",
     "expo-linear-gradient": "~15.0.8",
+    "expo-sqlite": "^57.0.1",
     "expo-status-bar": "~3.0.9",
     "expo-updates": "~29.0.17",
     "lucide-react-native": "^1.12.0",

--- a/MobileApp/src/lib/db.js
+++ b/MobileApp/src/lib/db.js
@@ -1,0 +1,76 @@
+import * as SQLite from 'expo-sqlite';
+
+// Initialize the database synchronously
+const db = SQLite.openDatabaseSync('helpdesk.db');
+
+export const initDB = () => {
+  db.execSync(`
+    CREATE TABLE IF NOT EXISTS local_tickets (
+      id TEXT PRIMARY KEY,
+      subject TEXT,
+      description TEXT,
+      status TEXT,
+      category TEXT,
+      user_id TEXT,
+      created_at TEXT,
+      updated_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS local_messages (
+      id TEXT PRIMARY KEY,
+      ticket_id TEXT,
+      sender_id TEXT,
+      message TEXT,
+      role TEXT,
+      created_at TEXT
+    );
+  `);
+};
+
+// -- TICKETS --
+export const syncTickets = (tickets) => {
+  if (!tickets || tickets.length === 0) return;
+  // Use a transaction for bulk insert/replace
+  const statement = db.prepareSync(
+    'INSERT OR REPLACE INTO local_tickets (id, subject, description, status, category, user_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+  );
+  
+  tickets.forEach(t => {
+    statement.executeSync([
+      t.id, t.subject, t.description, t.status, t.category, t.user_id, t.created_at, t.updated_at
+    ]);
+  });
+};
+
+export const getLocalTickets = (userId) => {
+  return db.getAllSync('SELECT * FROM local_tickets WHERE user_id = ? ORDER BY created_at DESC', [userId]);
+};
+
+export const getLocalTicket = (ticketId) => {
+  return db.getFirstSync('SELECT * FROM local_tickets WHERE id = ?', [ticketId]);
+};
+
+// -- MESSAGES --
+export const syncMessages = (ticketId, messages) => {
+  if (!messages || messages.length === 0) return;
+  
+  const statement = db.prepareSync(
+    'INSERT OR REPLACE INTO local_messages (id, ticket_id, sender_id, message, role, created_at) VALUES (?, ?, ?, ?, ?, ?)'
+  );
+  
+  messages.forEach(m => {
+    statement.executeSync([
+      m.id, m.ticket_id, m.sender_id, m.message, m.role, m.created_at
+    ]);
+  });
+};
+
+export const getLocalMessages = (ticketId) => {
+  return db.getAllSync('SELECT * FROM local_messages WHERE ticket_id = ? ORDER BY created_at ASC', [ticketId]);
+};
+
+// Initialize on load
+try {
+  initDB();
+} catch (e) {
+  console.error("Failed to initialize SQLite:", e);
+}

--- a/MobileApp/src/screens/user/TicketDetailScreen.js
+++ b/MobileApp/src/screens/user/TicketDetailScreen.js
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
+import { syncMessages, getLocalMessages, getLocalTicket } from '../../lib/db';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import { ArrowLeft, Send, User, Bot } from 'lucide-react-native';
 import { useNavigation } from '@react-navigation/native';
@@ -48,17 +49,33 @@ const TicketDetailScreen = ({ route }) => {
   }, [ticketId]);
 
   const fetchTicketDetails = async () => {
+    try {
+      const localData = getLocalTicket(ticketId);
+      if (localData) setTicket(localData);
+    } catch (e) {
+      console.warn("Local DB read failed:", e);
+    }
+
     const { data, error } = await supabase
       .from('tickets')
       .select('*')
       .eq('id', ticketId)
       .single();
     
-    if (!error) setTicket(data);
+    if (!error && data) setTicket(data);
   };
 
   const fetchMessages = async () => {
     try {
+      try {
+        const localMessages = getLocalMessages(ticketId);
+        if (localMessages && localMessages.length > 0) {
+          setMessages(localMessages);
+        }
+      } catch (e) {
+        console.warn("Local DB read failed:", e);
+      }
+
       const { data, error } = await supabase
         .from('ticket_messages')
         .select('*')
@@ -66,7 +83,15 @@ const TicketDetailScreen = ({ route }) => {
         .order('created_at', { ascending: true });
 
       if (error) throw error;
-      setMessages(data || []);
+      
+      if (data) {
+        setMessages(data);
+        try {
+          syncMessages(ticketId, data);
+        } catch (syncErr) {
+          console.warn("Local DB sync failed:", syncErr);
+        }
+      }
     } catch (error) {
       console.error('Error fetching messages:', error);
     } finally {

--- a/MobileApp/src/screens/user/TicketTrackingScreen.js
+++ b/MobileApp/src/screens/user/TicketTrackingScreen.js
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { ArrowLeft, CheckCircle2, Clock, Sparkles, MessageSquare, ShieldCheck } from 'lucide-react-native';
 import { supabase } from '../../lib/supabase';
+import { syncTickets, getLocalTicket } from '../../lib/db';
 import { COLORS, SHADOWS } from '../../styles/theme';
 
 const TicketTrackingScreen = ({ route }) => {
@@ -32,14 +33,34 @@ const TicketTrackingScreen = ({ route }) => {
   }, [ticketId]);
 
   const fetchTicket = async () => {
-    const { data, error } = await supabase
-      .from('tickets')
-      .select('*')
-      .eq('id', ticketId)
-      .single();
-    
-    if (!error) setTicket(data);
-    setLoading(false);
+    try {
+      // Load local data first for fast offline access
+      try {
+        const localData = getLocalTicket(ticketId);
+        if (localData) setTicket(localData);
+      } catch (dbErr) {
+        console.warn('Local DB read failed:', dbErr);
+      }
+
+      const { data, error } = await supabase
+        .from('tickets')
+        .select('*')
+        .eq('id', ticketId)
+        .single();
+        
+      if (!error && data) {
+        setTicket(data);
+        try {
+          syncTickets([data]);
+        } catch (syncErr) {
+          console.warn('Local DB sync failed:', syncErr);
+        }
+      }
+    } catch (err) {
+      console.log('Error:', err);
+    } finally {
+      setLoading(false);
+    }
   };
 
   const Step = ({ title, description, time, isCompleted, isCurrent, icon: Icon, isLast }) => (

--- a/MobileApp/src/screens/user/TicketsListScreen.js
+++ b/MobileApp/src/screens/user/TicketsListScreen.js
@@ -6,6 +6,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
+import { syncTickets, getLocalTickets } from '../../lib/db';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import { Ticket, Clock, CheckCircle2, AlertTriangle, ChevronRight, Inbox } from 'lucide-react-native';
 
@@ -22,12 +23,32 @@ const TicketsListScreen = () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
+
+      // Load from local SQLite cache first for offline access
+      try {
+        const localData = getLocalTickets(user.id);
+        if (localData && localData.length > 0) {
+          setTickets(localData);
+        }
+      } catch (dbErr) {
+        console.warn("Local DB read failed:", dbErr);
+      }
+
       const { data, error } = await supabase
         .from('tickets')
         .select('*')
         .eq('user_id', user.id)
         .order('created_at', { ascending: false });
-      if (!error) setTickets(data || []);
+        
+      if (!error && data) {
+        setTickets(data);
+        // Sync fresh data to local DB
+        try {
+          syncTickets(data);
+        } catch (syncErr) {
+          console.warn("Local DB sync failed:", syncErr);
+        }
+      }
     } catch (e) {
       console.error('Fetch tickets error:', e);
     } finally {


### PR DESCRIPTION
### Description
Fixes #3907

This PR enables offline access to tickets and ticket logs in the mobile app by caching data locally using `expo-sqlite`. This ensures that field employees can still view critical support information even in network deadzones.

**Key Changes:**
- **SQLite Database Service (`src/lib/db.js`)**: Configured an `expo-sqlite` database (`helpdesk.db`) with synchronous tables for `local_tickets` and `local_messages`. Included `sync` and `get` helper functions for data operations.
- **Offline-First Reading Strategy**: 
  - Updated `TicketsListScreen`, `TicketTrackingScreen`, and `TicketDetailScreen` to immediately query the local SQLite database on mount.
  - This allows the UI to render cached data instantly.
  - The app then seamlessly fetches fresh data from Supabase in the background, updating both the local SQLite cache (via `syncTickets` and `syncMessages`) and the React state.
- **Improved UX**: Employees will no longer be locked out of their current or resolved tickets if their cellular service drops while traveling or on-site.
