### PR TITLE
feat(auth): refresh JWT token automatically on expiry warnings (#3896)

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -12,6 +12,7 @@ import useTicketStore from "./store/ticketStore";
 import Toaster from "./components/shared/Toaster";
 import BugReportWidget from "./components/shared/BugReportWidget";
 import useRealtimeNotifications from "./hooks/useRealtimeNotifications";
+import useTokenRefresh from "./hooks/useTokenRefresh";
 
 // Auth Components
 import Login from "./pages/Login";
@@ -154,6 +155,9 @@ function AppLayout() {
 
   // Initialize Global Realtime Notifications Listener
   useRealtimeNotifications();
+
+  // Silent JWT refresh loop — fires 2 min before access_token expires
+  useTokenRefresh();
 
   useEffect(() => {
     if (!user) return;

--- a/Frontend/src/hooks/useTokenRefresh.js
+++ b/Frontend/src/hooks/useTokenRefresh.js
@@ -1,0 +1,125 @@
+/**
+ * useTokenRefresh — Silent JWT refresh loop hook (#3896)
+ *
+ * Proactively refreshes the backend HttpOnly session cookies (~2 minutes
+ * before the access_token expires) to prevent mid-session 401 Unauthorized
+ * errors on authenticated API calls.
+ *
+ * Flow:
+ *   1. On mount (and whenever `user` changes), reads the Supabase session
+ *      `expires_at` timestamp.
+ *   2. Calculates the delay: (expires_at - now - REFRESH_BUFFER_MS).
+ *   3. Schedules a `setTimeout` for that delay.
+ *   4. On fire, calls `POST /auth/refresh` — the backend reads the HttpOnly
+ *      `refresh_token` cookie and rotates both cookies, returning the new
+ *      `expires_at` for the next cycle.
+ *   5. Reschedules itself with the new expiry to keep the loop alive.
+ *   6. On a 401 from the refresh endpoint (refresh token itself expired),
+ *      logs the user out cleanly.
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import { API_CONFIG } from '../config';
+import useAuthStore from '../store/authStore';
+
+/** Trigger refresh this many ms before the token actually expires (2 minutes). */
+const REFRESH_BUFFER_MS = 2 * 60 * 1000;
+
+/** Minimum delay to avoid a tight spin loop on malformed expiry values. */
+const MIN_DELAY_MS = 5_000;
+
+export default function useTokenRefresh() {
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const setSessionExpiresAt = useAuthStore((s) => s.setSessionExpiresAt);
+  const timerRef = useRef(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Perform the actual silent refresh against the FastAPI backend.
+   * Returns the new `expires_at` Unix timestamp (seconds), or null on failure.
+   */
+  const doRefresh = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_CONFIG.BACKEND_URL}/auth/refresh`, {
+        method: 'POST',
+        credentials: 'include', // sends HttpOnly cookies automatically
+      });
+
+      if (res.status === 401) {
+        // Refresh token itself has expired — force logout
+        console.warn('[useTokenRefresh] Refresh token expired, logging out.');
+        await logout();
+        return null;
+      }
+
+      if (!res.ok) {
+        console.error('[useTokenRefresh] Refresh request failed:', res.status);
+        return null;
+      }
+
+      const data = await res.json();
+      if (data?.expires_at) {
+        setSessionExpiresAt(data.expires_at);
+      }
+      return data?.expires_at ?? null;
+    } catch (err) {
+      console.error('[useTokenRefresh] Network error during refresh:', err);
+      return null;
+    }
+  }, [logout, setSessionExpiresAt]);
+
+  /**
+   * Schedule the next refresh cycle based on a given `expires_at` Unix
+   * timestamp (in seconds, as returned by Supabase/backend).
+   */
+  const scheduleNext = useCallback(
+    (expiresAtSeconds) => {
+      clearTimer();
+
+      if (!expiresAtSeconds) return;
+
+      const nowMs = Date.now();
+      const expiresAtMs = expiresAtSeconds * 1000;
+      const delay = Math.max(expiresAtMs - nowMs - REFRESH_BUFFER_MS, MIN_DELAY_MS);
+
+      console.log(
+        `[useTokenRefresh] Next silent refresh in ${Math.round(delay / 1000)}s`
+      );
+
+      timerRef.current = setTimeout(async () => {
+        const newExpiresAt = await doRefresh();
+        if (newExpiresAt) {
+          scheduleNext(newExpiresAt);
+        }
+      }, delay);
+    },
+    [clearTimer, doRefresh]
+  );
+
+  useEffect(() => {
+    if (!user) {
+      // Not logged in — clear any pending timer and stop
+      clearTimer();
+      return;
+    }
+
+    // Bootstrap: read the current session expiry from Supabase client state
+    supabase.auth.getSession().then(({ data }) => {
+      const expiresAt = data?.session?.expires_at;
+      if (expiresAt) {
+        setSessionExpiresAt(expiresAt);
+        scheduleNext(expiresAt);
+      }
+    });
+
+    return () => clearTimer();
+  }, [user, clearTimer, scheduleNext, setSessionExpiresAt]);
+}

--- a/Frontend/src/hooks/useTokenRefresh.js
+++ b/Frontend/src/hooks/useTokenRefresh.js
@@ -76,37 +76,28 @@ export default function useTokenRefresh() {
     }
   }, [logout, setSessionExpiresAt]);
 
-  /**
-   * Schedule the next refresh cycle based on a given `expires_at` Unix
-   * timestamp (in seconds, as returned by Supabase/backend).
-   */
-  const scheduleNext = useCallback(
-    (expiresAtSeconds) => {
-      clearTimer();
+  const scheduleNextRef = useRef(null);
 
-      if (!expiresAtSeconds) return;
+  scheduleNextRef.current = (expiresAtSeconds) => {
+    clearTimer();
+    if (!expiresAtSeconds) return;
 
-      const nowMs = Date.now();
-      const expiresAtMs = expiresAtSeconds * 1000;
-      const delay = Math.max(expiresAtMs - nowMs - REFRESH_BUFFER_MS, MIN_DELAY_MS);
+    const nowMs = Date.now();
+    const expiresAtMs = expiresAtSeconds * 1000;
+    const delay = Math.max(expiresAtMs - nowMs - REFRESH_BUFFER_MS, MIN_DELAY_MS);
 
-      console.log(
-        `[useTokenRefresh] Next silent refresh in ${Math.round(delay / 1000)}s`
-      );
+    console.log(`[useTokenRefresh] Next silent refresh in ${Math.round(delay / 1000)}s`);
 
-      timerRef.current = setTimeout(async () => {
-        const newExpiresAt = await doRefresh();
-        if (newExpiresAt) {
-          scheduleNext(newExpiresAt);
-        }
-      }, delay);
-    },
-    [clearTimer, doRefresh]
-  );
+    timerRef.current = setTimeout(async () => {
+      const newExpiresAt = await doRefresh();
+      if (newExpiresAt && scheduleNextRef.current) {
+        scheduleNextRef.current(newExpiresAt);
+      }
+    }, delay);
+  };
 
   useEffect(() => {
     if (!user) {
-      // Not logged in — clear any pending timer and stop
       clearTimer();
       return;
     }
@@ -114,12 +105,12 @@ export default function useTokenRefresh() {
     // Bootstrap: read the current session expiry from Supabase client state
     supabase.auth.getSession().then(({ data }) => {
       const expiresAt = data?.session?.expires_at;
-      if (expiresAt) {
+      if (expiresAt && scheduleNextRef.current) {
         setSessionExpiresAt(expiresAt);
-        scheduleNext(expiresAt);
+        scheduleNextRef.current(expiresAt);
       }
     });
 
     return () => clearTimer();
-  }, [user, clearTimer, scheduleNext, setSessionExpiresAt]);
+  }, [user, clearTimer, setSessionExpiresAt]);
 }

--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -10,6 +10,11 @@ const useAuthStore = create(
             user: null,
             profile: null,
             loading: false,
+            /** Unix timestamp (seconds) when the current access_token expires. */
+            sessionExpiresAt: null,
+
+            /** Called by useTokenRefresh after a successful silent refresh. */
+            setSessionExpiresAt: (expiresAt) => set({ sessionExpiresAt: expiresAt }),
 
             // --- SUPABASE AUTH METHODS ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1200,6 +1200,37 @@ async def auth_signup(body: SignupBody, response: Response):
     user_payload = user.model_dump() if user and hasattr(user, "model_dump") else None
     return {"user": user_payload, "message": "Signup complete"}
 
+@app.post("/auth/refresh")
+async def auth_refresh(request: Request, response: Response):
+    """
+    Silent token refresh endpoint.
+    Reads the HttpOnly refresh_token cookie, exchanges it with Supabase for
+    a fresh access_token + refresh_token pair, and rotates the cookies.
+    Called automatically by the Frontend refresh loop before access_token expires.
+    """
+    refresh_token = request.cookies.get(REFRESH_COOKIE)
+    if not refresh_token:
+        raise HTTPException(status_code=401, detail="No refresh token cookie present")
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database connection offline")
+
+    try:
+        result = supabase.auth.refresh_session(refresh_token)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Token refresh failed: {exc}",
+        ) from exc
+
+    session = getattr(result, "session", None)
+    if not session or not getattr(session, "access_token", None):
+        raise HTTPException(status_code=401, detail="Refresh session returned no valid session")
+
+    _set_session_cookies(response, session)
+
+    expires_at = getattr(session, "expires_at", None)
+    return {"ok": True, "expires_at": expires_at}
+
 @app.post("/auth/logout")
 async def auth_logout(response: Response):
     _clear_session_cookies(response)


### PR DESCRIPTION
### Description
Fixes #3896

Implements a fully silent, proactive JWT refresh loop that prevents mid-session `401 Unauthorized` errors caused by expired `access_token` cookies.

**Key Changes:**
- **`backend/main.py` — `POST /auth/refresh`**: New endpoint that reads the HttpOnly `refresh_token` cookie, exchanges it via `supabase.auth.refresh_session()`, and rotates both cookies in-place. Returns the new `expires_at` Unix timestamp for the client to schedule the next refresh cycle.
- **`Frontend/src/hooks/useTokenRefresh.js`** _(NEW)_: Custom React hook containing the full silent refresh loop:
  - On mount, reads `session.expires_at` from the active Supabase client session.
  - Schedules a `setTimeout` for `(expires_at - now - 2 minutes)` to fire before expiry.
  - On fire, calls `POST /auth/refresh` with `credentials: 'include'` to exchange cookies transparently.
  - Reschedules the next cycle from the new `expires_at` timestamp returned by the backend.
  - On a `401` (refresh token itself expired), calls `logout()` to cleanly sign the user out.
- **`Frontend/src/store/authStore.js`**: Added `sessionExpiresAt` state field and `setSessionExpiresAt` action for the hook to update Zustand after each successful cycle.
- **`Frontend/src/App.jsx`**: Mounted `useTokenRefresh()` inside `AppLayout` alongside `useRealtimeNotifications()` so the loop is globally active for the entire authenticated session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic, silent session renewal shortly before authentication expiry.
  * Introduced a server-side refresh endpoint that uses HttpOnly refresh cookies to rotate session cookies securely.
  * Session expiration is now tracked to schedule timely renewals.

* **Bug Fixes**
  * Reduces unexpected sign-outs by keeping valid sessions alive during active use.
  * When refresh fails or expires, the app safely ends the refresh flow and signs the user out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->