### PR TITLE
feat(backend): log application activities via structured JSON format #3905

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,10 @@ import datetime
 import traceback
 import warnings
 import logging
+from utils.logger import get_json_logger
+
+# Configure root logger to output structured JSON
+get_json_logger()
 import hashlib
 from contextlib import asynccontextmanager
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ easyocr
 slowapi>=0.1.9
 supabase==2.22.4
 storage3==2.22.4
+python-json-logger>=2.0.7

--- a/backend/scripts/seed_company_settings.py
+++ b/backend/scripts/seed_company_settings.py
@@ -33,12 +33,14 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="[SeedCompanySettings] %(asctime)s - %(levelname)s - %(message)s"
-)
-logger = logging.getLogger(__name__)
+import sys
+import os
+
+# Ensure backend root is in sys.path so we can import utils
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from utils.logger import get_json_logger
+
+logger = get_json_logger(__name__)
 
 
 def seed_company_settings():

--- a/backend/services/auto_close_service.py
+++ b/backend/services/auto_close_service.py
@@ -20,13 +20,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+from utils.logger import get_json_logger
 
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[AutoCloseService] %(asctime)s - %(levelname)s - %(message)s")
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+logger = get_json_logger(__name__)
 
 
 class AutoCloseService:

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -24,13 +24,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+from utils.logger import get_json_logger
 
-handler = logging.StreamHandler()
-formatter = logging.Formatter("[NotificationRouting] %(asctime)s - %(levelname)s - %(message)s")
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+logger = get_json_logger(__name__)
 
 
 class NotificationType(str, Enum):

--- a/backend/utils/logger.py
+++ b/backend/utils/logger.py
@@ -1,0 +1,26 @@
+import logging
+import sys
+from pythonjsonlogger import jsonlogger
+
+def get_json_logger(name: str = None) -> logging.Logger:
+    """
+    Returns a logger configured to output structured JSON logs.
+    Ideal for CloudWatch, Datadog, or other centralized logging systems.
+    """
+    logger = logging.getLogger(name)
+    
+    # Only add handler if not already present to avoid duplicate logs
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        log_handler = logging.StreamHandler(sys.stdout)
+        
+        # Configure JSON formatter with standard fields
+        formatter = jsonlogger.JsonFormatter(
+            fmt='%(asctime)s %(levelname)s %(name)s %(message)s',
+            datefmt='%Y-%m-%dT%H:%M:%S%z'
+        )
+        
+        log_handler.setFormatter(formatter)
+        logger.addHandler(log_handler)
+        
+    return logger


### PR DESCRIPTION
### Description
Fixes #3905

This PR transitions the backend Python application logs from standard unstructured text strings to fully structured JSON. This ensures seamless ingestion, querying, and parsing by centralized observability platforms such as Datadog and AWS CloudWatch.

**Key Changes:**
- **Centralized Logger Module (`backend/utils/logger.py`)**: Implemented a core configuration module that initializes `python-json-logger`. It automatically structures payloads with key context including `asctime`, `levelname`, `name`, and `message`.
- **Root Logger Configuration**: Initialized the global JSON format against the root logger in `main.py`, cascading structured output down to all uncaught logs within the FastAPI process.
- **Service Refactoring**: Cleaned up manual string formatting in `auto_close_service.py`, `notification_routing.py`, and `seed_company_settings.py` so background scripts and background services inherently utilize the centralized structured config.
