### PR TITLE
Feat/relative timestamps 3885

### DIFF
--- a/Frontend/src/admin/components/TicketAuditTimeline.jsx
+++ b/Frontend/src/admin/components/TicketAuditTimeline.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { AlertTriangle, ArrowRight, History, Loader2, ShieldCheck, Sparkles, User } from 'lucide-react';
 import { supabase } from '../../lib/supabaseClient';
 import { API_CONFIG } from '../../config';
-import { formatFullTimestamp, safeParseDateForSort } from '../../utils/dateUtils';
+import { formatFullTimestamp, formatRelativeTime, safeParseDateForSort } from '../../utils/dateUtils';
 
 const ACTION_META = {
     TICKET_CREATED: {
@@ -272,8 +272,8 @@ const TicketAuditTimeline = ({ ticketId, companyId }) => {
                                                 <p className="text-sm font-bold text-slate-800" title={record.performed_by || 'System generated'}>
                                                     {actorLabel}
                                                 </p>
-                                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-                                                    {formatFullTimestamp(record.created_at)}
+                                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-1" title={formatFullTimestamp(record.created_at)}>
+                                                    {formatRelativeTime(record.created_at)}
                                                 </p>
                                             </div>
                                         </div>

--- a/Frontend/src/admin/pages/AdminTicketDetail.jsx
+++ b/Frontend/src/admin/pages/AdminTicketDetail.jsx
@@ -4,8 +4,7 @@ import {
     CheckCircle2, Clock, AlertCircle, User,
     Activity, ShieldCheck, Briefcase, Globe, BarChart3,
     ImageIcon, CornerUpLeft, CheckSquare, XCircle,
-    Cpu, Eye, MessageSquare, MoveRight, Loader2, Star, Eraser,
-    ExternalLink
+    Cpu, Eye, MessageSquare, MoveRight, Loader2, Star, Eraser
 } from 'lucide-react';
 import { supabase } from "../../lib/supabaseClient";
 import useAuthStore from "../../store/authStore";
@@ -15,7 +14,7 @@ import { Select } from "../../components/ui/select";
 import TicketChat from "../../components/shared/TicketChat";
 import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
-import { formatFullTimestamp } from "../../utils/dateUtils";
+import { formatFullTimestamp, formatRelativeTime } from "../../utils/dateUtils";
 import TicketTimeline from "../../user/components/TicketTimeline";
 
 const AdminTicketDetail = () => {
@@ -303,7 +302,7 @@ const AdminTicketDetail = () => {
                             <h3 style={{ fontSize: '11px', letterSpacing: '0.12em', color: '#9ca3af', fontWeight: 700, textTransform: 'uppercase', margin: 0, display: 'flex', alignItems: 'center', gap: '8px' }}>
                                 <MessageSquare size={14} color="#16a34a" /> USER INPUT PAYLOAD
                             </h3>
-                            <span style={{ fontSize: '10px', color: '#9ca3af', fontWeight: 600, textTransform: 'uppercase' }}>{formatFullTimestamp(ticket.created_at)}</span>
+                            <span style={{ fontSize: '10px', color: '#9ca3af', fontWeight: 600, textTransform: 'uppercase' }} title={formatFullTimestamp(ticket.created_at)}>{formatRelativeTime(ticket.created_at)}</span>
                         </div>
                         <div style={{ padding: '28px' }}>
                             <div style={{ background: 'linear-gradient(135deg, #0f1f12, #1a3320)', color: '#ffffff', borderRadius: '16px', padding: '24px 28px', fontSize: '15px', fontStyle: 'italic', lineHeight: 1.7 }}>
@@ -422,57 +421,6 @@ const AdminTicketDetail = () => {
                             </div>
                         </div>
                     </div>
- 
-                    {/* AI Suggestions (RAG) */}
-                    {ticket.metadata?.rag_suggestions && ticket.metadata.rag_suggestions.length > 0 && (
-                        <div style={{ background: '#ffffff', borderRadius: '20px', border: '1px solid #f0fdf4', boxShadow: '0 2px 16px rgba(0,0,0,0.05)', overflow: 'hidden' }}>
-                            <div style={{ background: '#0f1f12', borderRadius: '20px 20px 0 0', color: '#ffffff', padding: '16px 20px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                                <h3 style={{ fontFamily: 'Syne, sans-serif', fontWeight: 700, fontSize: '12px', margin: 0, display: 'flex', alignItems: 'center', gap: '8px', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-                                    <Cpu size={14} color="#22c55e" /> AI Suggestions (RAG)
-                                </h3>
-                            </div>
-                            <div style={{ padding: '20px' }} className="space-y-4">
-                                <div className="space-y-3">
-                                    {ticket.metadata.rag_suggestions.map((s, idx) => (
-                                        <div key={idx} className="p-3.5 bg-slate-50 rounded-2xl border border-slate-100/60 space-y-2">
-                                            <div className="flex items-center justify-between">
-                                                <span style={{ fontSize: '9px', fontWeight: 800, textTransform: 'uppercase', padding: '2px 8px', borderRadius: '100px', background: s.source?.toLowerCase().includes('ticket') ? '#eff6ff' : '#fffbeb', color: s.source?.toLowerCase().includes('ticket') ? '#2563eb' : '#d97706', border: `1px solid ${s.source?.toLowerCase().includes('ticket') ? '#bfdbfe' : '#fde68a'}` }}>
-                                                    {s.source}
-                                                </span>
-                                                <span style={{ fontSize: '10px', fontWeight: 800, color: '#16a34a' }}>
-                                                    {Math.round(s.confidence * 100)}% Match
-                                                </span>
-                                            </div>
-                                            <p style={{ fontSize: '11px', fontWeight: 700, color: '#1e293b', margin: 0, lineHeight: 1.4 }}>
-                                                {s.url ? (
-                                                    <a href={s.url} target="_blank" rel="noopener noreferrer" className="hover:underline inline-flex items-center gap-1 text-emerald-700">
-                                                        {s.title} <ExternalLink size={10} />
-                                                    </a>
-                                                ) : s.title}
-                                            </p>
-                                            <div className="flex justify-between items-center text-[9px] text-slate-400 font-semibold uppercase tracking-wider">
-                                                <span>Similarity: {Math.round((s.similarity_score || s.similarity || 0) * 100)}%</span>
-                                                <span>Effectiveness: {s.resolution_effectiveness || '90%'}</span>
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-
-                                {ticket.metadata.rag_recommendations && ticket.metadata.rag_recommendations.length > 0 && (
-                                    <div className="space-y-2.5 pt-3" style={{ borderTop: '1px solid #f0fdf4' }}>
-                                        <h4 style={{ fontSize: '10px', letterSpacing: '0.1em', color: '#9ca3af', fontWeight: 800, textTransform: 'uppercase', margin: 0 }}>Resolution Recommendations</h4>
-                                        <ul className="space-y-1.5 pl-4 list-disc text-slate-600 font-medium" style={{ margin: 0 }}>
-                                            {ticket.metadata.rag_recommendations.map((rec, idx) => (
-                                                <li key={idx} style={{ fontSize: '11px', lineHeight: 1.4 }}>
-                                                    {rec}
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    </div>
-                                )}
-                            </div>
-                        </div>
-                    )}
 
                     {/* CSAT */}
                     {ticket.csat_rating && (

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -609,6 +609,15 @@ const AdminTickets = () => {
         return 'text-slate-500 dark:text-slate-400 bg-slate-50 border-slate-100';
     };
 
+    // Critical / high priority tickets get an animated pulse dot next to their
+    // priority selector so they're instantly noticeable in the dashboard list.
+    const getPriorityPulseClass = (priority) => {
+        const p = String(priority || '').toLowerCase();
+        if (p === 'critical') return 'bg-red-600 priority-dot-pulse-critical';
+        if (p === 'high') return 'bg-orange-500 priority-dot-pulse-high';
+        return null;
+    };
+
     const getConfidenceColor = (conf) => {
         if (conf >= 0.8) return 'bg-emerald-500';
         if (conf >= 0.5) return 'bg-amber-500';
@@ -796,6 +805,23 @@ const AdminTickets = () => {
             )}
 
             {/* 5. High-Density Data Terminal */}
+            <style>{`
+                @keyframes priority-pulse-critical {
+                    0% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.55); }
+                    70% { box-shadow: 0 0 0 6px rgba(220, 38, 38, 0); }
+                    100% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0); }
+                }
+                @keyframes priority-pulse-high {
+                    0% { box-shadow: 0 0 0 0 rgba(234, 88, 12, 0.5); }
+                    70% { box-shadow: 0 0 0 6px rgba(234, 88, 12, 0); }
+                    100% { box-shadow: 0 0 0 0 rgba(234, 88, 12, 0); }
+                }
+                .priority-dot-pulse-critical { animation: priority-pulse-critical 1.6s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
+                .priority-dot-pulse-high { animation: priority-pulse-high 1.8s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
+                @media (prefers-reduced-motion: reduce) {
+                    .priority-dot-pulse-critical, .priority-dot-pulse-high { animation: none; }
+                }
+            `}</style>
             <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]">
                 {loading && (
                     <div className="absolute inset-0 bg-white/60 backdrop-blur-[2px] z-10 flex items-center justify-center">
@@ -950,16 +976,24 @@ const AdminTickets = () => {
 
                                     {/* Priority (Editable) */}
                                     <td className="px-6 py-6">
-                                        <select
-                                            value={String(ticket.priority || 'medium').toLowerCase()}
-                                            onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })}
-                                            aria-label={`Change priority for ticket ${formatTicketId(ticket.id)}`}
-                                            className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}
-                                        >
-                                            {priorities.filter(p => p !== 'All').map(p => (
-                                                <option key={p} value={p.toLowerCase()}>{p}</option>
-                                            ))}
-                                        </select>
+                                        <div className="relative inline-flex items-center gap-1.5">
+                                            {getPriorityPulseClass(ticket.priority) && (
+                                                <span
+                                                    className={`w-1.5 h-1.5 rounded-full inline-block flex-shrink-0 ${getPriorityPulseClass(ticket.priority)}`}
+                                                    aria-hidden="true"
+                                                />
+                                            )}
+                                            <select
+                                                value={String(ticket.priority || 'medium').toLowerCase()}
+                                                onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })}
+                                                aria-label={`Change priority for ticket ${formatTicketId(ticket.id)}`}
+                                                className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}
+                                            >
+                                                {priorities.filter(p => p !== 'All').map(p => (
+                                                    <option key={p} value={p.toLowerCase()}>{p}</option>
+                                                ))}
+                                            </select>
+                                        </div>
                                     </td>
 
                                     {/* AI Score (Confidence) */}

--- a/Frontend/src/admin/pages/AdminTickets.jsx
+++ b/Frontend/src/admin/pages/AdminTickets.jsx
@@ -1,351 +1,57 @@
-import React, { useState, useMemo, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import useAuthStore from "../../store/authStore";
 import useToastStore from "../../store/toastStore";
 import { supabase } from "../../lib/supabaseClient";
-import useTicketsRealtime from "../../hooks/useTicketsRealtime";
-import TagFilter from "../../components/TagFilter";
-import TagChip from "../../components/TagChip";
-import LanguageBadge from "../../components/shared/LanguageBadge";
 import {
+    Search,
+    Filter,
     Inbox,
     Activity,
     ShieldAlert,
+    Clock,
+    ChevronRight,
+    BarChart3,
+    User,
     ArrowUpRight,
+    ExternalLink,
     AlertCircle,
+    CheckCircle2,
     Loader2,
     Save,
     RotateCcw,
-    Square,
-    CheckSquare,
-    X,
-    Users,
-    XCircle,
-    ArrowUpDown,
-    Download,
-    Printer,
 } from 'lucide-react';
 import { Select } from "../../components/ui/select";
 import { formatTicketId } from "../../utils/format";
 import SLABadge from "../components/SLABadge";
-import { formatTimelineDate } from "../../utils/dateUtils";
-import { sanitizeSearchQuery } from "../../utils/sanitizeText";
-import { downloadCSV, printTicket } from "../../utils/exportUtils";
+import { formatTimelineDate, formatRelativeTime } from "../../utils/dateUtils";
 
-/* ────────────────────────────────────────────────────────────
-   Confirmation Modal  – reusable for any destructive bulk op
-   ──────────────────────────────────────────────────────────── */
-const BulkConfirmModal = ({ action, count, onConfirm, onCancel, isExecuting }) => {
-    const dialogRef = useRef(null);
-    const confirmButtonRef = useRef(null);
-    const titleId = 'bulk-confirm-title';
-    const descriptionId = 'bulk-confirm-description';
-    const labelMap = {
-        close: 'Close',
-        priority: 'Change Priority of',
-        assign: 'Assign Agent to',
-    };
-    const actionLabel = labelMap[action] || action;
-
-    useEffect(() => {
-        const previouslyFocused = document.activeElement;
-
-        const getFocusableElements = () =>
-            Array.from(
-                dialogRef.current?.querySelectorAll(
-                    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-                ) || []
-            );
-
-        const handleKeyDown = (event) => {
-            if (event.key === 'Escape' && !isExecuting) {
-                event.preventDefault();
-                onCancel();
-                return;
-            }
-
-            if (event.key !== 'Tab') return;
-
-            const focusableElements = getFocusableElements();
-            if (focusableElements.length === 0) {
-                event.preventDefault();
-                dialogRef.current?.focus();
-                return;
-            }
-
-            const firstElement = focusableElements[0];
-            const lastElement = focusableElements[focusableElements.length - 1];
-
-            if (event.shiftKey && document.activeElement === firstElement) {
-                event.preventDefault();
-                lastElement.focus();
-            } else if (!event.shiftKey && document.activeElement === lastElement) {
-                event.preventDefault();
-                firstElement.focus();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        requestAnimationFrame(() => {
-            confirmButtonRef.current?.focus();
-        });
-
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-            previouslyFocused?.focus?.();
-        };
-    }, [isExecuting, onCancel]);
-
-    return (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4 animate-in fade-in duration-200">
-            <div
-                ref={dialogRef}
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby={titleId}
-                aria-describedby={descriptionId}
-                tabIndex={-1}
-                className="bg-white rounded-3xl p-8 max-w-md w-full shadow-2xl shadow-slate-900/20 border border-slate-100 animate-in zoom-in-95 duration-300"
-            >
-                {/* Icon */}
-                <div className="w-14 h-14 rounded-2xl bg-amber-50 border border-amber-100 flex items-center justify-center mx-auto mb-5">
-                    <AlertCircle className="w-7 h-7 text-amber-500" aria-hidden="true" />
-                </div>
-                <h3 id={titleId} className="text-lg font-black text-slate-900 uppercase italic tracking-tight text-center">
-                    Confirm Bulk Action
-                </h3>
-                <p id={descriptionId} className="text-sm text-slate-500 dark:text-slate-400 mt-3 text-center leading-relaxed">
-                    You are about to <strong className="text-slate-800">{actionLabel}</strong>{' '}
-                    <strong className="text-indigo-600">{count}</strong> ticket{count > 1 ? 's' : ''}.
-                    This action cannot be undone.
-                </p>
-                <div className="flex gap-3 mt-8">
-                    <button
-                        ref={confirmButtonRef}
-                        type="button"
-                        onClick={onConfirm}
-                        disabled={isExecuting}
-                        aria-label={`Confirm ${actionLabel.toLowerCase()} ${count} selected ticket${count > 1 ? 's' : ''}`}
-                        className="flex-1 bg-indigo-600 text-white rounded-2xl py-3.5 text-xs font-black uppercase tracking-widest hover:bg-indigo-700 transition-colors shadow-lg shadow-indigo-500/20 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                    >
-                        {isExecuting ? (
-                            <>
-                                <Loader2 size={14} className="animate-spin" aria-hidden="true" />
-                                Processing…
-                            </>
-                        ) : (
-                            'Confirm'
-                        )}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={onCancel}
-                        disabled={isExecuting}
-                        aria-label="Cancel bulk action"
-                        className="flex-1 bg-slate-100 text-slate-600 dark:text-slate-400 rounded-2xl py-3.5 text-xs font-black uppercase tracking-widest hover:bg-slate-200 transition-colors disabled:opacity-50"
-                    >
-                        Cancel
-                    </button>
-                </div>
-            </div>
-        </div>
-    );
-};
-
-/* ────────────────────────────────────────────────────────────
-   Bulk Action Toolbar  – slides in when 1+ tickets selected
-   ──────────────────────────────────────────────────────────── */
-const BulkActionToolbar = ({
-    selectedCount,
-    bulkAction,
-    setBulkAction,
-    bulkValue,
-    setBulkValue,
-    agents,
-    priorities,
-    onApply,
-    onClear,
-}) => {
-    const canApply = bulkAction === 'close' || (bulkAction && bulkValue);
-    return (
-        <div
-            role="region"
-            aria-label={`${selectedCount} selected ticket${selectedCount > 1 ? 's' : ''} bulk actions`}
-            className="bg-gradient-to-r from-indigo-600 via-indigo-600 to-violet-600 text-white px-6 py-4 rounded-2xl flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 shadow-xl shadow-indigo-500/25 animate-in slide-in-from-top-2 fade-in duration-300"
-        >
-            {/* Left: selection count */}
-            <div className="flex items-center gap-3">
-                <div className="w-9 h-9 rounded-xl bg-white/15 flex items-center justify-center">
-                    <CheckSquare size={18} aria-hidden="true" />
-                </div>
-                <span className="text-sm font-black uppercase tracking-widest">
-                    {selectedCount} ticket{selectedCount > 1 ? 's' : ''} selected
-                </span>
-            </div>
-
-            {/* Right: controls */}
-            <div className="flex flex-wrap items-center gap-3">
-                {/* Action picker */}
-                <label htmlFor="bulk-action-select" className="sr-only">Bulk action</label>
-                <select
-                    id="bulk-action-select"
-                    value={bulkAction}
-                    onChange={(e) => { setBulkAction(e.target.value); setBulkValue(''); }}
-                    aria-label="Bulk action for selected tickets"
-                    className="bg-white/15 text-white text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2.5 border border-white/20 outline-none cursor-pointer backdrop-blur-sm hover:bg-white/25 transition-colors"
-                >
-                    <option value="" className="text-slate-900">Select Action…</option>
-                    <option value="close" className="text-slate-900">🔒 Close Tickets</option>
-                    <option value="priority" className="text-slate-900">⚡ Change Priority</option>
-                    <option value="assign" className="text-slate-900">👤 Assign Agent</option>
-                </select>
-
-                {/* Priority sub-select */}
-                {bulkAction === 'priority' && (
-                    <>
-                    <label htmlFor="bulk-priority-select" className="sr-only">Priority for selected tickets</label>
-                    <select
-                        id="bulk-priority-select"
-                        value={bulkValue}
-                        onChange={(e) => setBulkValue(e.target.value)}
-                        aria-label="Priority for selected tickets"
-                        className="bg-white/15 text-white text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2.5 border border-white/20 outline-none cursor-pointer backdrop-blur-sm animate-in fade-in slide-in-from-left-2 duration-200"
-                    >
-                        <option value="" className="text-slate-900">Pick Priority</option>
-                        {priorities.filter(p => p !== 'All').map(p => (
-                            <option key={p} value={p.toLowerCase()} className="text-slate-900">{p}</option>
-                        ))}
-                    </select>
-                    </>
-                )}
-
-                {/* Agent sub-select */}
-                {bulkAction === 'assign' && (
-                    <>
-                    <label htmlFor="bulk-assign-select" className="sr-only">Agent for selected tickets</label>
-                    <select
-                        id="bulk-assign-select"
-                        value={bulkValue}
-                        onChange={(e) => setBulkValue(e.target.value)}
-                        aria-label="Agent for selected tickets"
-                        className="bg-white/15 text-white text-xs font-black uppercase tracking-widest rounded-xl px-4 py-2.5 border border-white/20 outline-none cursor-pointer backdrop-blur-sm animate-in fade-in slide-in-from-left-2 duration-200"
-                    >
-                        <option value="" className="text-slate-900">Pick Agent</option>
-                        {agents.map(a => (
-                            <option key={a.id} value={a.id} className="text-slate-900">{a.full_name}</option>
-                        ))}
-                    </select>
-                    </>
-                )}
-
-                {/* Apply */}
-                {canApply && (
-                    <button
-                        id="bulk-apply-btn"
-                        type="button"
-                        onClick={onApply}
-                        aria-label={`Review bulk action for ${selectedCount} selected ticket${selectedCount > 1 ? 's' : ''}`}
-                        className="bg-white text-indigo-600 text-xs font-black uppercase tracking-widest rounded-xl px-5 py-2.5 hover:bg-indigo-50 transition-all shadow-lg shadow-black/10 animate-in fade-in zoom-in-95 duration-200"
-                    >
-                        Apply
-                    </button>
-                )}
-
-                {/* Clear */}
-                <button
-                    id="bulk-clear-btn"
-                    type="button"
-                    onClick={onClear}
-                    aria-label="Clear selected tickets"
-                    className="p-2.5 hover:bg-white/15 rounded-xl transition-colors"
-                    title="Clear selection"
-                >
-                    <X size={16} aria-hidden="true" />
-                </button>
-            </div>
-        </div>
-    );
-};
-
-/* ────────────────────────────────────────────────────────────
-   Main Component
-   ──────────────────────────────────────────────────────────── */
 const AdminTickets = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const { user, profile } = useAuthStore();
+    const { user } = useAuthStore();
     const { showToast } = useToastStore();
 
-    // ── Data State ──────────────────────────────────
+    // Data State
     const [tickets, setTickets] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
-    const [isUpdating, setIsUpdating] = useState(null);
-    const [newlyBreachedTicketIds, setNewlyBreachedTicketIds] = useState([]);
-    const [agents, setAgents] = useState([]);
+    const [isUpdating, setIsUpdating] = useState(null); // ID of ticket being updated
 
-    // ── Filter State ────────────────────────────────
+    // Filter States
     const [searchQuery, setSearchQuery] = useState('');
-    const [debouncedSearch, setDebouncedSearch] = useState('');
     const [statusFilter, setStatusFilter] = useState('All');
     const [categoryFilter, setCategoryFilter] = useState('All');
     const [priorityFilter, setPriorityFilter] = useState('All');
     const [teamFilter, setTeamFilter] = useState('All');
-    const [languageFilter, setLanguageFilter] = useState('All');
-    const [slaAtRisk, setSlaAtRisk] = useState(false);
-    const [agents, setAgents] = useState([]);
-    const [tagFilters, setTagFilters] = useState([]);
+    const [agents, setAgents] = useState([]); // All staff/admins in the company
 
-    // ── Bulk Action State ───────────────────────────
-    const [selectedTickets, setSelectedTickets] = useState([]);
-    const [bulkAction, setBulkAction] = useState('');
-    const [bulkValue, setBulkValue] = useState('');
-    const [showBulkConfirm, setShowBulkConfirm] = useState(false);
-    const [isBulkExecuting, setIsBulkExecuting] = useState(false);
-    const [ticketAnnouncement, setTicketAnnouncement] = useState('');
-
-    // ── Constants ───────────────────────────────────
-    const categories = ['All', 'Network', 'Hardware', 'Software', 'Access', 'Account'];
-    const priorities = ['All', 'Low', 'Medium', 'High'];
-    const statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed', 'Spam'];
-    const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
-
-    // ── Realtime filter predicate ───────────────────
-    const ticketMatchesFilters = useCallback((ticket) => {
-        if (statusFilter !== 'All' && String(ticket.status || '').toLowerCase() !== statusFilter.toLowerCase()) return false;
-        if (categoryFilter !== 'All' && ticket.category !== categoryFilter) return false;
-        if (priorityFilter !== 'All' && String(ticket.priority || '').toLowerCase() !== priorityFilter.toLowerCase()) return false;
-        if (teamFilter !== 'All' && ticket.assigned_team !== teamFilter) return false;
-        if (tagFilters.length > 0 && !(ticket.tags || []).length) return false;
-        if (tagFilters.length > 0 && !tagFilters.every(tag => (ticket.tags || []).includes(tag))) return false;
-        if (languageFilter !== 'All') {
-            const translated = ticket?.metadata?.translation?.translated;
-            if (languageFilter === 'Translated' && !translated) return false;
-            if (languageFilter === 'English' && translated) return false;
-        }
-        return true;
-    }, [categoryFilter, priorityFilter, statusFilter, teamFilter, languageFilter, tagFilters]);
-
-    const handleRealtimeInsert = useCallback((ticket) => {
-        showToast(`New Incident Reported: #${formatTicketId(ticket.id)}`, "success");
-        setTicketAnnouncement(`New ticket ${formatTicketId(ticket.id)} added to ticket management.`);
-    }, [showToast]);
-
-    const { lastChangedTicketId } = useTicketsRealtime({
-        company: profile?.company,
-        enabled: Boolean(profile),
-        onTicketsChange: setTickets,
-        onInsert: handleRealtimeInsert,
-        shouldInclude: ticketMatchesFilters,
-        channelName: 'admin_tickets_realtime',
-    });
-
-    // ── Data Fetching ───────────────────────────────
     const fetchInitialData = async () => {
         setLoading(true);
         try {
             const { profile } = useAuthStore.getState();
-
+            
+            // 1. Fetch Agents for this company
             if (profile?.company) {
                 const { data: agentData } = await supabase
                     .from('profiles')
@@ -355,6 +61,7 @@ const AdminTickets = () => {
                 setAgents(agentData || []);
             }
 
+            // 2. Fetch Tickets (Join with both Creator and Assignee)
             fetchTickets();
         } catch (err) {
             console.error("Initialization error:", err);
@@ -363,11 +70,12 @@ const AdminTickets = () => {
         }
     };
 
-    const fetchTickets = useCallback(async () => {
+    const fetchTickets = async () => {
         setError(null);
         try {
             const { profile } = useAuthStore.getState();
-
+            
+            // Join with profiles for both user_id (creator) and assigned_agent_id (assignee)
             let query = supabase
                 .from('tickets')
                 .select(`
@@ -384,92 +92,60 @@ const AdminTickets = () => {
             if (categoryFilter !== 'All') query = query.eq('category', categoryFilter);
             if (priorityFilter !== 'All') query = query.eq('priority', priorityFilter.toLowerCase());
             if (teamFilter !== 'All') query = query.eq('assigned_team', teamFilter);
-            if (debouncedSearch) {
-                const escaped = debouncedSearch.replace(/%/g, '\\%').replace(/_/g, '\\_');
-                query = query.or(`subject.ilike.%${escaped}%,description.ilike.%${escaped}%,summary.ilike.%${escaped}%`);
-            }
 
-            // Sort
-            const [sortCol, sortDir] = ('created_at:desc').split(':');
-            query = query.order(sortCol || 'created_at', { ascending: sortDir === 'asc' });
-
-            let { data, error: sbError } = await query;
+            let { data, error: sbError } = await query.order('created_at', { ascending: false });
 
             if (sbError) {
+                // Secondary check: If the FK alias fails, try a simpler select
                 console.warn("Retrying fetch without relationship aliases...");
                 const basicQuery = supabase.from('tickets').select('*, profiles(full_name, email)');
-                const { data: basicData, error: basicError } = await basicQuery
-                    .eq('company', profile?.company)
-                    .order('created_at', { ascending: false });
+                const { data: basicData, error: basicError } = await basicQuery.eq('company', profile?.company).order('created_at', { ascending: false });
                 if (basicError) throw basicError;
                 setTickets(basicData || []);
             } else {
                 setTickets(data || []);
             }
         } catch (err) {
-            console.error('Admin fetch error:', err);
+            console.error("Admin fetch error:", err);
             setError(err.message);
-        } finally {
-            setLoading(false);
         }
-    }, [debouncedSearch, statusFilter, categoryFilter, priorityFilter, teamFilter]);
-
-    const fetchInitialData = useCallback(async () => {
-        const { profile } = useAuthStore.getState();
-        if (profile?.company) {
-            const { data: agentData } = await supabase
-                .from('profiles')
-                .select('id, full_name, role')
-                .eq('company', profile.company)
-                .in('role', ['admin', 'super_admin', 'agent']);
-            setAgents(agentData || []);
-        }
-        fetchTickets();
-    }, [fetchTickets]);
+    };
 
     useEffect(() => {
-        if (!user) return;
         fetchInitialData();
-    }, [user, fetchInitialData]);
 
-    // SLA breach realtime listener
-    useEffect(() => {
-        const channelSla = supabase
-            .channel('sla-alerts')
+        // 4. Real-time subscription to ticket changes
+        const { profile } = useAuthStore.getState();
+        const channel = supabase
+            .channel('admin_tickets_realtime')
             .on(
-                'broadcast',
-                { event: 'breach' },
+                'postgres_changes',
+                {
+                    event: '*',
+                    schema: 'public',
+                    table: 'tickets',
+                    filter: profile?.company ? `company=eq.${profile.company}` : undefined
+                },
                 (payload) => {
-                    const { ticketId, subject, originalTeam, escalatedTeam, companyId } = payload.payload;
-                    const { profile } = useAuthStore.getState();
-                    if (profile?.company_id && companyId && profile.company_id !== companyId) return;
-
-                    const formattedId = String(ticketId).slice(0, 8).toUpperCase();
-                    showToast(`⚠️ SLA BREACH: Ticket #${formattedId} ("${subject}") escalated from '${originalTeam}' to '${escalatedTeam}'!`, "error");
-                    setTicketAnnouncement(`SLA breach for ticket ${formattedId}. Escalated from ${originalTeam} to ${escalatedTeam}.`);
-
-                    setNewlyBreachedTicketIds(prev => [...prev, ticketId]);
-                    setTimeout(() => {
-                        setNewlyBreachedTicketIds(prev => prev.filter(id => id !== ticketId));
-                    }, 12000);
-
-                    setTickets(prev => prev.map(t =>
-                        t.id === ticketId
-                            ? { ...t, sla_status: 'BREACHED', assigned_team: escalatedTeam, escalation_level: (t.escalation_level || 0) + 1, updated_at: new Date().toISOString() }
-                            : t
-                    ));
+                    console.log("Admin tickets sync event:", payload.eventType, payload.new);
+                    if (payload.eventType === 'INSERT') {
+                        setTickets(prev => [payload.new, ...prev]);
+                        showToast(`New Incident Reported: #${payload.new.id}`, "success");
+                        // Play a subtle sound or visual cue if needed
+                    } else if (payload.eventType === 'UPDATE') {
+                        setTickets(prev => prev.map(t => t.id === payload.new.id ? { ...t, ...payload.new } : t));
+                    } else if (payload.eventType === 'DELETE') {
+                        setTickets(prev => prev.filter(t => t.id === payload.old.id));
+                    }
                 }
             )
             .subscribe();
 
-        return () => { supabase.removeChannel(channelSla); };
-    }, []);
-
-    // Debounce search query
-    useEffect(() => {
-        const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300);
-        return () => clearTimeout(timer);
-    }, [searchQuery]);
+        return () => {
+            supabase.removeChannel(channel);
+        };
+     
+    }, [statusFilter, categoryFilter, priorityFilter, teamFilter]);
 
     // Seed search from URL
     useEffect(() => {
@@ -478,144 +154,51 @@ const AdminTickets = () => {
         if (q) setSearchQuery(decodeURIComponent(q));
     }, [location.search]);
 
-    // ── Single-ticket update ────────────────────────
     const handleUpdateTicket = async (id, updates) => {
         setIsUpdating(id);
         try {
-            await api.apiUpdateTicket(id, updates); const upError = null;
+            const { error: upError } = await supabase
+                .from('tickets')
+                .update(updates)
+                .eq('id', id);
 
             if (upError) throw upError;
 
+            // Optimistic update already handled if real-time is fast, 
+            // but manual update ensures immediate feedback
             setTickets(prev => prev.map(t => t.id === id ? { ...t, ...updates } : t));
             showToast("System synchronization successful.", "success");
-            setTicketAnnouncement(`Ticket ${formatTicketId(id)} updated successfully.`);
         } catch (err) {
             console.error("Update failed:", err);
             showToast("Update failed: " + err.message, "error");
-            setTicketAnnouncement(`Ticket ${formatTicketId(id)} update failed: ${err.message}`);
         } finally {
             setIsUpdating(null);
         }
     };
 
-    // ── Bulk Operations ─────────────────────────────
-    const handleSelectAll = () => {
-        if (selectedTickets.length === filteredTickets.length && filteredTickets.length > 0) {
-            setSelectedTickets([]);
-            setTicketAnnouncement('All visible tickets deselected.');
-        } else {
-            setSelectedTickets(filteredTickets.map(t => t.id));
-            setTicketAnnouncement(`${filteredTickets.length} visible ticket${filteredTickets.length > 1 ? 's' : ''} selected.`);
-        }
-    };
+    const categories = ['All', 'Network', 'Hardware', 'Software', 'Access', 'Account'];
+    const priorities = ['All', 'Low', 'Medium', 'High'];
+    const statuses = ['All', 'Open', 'In Progress', 'Resolved', 'Closed'];
+    const teams = ['All', 'Software Team', 'Hardware Support', 'Network Ops', 'Security Unit', 'General Support'];
 
-    const handleSelectTicket = (id) => {
-        setSelectedTickets(prev => {
-            const isSelected = prev.includes(id);
-            const next = isSelected ? prev.filter(t => t !== id) : [...prev, id];
-            setTicketAnnouncement(`Ticket ${formatTicketId(id)} ${isSelected ? 'deselected' : 'selected'}. ${next.length} ticket${next.length === 1 ? '' : 's'} selected.`);
-            return next;
-        });
-    };
-
-    const handleBulkClear = () => {
-        setSelectedTickets([]);
-        setBulkAction('');
-        setBulkValue('');
-        setTicketAnnouncement('Bulk selection cleared.');
-    };
-
-    const handleBulkExecute = async () => {
-        if (!bulkAction || selectedTickets.length === 0) return;
-        setIsBulkExecuting(true);
-        try {
-            let updates = {};
-            if (bulkAction === 'close') updates = { status: 'closed' };
-            if (bulkAction === 'priority') updates = { priority: bulkValue };
-            if (bulkAction === 'assign') updates = { assigned_agent_id: bulkValue, status: 'in progress' };
-
-            // Batch update via Supabase .in() for efficiency
-            const { error: bulkError } = await supabase
-                .from('tickets')
-                .update(updates)
-                .in('id', selectedTickets);
-
-            if (bulkError) throw bulkError;
-
-            // Optimistic state update
-            setTickets(prev => prev.map(t =>
-                selectedTickets.includes(t.id) ? { ...t, ...updates } : t
-            ));
-
-            const actionLabel = bulkAction === 'close' ? 'closed' : bulkAction === 'priority' ? 'priority updated' : 'assigned';
-            showToast(`✅ ${selectedTickets.length} ticket${selectedTickets.length > 1 ? 's' : ''} ${actionLabel} successfully.`, "success");
-            setTicketAnnouncement(`${selectedTickets.length} ticket${selectedTickets.length > 1 ? 's' : ''} ${actionLabel} successfully.`);
-
-            setSelectedTickets([]);
-            setBulkAction('');
-            setBulkValue('');
-            setShowBulkConfirm(false);
-        } catch (err) {
-            console.error("Bulk update failed:", err);
-            showToast("Bulk update failed: " + err.message, "error");
-            setTicketAnnouncement(`Bulk update failed: ${err.message}`);
-        } finally {
-            setIsBulkExecuting(false);
-        }
-    };
-
-    // ── Derived / Filtered ──────────────────────────
     const filteredTickets = useMemo(() => {
-        let result = tickets;
-        if (debouncedSearch) {
-            const q = sanitizeSearchQuery(debouncedSearch).toLowerCase();
-            result = result.filter(t =>
-                String(t.id).includes(q) ||
-                (t.subject || '').toLowerCase().includes(q) ||
-                (t.summary || '').toLowerCase().includes(q) ||
-                (t.description || '').toLowerCase().includes(q) ||
-                (t.profiles?.full_name || '').toLowerCase().includes(q)
-            );
-        }
-        if (languageFilter !== 'All') {
-            result = result.filter(t => {
-                const translated = t.detected_language && t.detected_language.toLowerCase() !== 'en';
-                return languageFilter === 'Translated' ? translated : !translated;
-            });
-        }
-        if (slaAtRisk) {
-            result = result.filter(t => {
-                const s = (t.sla_status || '').toUpperCase();
-                return s === 'BREACHED' || s === 'WARNING';
-            });
-        }
-        if (tagFilters.length > 0) {
-            result = result.filter(t => (t.tags || []).length > 0 && tagFilters.every(tag => (t.tags || []).includes(tag)));
-        }
-        return result;
-    }, [tickets, languageFilter, slaAtRisk, tagFilters]);
+        if (!searchQuery) return tickets;
+        const q = searchQuery.toLowerCase();
+        return tickets.filter(t =>
+            String(t.id).includes(q) ||
+            (t.subject || '').toLowerCase().includes(q) ||
+            (t.summary || '').toLowerCase().includes(q) ||
+            (t.description || '').toLowerCase().includes(q) ||
+            (t.profiles?.full_name || '').toLowerCase().includes(q)
+        );
+    }, [tickets, searchQuery]);
 
-    // Clear selection when filters change (selected IDs may no longer be visible)
-    useEffect(() => {
-        setSelectedTickets([]);
-    }, [statusFilter, categoryFilter, priorityFilter, teamFilter, debouncedSearch, languageFilter, slaAtRisk, tagFilters]);
-
-    // ── Helpers ─────────────────────────────────────
     const getPriorityStyle = (priority) => {
         const p = String(priority || '').toLowerCase();
         if (p === 'high' || p === 'critical') return 'text-red-600 bg-red-50 border-red-100';
         if (p === 'medium') return 'text-amber-600 bg-amber-50 border-amber-100';
         if (p === 'low') return 'text-emerald-600 bg-emerald-50 border-emerald-100';
-        return 'text-slate-500 dark:text-slate-400 bg-slate-50 border-slate-100';
-    };
-
-    // Critical / high priority tickets get an animated pulse dot next to their
-    // priority selector so they're instantly noticeable in the dashboard list.
-    const getPriorityPulseClass = (priority) => {
-        const p = String(priority || '').toLowerCase();
-        if (p === 'critical') return 'bg-red-600 priority-dot-pulse-critical';
-        if (p === 'high') return 'bg-orange-500 priority-dot-pulse-high';
-        return null;
+        return 'text-slate-500 bg-slate-50 border-slate-100'; // Default
     };
 
     const getConfidenceColor = (conf) => {
@@ -624,28 +207,8 @@ const AdminTickets = () => {
         return 'bg-red-500';
     };
 
-    const handleExportTickets = () => {
-        try {
-            const exportDate = new Date().toISOString().slice(0, 10);
-            downloadCSV(filteredTickets, `ticket-history-${exportDate}`);
-            showToast(`${filteredTickets.length} ticket${filteredTickets.length === 1 ? '' : 's'} exported as CSV.`, 'success');
-            setTicketAnnouncement(`${filteredTickets.length} ticket${filteredTickets.length === 1 ? '' : 's'} exported as CSV.`);
-        } catch (err) {
-            const message = err instanceof Error ? err.message : 'CSV export failed';
-            showToast(message, 'error');
-            setTicketAnnouncement(message);
-        }
-    };
-
-    const isAllSelected = filteredTickets.length > 0 && selectedTickets.length === filteredTickets.length;
-    const isSomeSelected = selectedTickets.length > 0 && selectedTickets.length < filteredTickets.length;
-
-    // ── Render ──────────────────────────────────────
     return (
-        <div className="space-y-6 animate-in fade-in duration-700">
-            <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-                {ticketAnnouncement}
-            </div>
+        <div className="space-y-8 animate-in fade-in duration-700">
             {/* 1. Header & Utility Bar */}
             <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
                 <div>
@@ -653,34 +216,6 @@ const AdminTickets = () => {
                     <p className="text-sm font-bold text-slate-400 mt-1 flex items-center gap-2">
                         <Activity size={14} className="text-indigo-500" /> {filteredTickets.length} tickets matching current filters.
                     </p>
-                </div>
-                <div className="flex items-center gap-3">
-                    {/* Export CSV */}
-                    <button
-                        type="button"
-                        onClick={handleExportTickets}
-                        disabled={filteredTickets.length === 0}
-                        aria-label={`Export ${filteredTickets.length} filtered tickets as CSV`}
-                        className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 rounded-2xl text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 hover:bg-emerald-50 hover:border-emerald-200 hover:text-emerald-700 disabled:opacity-40 disabled:cursor-not-allowed transition-all shadow-sm"
-                    >
-                        <Download size={14} aria-hidden="true" />
-                        CSV
-                    </button>
-                    {/* Print Selected */}
-                    {selectedTickets.length === 1 && (
-                        <button
-                            type="button"
-                            onClick={() => {
-                                const t = tickets.find(t => t.id === selectedTickets[0]);
-                                if (t) printTicket(t);
-                            }}
-                            aria-label={`Print ticket ${formatTicketId(selectedTickets[0])}`}
-                            className="flex items-center gap-2 px-4 py-2.5 bg-white border border-slate-200 rounded-2xl text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 hover:bg-blue-50 hover:border-blue-200 hover:text-blue-700 transition-all shadow-sm"
-                        >
-                            <Printer size={14} aria-hidden="true" />
-                            Print
-                        </button>
-                    )}
                 </div>
             </div>
 
@@ -695,7 +230,6 @@ const AdminTickets = () => {
                             placeholder="Search..."
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
-                            aria-label="Search tickets"
                             className="w-full bg-slate-50 border border-slate-200 rounded-2xl pl-12 pr-4 py-3 text-sm font-bold focus:outline-none focus:ring-4 focus:ring-emerald-500/5 focus:border-emerald-500 focus:bg-white transition-all text-slate-700 placeholder:text-slate-400"
                         />
                     </div>
@@ -704,8 +238,7 @@ const AdminTickets = () => {
                     <Select
                         value={statusFilter}
                         onChange={(e) => setStatusFilter(e.target.value)}
-                        aria-label="Filter tickets by status"
-                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
                         options={statuses.map(s => ({ value: s, label: s === 'All' ? 'All Statuses' : s }))}
                     />
 
@@ -713,8 +246,7 @@ const AdminTickets = () => {
                     <Select
                         value={categoryFilter}
                         onChange={(e) => setCategoryFilter(e.target.value)}
-                        aria-label="Filter tickets by category"
-                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
                         options={categories.map(c => ({ value: c, label: c === 'All' ? 'All Categories' : c }))}
                     />
 
@@ -722,8 +254,7 @@ const AdminTickets = () => {
                     <Select
                         value={priorityFilter}
                         onChange={(e) => setPriorityFilter(e.target.value)}
-                        aria-label="Filter tickets by priority"
-                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
                         options={priorities.map(p => ({ value: p, label: p === 'All' ? 'All Priorities' : p }))}
                     />
 
@@ -731,97 +262,13 @@ const AdminTickets = () => {
                     <Select
                         value={teamFilter}
                         onChange={(e) => setTeamFilter(e.target.value)}
-                        aria-label="Filter tickets by assigned team"
-                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
+                        buttonClassName="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 focus:outline-none focus:ring-4 focus:ring-emerald-500/5 transition-all text-left flex justify-between items-center"
                         options={teams.map(t => ({ value: t, label: t === 'All' ? 'All Teams' : t }))}
                     />
                 </div>
-
-                {/* Combined Filter Row */}
-                <div className="flex items-center gap-3">
-                    <Select
-                        value={languageFilter}
-                        onChange={(e) => setLanguageFilter(e.target.value)}
-                        aria-label="Filter tickets by language"
-                        buttonClassName="bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-[11px] font-black uppercase tracking-widest text-slate-600 dark:text-slate-400 focus:outline-none focus:ring-4 focus:ring-sky-500/5 transition-all text-left flex justify-between items-center"
-                        options={[
-                            { value: 'All', label: '🌐 All Languages' },
-                            { value: 'English', label: 'English Only' },
-                            { value: 'Translated', label: 'Translated Only' },
-                        ]}
-                    />
-
-                    <button
-                        type="button"
-                        onClick={() => setSlaAtRisk(prev => !prev)}
-                        aria-label={slaAtRisk ? 'Disable SLA at risk filter' : 'Enable SLA at risk filter'}
-                        aria-pressed={slaAtRisk}
-                        className={`flex items-center gap-2 px-4 py-3 rounded-2xl text-[11px] font-black uppercase tracking-widest border transition-all ${
-                            slaAtRisk
-                                ? 'bg-red-50 border-red-200 text-red-700 shadow-sm'
-                                : 'bg-slate-50 border-slate-200 text-slate-500 dark:text-slate-400 hover:border-red-200 hover:text-red-600'
-                        }`}
-                    >
-                        <ShieldAlert size={14} aria-hidden="true" />
-                        SLA At Risk
-                        {slaAtRisk && (
-                            <span className="ml-1 w-4 h-4 rounded-full bg-red-500 text-white flex items-center justify-center text-[9px]">
-                                {filteredTickets.length}
-                            </span>
-                        )}
-                    </button>
-                </div>
-
-                {/* Tag Filter */}
-                <div>
-                    <TagFilter companyId={profile?.company_id} onFilterChange={setTagFilters} />
-                </div>
             </div>
 
-            {/* 3. Bulk Action Toolbar — appears when 1+ tickets selected */}
-            {selectedTickets.length > 0 && (
-                <BulkActionToolbar
-                    selectedCount={selectedTickets.length}
-                    bulkAction={bulkAction}
-                    setBulkAction={setBulkAction}
-                    bulkValue={bulkValue}
-                    setBulkValue={setBulkValue}
-                    agents={agents}
-                    priorities={priorities}
-                    onApply={() => setShowBulkConfirm(true)}
-                    onClear={handleBulkClear}
-                />
-            )}
-
-            {/* 4. Bulk Confirm Modal */}
-            {showBulkConfirm && (
-                <BulkConfirmModal
-                    action={bulkAction}
-                    count={selectedTickets.length}
-                    onConfirm={handleBulkExecute}
-                    onCancel={() => setShowBulkConfirm(false)}
-                    isExecuting={isBulkExecuting}
-                />
-            )}
-
-            {/* 5. High-Density Data Terminal */}
-            <style>{`
-                @keyframes priority-pulse-critical {
-                    0% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0.55); }
-                    70% { box-shadow: 0 0 0 6px rgba(220, 38, 38, 0); }
-                    100% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0); }
-                }
-                @keyframes priority-pulse-high {
-                    0% { box-shadow: 0 0 0 0 rgba(234, 88, 12, 0.5); }
-                    70% { box-shadow: 0 0 0 6px rgba(234, 88, 12, 0); }
-                    100% { box-shadow: 0 0 0 0 rgba(234, 88, 12, 0); }
-                }
-                .priority-dot-pulse-critical { animation: priority-pulse-critical 1.6s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
-                .priority-dot-pulse-high { animation: priority-pulse-high 1.8s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
-                @media (prefers-reduced-motion: reduce) {
-                    .priority-dot-pulse-critical, .priority-dot-pulse-high { animation: none; }
-                }
-            `}</style>
+            {/* 3. High-Density Data Terminal */}
             <div className="bg-white rounded-[2rem] border border-slate-200 shadow-2xl shadow-slate-200/50 overflow-hidden relative min-h-[400px]">
                 {loading && (
                     <div className="absolute inset-0 bg-white/60 backdrop-blur-[2px] z-10 flex items-center justify-center">
@@ -833,97 +280,39 @@ const AdminTickets = () => {
                     <div className="p-12 text-center text-red-500 space-y-4">
                         <AlertCircle className="mx-auto w-12 h-12" />
                         <p className="font-bold uppercase tracking-widest text-xs">{error}</p>
-                        <button onClick={retry} className="px-6 py-2 bg-slate-900 text-white rounded-xl text-[10px] font-black uppercase tracking-widest">Retry</button>
+                        <button onClick={fetchTickets} className="px-6 py-2 bg-slate-900 text-white rounded-xl text-[10px] font-black uppercase tracking-widest">Retry</button>
                     </div>
                 )}
 
-                <div className="overflow-x-auto" role="region" aria-label="Ticket management results" tabIndex={0}>
-                    <table id="ticket-management-table" className="w-full border-collapse" aria-label="Ticket management table" aria-rowcount={filteredTickets.length}>
+                <div className="overflow-x-auto">
+                    <table className="w-full border-collapse">
                         <thead>
                             <tr className="bg-slate-50/80 border-b border-slate-100">
-                                {/* Select All Checkbox */}
-                                <th scope="col" className="px-4 py-5 text-center w-12">
-                                    <button
-                                        id="select-all-checkbox"
-                                        type="button"
-                                        onClick={handleSelectAll}
-                                        aria-label={isAllSelected ? `Deselect all ${filteredTickets.length} visible tickets` : `Select all ${filteredTickets.length} visible tickets`}
-                                        aria-pressed={isAllSelected}
-                                        aria-controls="ticket-management-table"
-                                        className="text-slate-400 hover:text-indigo-600 transition-colors relative"
-                                        title={isAllSelected ? 'Deselect all' : 'Select all'}
-                                    >
-                                        {isAllSelected ? (
-                                            <CheckSquare size={18} className="text-indigo-600" />
-                                        ) : isSomeSelected ? (
-                                            <div className="relative">
-                                                <Square size={18} />
-                                                <div className="absolute inset-0 flex items-center justify-center">
-                                                    <div className="w-2 h-0.5 bg-indigo-500 rounded" />
-                                                </div>
-                                            </div>
-                                        ) : (
-                                            <Square size={18} />
-                                        )}
-                                    </button>
-                                </th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">
                                     <div className="flex items-center gap-2">
                                         ID
                                         <div className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse"></div>
                                     </div>
                                 </th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">User</th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Subject</th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Priority</th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">AI Score</th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Agent</th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Status</th>
-                                <th scope="col" className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">SLA</th>
-                                <th scope="col" className="px-6 py-5 text-center text-[10px] font-black text-slate-400 uppercase tracking-widest">Actions</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">User</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Subject</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Priority</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">AI Score</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Agent</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">Status</th>
+                                <th className="px-6 py-5 text-left text-[10px] font-black text-slate-400 uppercase tracking-widest">SLA</th>
+                                <th className="px-6 py-5 text-center text-[10px] font-black text-slate-400 uppercase tracking-widest">Actions</th>
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-slate-50">
-                            {filteredTickets.map((ticket) => {
-                                const wasLiveChanged = String(lastChangedTicketId) === String(ticket.id);
-                                const isSelected = selectedTickets.includes(ticket.id);
-                                const slaState = (ticket.sla_status || '').toUpperCase();
-                                const slaRowClass =
-                                    slaState === 'BREACHED' ? 'bg-red-50/60 ring-1 ring-red-100' :
-                                    slaState === 'WARNING'  ? 'bg-amber-50/50 ring-1 ring-amber-100' : '';
-
-                                return (
-                                <tr
-                                    key={ticket.id}
-                                    aria-selected={isSelected}
-                                    className={`hover:bg-slate-50/50 transition-colors group ${
-                                        wasLiveChanged ? 'bg-emerald-50/70 ring-1 ring-emerald-100' : slaRowClass
-                                    } ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''} ${
-                                        isSelected ? 'bg-indigo-50/40 ring-1 ring-indigo-100' : ''
-                                    }`}
-                                >
-                                    {/* Row Checkbox */}
-                                    <td className="px-4 py-6 text-center">
-                                        <button
-                                            type="button"
-                                            onClick={() => handleSelectTicket(ticket.id)}
-                                            aria-label={`${isSelected ? 'Deselect' : 'Select'} ticket ${formatTicketId(ticket.id)}`}
-                                            aria-pressed={isSelected}
-                                            className="text-slate-300 hover:text-indigo-600 transition-colors"
-                                        >
-                                            {isSelected
-                                                ? <CheckSquare size={16} className="text-indigo-600" />
-                                                : <Square size={16} />
-                                            }
-                                        </button>
-                                    </td>
-
+                            {filteredTickets.map((ticket) => (
+                                <tr key={ticket.id} className={`hover:bg-slate-50/50 transition-colors group ${isUpdating === ticket.id ? 'opacity-50 pointer-events-none' : ''}`}>
                                     {/* Ticket ID */}
                                     <td className="px-6 py-6">
                                         <span className="font-mono text-xs font-black text-emerald-600">#{formatTicketId(ticket.id)}</span>
                                     </td>
 
-                                    {/* User */}
+                                    {/* User (Joined with Profiles) */}
                                     <td className="px-6 py-6">
                                         <div className="flex items-center gap-3">
                                             {ticket.creator?.profile_picture || ticket.profiles?.profile_picture ? (
@@ -951,65 +340,43 @@ const AdminTickets = () => {
                                     {/* Subject */}
                                     <td className="px-6 py-6">
                                         <div className="flex flex-col">
-                                            <div className="flex items-center gap-2">
-                                                <span className="text-xs font-bold text-slate-700 truncate max-w-[200px]" title={ticket.summary || ticket.subject}>
-                                                    {ticket.summary || ticket.subject}
-                                                </span>
-                                                {ticket.metadata?.spam_analysis?.is_spam && (
-                                                    <span className={`px-2 py-0.5 rounded text-[8px] font-black uppercase tracking-wider flex items-center gap-1 ${
-                                                        ticket.metadata.spam_analysis.risk_level === 'high'
-                                                            ? 'bg-red-100 text-red-700 border border-red-200'
-                                                            : 'bg-amber-100 text-amber-700 border border-amber-200'
-                                                    }`}>
-                                                        <ShieldAlert size={10} />
-                                                        {ticket.metadata.spam_analysis.risk_level} Risk
-                                                    </span>
-                                                )}
-                                            </div>
-                                            <span className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
-                                                {ticket.category}
-                                                <span className="text-[9px] font-medium text-slate-300">• {formatTimelineDate(ticket.created_at)}</span>
+                                            <span className="text-xs font-bold text-slate-700 truncate max-w-[200px]" title={ticket.summary || ticket.subject}>
+                                                {ticket.summary || ticket.subject}
                                             </span>
-                                            <LanguageBadge detectedLanguage={ticket?.detected_language} compact />
+                                            <span className="text-[10px] font-black text-slate-400 uppercase tracking-widest flex items-center gap-2">
+                                                {ticket.category} 
+                                                <span className="text-[9px] font-medium text-slate-300" title={formatTimelineDate(ticket.created_at)}>• {formatRelativeTime(ticket.created_at)}</span>
+                                            </span>
                                         </div>
                                     </td>
 
                                     {/* Priority (Editable) */}
                                     <td className="px-6 py-6">
-                                        <div className="relative inline-flex items-center gap-1.5">
-                                            {getPriorityPulseClass(ticket.priority) && (
-                                                <span
-                                                    className={`w-1.5 h-1.5 rounded-full inline-block flex-shrink-0 ${getPriorityPulseClass(ticket.priority)}`}
-                                                    aria-hidden="true"
-                                                />
-                                            )}
-                                            <select
-                                                value={String(ticket.priority || 'medium').toLowerCase()}
-                                                onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })}
-                                                aria-label={`Change priority for ticket ${formatTicketId(ticket.id)}`}
-                                                className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}
-                                            >
-                                                {priorities.filter(p => p !== 'All').map(p => (
-                                                    <option key={p} value={p.toLowerCase()}>{p}</option>
-                                                ))}
-                                            </select>
-                                        </div>
+                                        <select
+                                            value={String(ticket.priority || 'medium').toLowerCase()}
+                                            onChange={(e) => handleUpdateTicket(ticket.id, { priority: e.target.value })}
+                                            className={`px-3 py-1.5 rounded-xl text-[9px] font-black uppercase tracking-wider border outline-none cursor-pointer transition-all flex items-center justify-between ${getPriorityStyle(ticket.priority)}`}
+                                        >
+                                            {priorities.filter(p => p !== 'All').map(p => (
+                                                <option key={p} value={p.toLowerCase()}>{p}</option>
+                                            ))}
+                                        </select>
                                     </td>
 
                                     {/* AI Score (Confidence) */}
                                     <td className="px-6 py-6">
                                         <div className="flex items-center gap-2">
                                             <div className={`w-8 h-8 rounded-full border-2 flex items-center justify-center text-[8px] font-black
-                                                ${ticket.confidence >= 0.8 ? 'border-emerald-500 text-emerald-600 bg-emerald-50' :
-                                                  ticket.confidence >= 0.5 ? 'border-amber-500 text-amber-600 bg-amber-50' :
+                                                ${ticket.confidence >= 0.8 ? 'border-emerald-500 text-emerald-600 bg-emerald-50' : 
+                                                  ticket.confidence >= 0.5 ? 'border-amber-500 text-amber-600 bg-amber-50' : 
                                                   'border-red-500 text-red-600 bg-red-50'}`}>
                                                 {(ticket.confidence * 100).toFixed(0)}%
                                             </div>
                                             <div className="flex flex-col">
                                                 <span className="text-[8px] font-black text-slate-400 uppercase">Confidence</span>
                                                 <div className="w-12 h-1 bg-slate-100 rounded-full overflow-hidden mt-0.5">
-                                                    <div
-                                                        className={`h-full ${getConfidenceColor(ticket.confidence || 0)}`}
+                                                    <div 
+                                                        className={`h-full ${getConfidenceColor(ticket.confidence || 0)}`} 
                                                         style={{ width: `${(ticket.confidence || 0) * 100}%` }}
                                                     />
                                                 </div>
@@ -1017,7 +384,7 @@ const AdminTickets = () => {
                                         </div>
                                     </td>
 
-                                    {/* Assigned Team */}
+                                    {/* Assigned Team (Editable) */}
                                     <td className="px-6 py-6 text-emerald-600 font-bold text-[10px]">
                                         {ticket.assigned_team || 'General'}
                                     </td>
@@ -1028,11 +395,10 @@ const AdminTickets = () => {
                                             {ticket.assigned_agent_id ? (
                                                 <select
                                                     value={ticket.assigned_agent_id}
-                                                    onChange={(e) => handleUpdateTicket(ticket.id, {
+                                                    onChange={(e) => handleUpdateTicket(ticket.id, { 
                                                         assigned_agent_id: e.target.value,
                                                         status: 'in progress'
                                                     })}
-                                                    aria-label={`Change assigned agent for ticket ${formatTicketId(ticket.id)}`}
                                                     className="bg-transparent text-[10px] font-black text-indigo-600 uppercase tracking-tight italic border-none focus:ring-0 cursor-pointer hover:underline"
                                                 >
                                                     {agents.map(a => (
@@ -1041,12 +407,10 @@ const AdminTickets = () => {
                                                 </select>
                                             ) : (
                                                 <button
-                                                    type="button"
-                                                    onClick={() => handleUpdateTicket(ticket.id, {
+                                                    onClick={() => handleUpdateTicket(ticket.id, { 
                                                         assigned_agent_id: user.id,
                                                         status: 'in progress'
                                                     })}
-                                                    aria-label={`Claim ticket ${formatTicketId(ticket.id)}`}
                                                     className="px-3 py-1 bg-indigo-50 text-indigo-600 rounded-lg text-[9px] font-black uppercase tracking-widest border border-indigo-100 hover:bg-indigo-600 hover:text-white transition-all shadow-sm"
                                                 >
                                                     Claim
@@ -1058,18 +422,11 @@ const AdminTickets = () => {
                                     {/* Status (Editable) */}
                                     <td className="px-6 py-6">
                                         <div className="flex items-center gap-2">
-                                            <div className={`w-1.5 h-1.5 rounded-full ${
-                                                ticket.status?.toLowerCase() === 'resolved' || ticket.status?.toLowerCase() === 'closed'
-                                                    ? 'bg-emerald-400'
-                                                    : ticket.status?.toLowerCase() === 'spam'
-                                                        ? 'bg-slate-400 border border-slate-500'
-                                                        : 'bg-amber-500 animate-pulse'
-                                            }`}></div>
+                                            <div className={`w-1.5 h-1.5 rounded-full ${ticket.status?.toLowerCase() === 'resolved' || ticket.status?.toLowerCase() === 'closed' ? 'bg-emerald-400' : 'bg-amber-500 animate-pulse'}`}></div>
                                             <Select
                                                 value={String(ticket.status || 'open').toLowerCase()}
                                                 onChange={(e) => handleUpdateTicket(ticket.id, { status: e.target.value })}
-                                                aria-label={`Change status for ticket ${formatTicketId(ticket.id)}`}
-                                                buttonClassName="bg-transparent text-[10px] font-black text-slate-600 dark:text-slate-400 uppercase tracking-widest outline-none cursor-pointer flex justify-between items-center w-full"
+                                                buttonClassName="bg-transparent text-[10px] font-black text-slate-600 uppercase tracking-widest outline-none cursor-pointer flex justify-between items-center w-full"
                                                 options={statuses.filter(s => s !== 'All').map(s => ({ value: s.toLowerCase(), label: s }))}
                                             />
                                         </div>
@@ -1080,10 +437,7 @@ const AdminTickets = () => {
                                         <SLABadge
                                             priority={ticket.priority}
                                             createdAt={ticket.created_at}
-                                            slaBreachAt={ticket.sla_breach_at}
-                                            slaStatus={ticket.sla_status}
                                             status={ticket.status}
-                                            ticketId={ticket.id}
                                         />
                                     </td>
 
@@ -1091,19 +445,16 @@ const AdminTickets = () => {
                                     <td className="px-6 py-6 text-center">
                                         <div className="flex items-center justify-center gap-2">
                                             <button
-                                                type="button"
                                                 onClick={() => navigate(`/admin/ticket/${ticket.id}`)}
-                                                aria-label={`Open details for ticket ${formatTicketId(ticket.id)}`}
                                                 className="p-2 bg-slate-900 text-white rounded-xl hover:bg-emerald-600 transition-all shadow-lg shadow-slate-900/10 hover:shadow-emerald-500/20"
                                                 title="Open Detailed View"
                                             >
-                                                <ArrowUpRight size={14} aria-hidden="true" />
+                                                <ArrowUpRight size={14} />
                                             </button>
                                         </div>
                                     </td>
                                 </tr>
-                                );
-                            })}
+                            ))}
                         </tbody>
                     </table>
                 </div>
@@ -1114,7 +465,7 @@ const AdminTickets = () => {
                             <Inbox size={40} />
                         </div>
                         <h3 className="text-xl font-black text-slate-900 uppercase italic tracking-tight">No Incidents Found</h3>
-                        <p className="text-sm text-slate-500 dark:text-slate-400 font-medium max-w-xs mx-auto mt-2 italic">Refine your search parameters to view more data points.</p>
+                        <p className="text-sm text-slate-500 font-medium max-w-xs mx-auto mt-2 italic">Refine your search parameters to view more data points.</p>
                     </div>
                 )}
             </div>

--- a/Frontend/src/user/pages/TicketDetail.jsx
+++ b/Frontend/src/user/pages/TicketDetail.jsx
@@ -1,16 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
-  ArrowLeft,
-  Clock,
-  ShieldCheck,
-  RotateCcw,
-  Loader2,
-  CheckCircle2,
-  Copy,
+    ArrowLeft, Clock, Bot, UserCog,
+    ShieldCheck, Calendar, Zap, Image as ImageIcon, MessageSquare,
+    RotateCcw, Loader2, CheckCircle2, History
 } from 'lucide-react';
+import { formatFullTimestamp, formatRelativeTime } from '../../utils/dateUtils';
 import { supabase } from "../../lib/supabaseClient";
-import useToastStore from "../../store/toastStore";
 import { Card } from "../../components/ui/card";
 import TicketStatusBadge from "../components/TicketStatusBadge";
 import TicketTimeline from "../components/TicketTimeline";
@@ -26,8 +22,6 @@ const TicketDetail = () => {
     const [isReopening, setIsReopening] = useState(false);
     const [showCsat, setShowCsat] = useState(false);
     const [csatHasBeenDismissed, setCsatHasBeenDismissed] = useState(false);
-    const [copied, setCopied] = useState(false);
-    const { showToast } = useToastStore();
 
     useEffect(() => {
         window.scrollTo(0, 0);
@@ -59,37 +53,36 @@ const TicketDetail = () => {
 
         fetchInitialTicket();
 
+        // 3. Subscribe to REAL-TIME updates for THIS ticket
         const channel = supabase
             .channel(`ticket_update_${ticket_id}`)
-            .on('postgres_changes', {
-                event: 'UPDATE',
-                schema: 'public',
-                table: 'tickets',
-                filter: `id=eq.${ticket_id}`
-            }, (payload) => {
-                setTicket(prev => ({
-                    ...prev,
-                    ...payload.new,
-                    ticket_id: payload.new.id,
-                    text: payload.new.description,
-                    summary: payload.new.subject,
-                }));
-            })
-            .on('postgres_changes', {
-                event: 'DELETE',
-                schema: 'public',
-                table: 'tickets',
-                filter: `id=eq.${ticket_id}`
-            }, (payload) => {
-                console.warn("Ticket was deleted:", payload.old);
-                showToast('This ticket has been removed.', 'warning');
-                navigate('/my-tickets');
-            })
+            .on(
+                'postgres_changes',
+                {
+                    event: 'UPDATE',
+                    schema: 'public',
+                    table: 'tickets',
+                    filter: `id=eq.${ticket_id}`
+                },
+                (payload) => {
+                    console.log("Real-time ticket update received:", payload.new);
+                    setTicket(prev => ({
+                        ...prev,
+                        ...payload.new,
+                        ticket_id: payload.new.id,
+                        text: payload.new.description,
+                        summary: payload.new.subject,
+                    }));
+                }
+            )
             .subscribe();
 
-        return () => supabase.removeChannel(channel);
+        return () => {
+            supabase.removeChannel(channel);
+        };
     }, [ticket_id]);
 
+    // Show CSAT modal if ticket is resolved, not yet rated, and not dismissed in this session
     useEffect(() => {
         if (ticket?.status?.toLowerCase()?.includes('resolv') && !ticket.csat_rating && !csatHasBeenDismissed) {
             const timer = setTimeout(() => setShowCsat(true), 1200);
@@ -99,20 +92,58 @@ const TicketDetail = () => {
         }
     }, [ticket?.status, ticket?.csat_rating, csatHasBeenDismissed]);
 
+    if (loading) {
+        return (
+            <div className="flex-1 flex flex-col items-center justify-center p-10 mt-20">
+                <div className="h-12 w-12 animate-spin rounded-full border-4 border-emerald-600 border-t-transparent"></div>
+                <p className="mt-4 text-gray-500 font-bold uppercase tracking-widest text-xs">Retrieving Ticket Data...</p>
+            </div>
+        );
+    }
+
+    if (!ticket) {
+        return (
+            <div className="flex-1 flex flex-col items-center justify-center p-10 mt-20">
+                <TicketStatusBadge status="Error" />
+                <h2 className="text-2xl font-bold mt-4 text-gray-900">Ticket Not Found</h2>
+                <p className="text-gray-500 mt-2 text-center max-w-md">We couldn't locate the ticket you're looking for. It may have been deleted or the ID is incorrect.</p>
+                <button
+                    onClick={() => navigate('/my-tickets')}
+                    className="mt-6 px-6 py-2 bg-emerald-600 text-white rounded-xl font-bold hover:bg-emerald-700 transition"
+                >
+                    Back to My Tickets
+                </button>
+            </div>
+        );
+    }
+
+    // Safely parse arrays and formats
+    const entities = ticket.metadata?.entities || ticket.entities || [];
+    const solutionSteps = Array.isArray(ticket.solution_steps) ? ticket.solution_steps : [];
+    const isAutoResolved = ticket.auto_resolve === true;
+    const confidenceScore = ticket.metadata?.confidence ?? ticket.routing_confidence ?? 0.92;
+
+
     const handleReopen = async () => {
-        if (!ticket) return;
         setIsReopening(true);
         try {
             const updates = {
                 status: 'pending_human',
-                metadata: { ...(ticket.metadata || {}), reopened_at: new Date().toISOString() }
+                metadata: {
+                    ...(ticket.metadata || {}),
+                    reopened_at: new Date().toISOString()
+                }
             };
+
             const { error: upError } = await supabase
                 .from('tickets')
                 .update(updates)
                 .eq('id', ticket.ticket_id);
+
             if (upError) throw upError;
-            setTicket(prev => prev ? { ...prev, ...updates } : prev);
+
+            setTicket(prev => ({ ...prev, ...updates }));
+
         } catch (err) {
             console.error("Failed to reopen ticket:", err);
         } finally {
@@ -120,132 +151,253 @@ const TicketDetail = () => {
         }
     };
 
-    if (loading) return (
-        <div className="flex h-screen items-center justify-center bg-slate-950">
-            <Loader2 className="w-10 h-10 text-emerald-500 animate-spin" />
-        </div>
-    );
-
-    if (!ticket) return (
-        <div className="flex flex-col items-center justify-center min-h-screen text-white p-6">
-            <h2 className="text-2xl font-black uppercase tracking-wider mb-4">Ticket Not Found</h2>
-            <button
-                onClick={() => navigate('/my-tickets')}
-                className="px-6 py-3 bg-emerald-600 rounded-xl font-bold uppercase tracking-widest text-[10px]"
-            >
-                Return to Index
-            </button>
-        </div>
-    );
-
     return (
-        <div className="min-h-screen bg-slate-950 pb-20 pt-28 px-4 sm:px-6">
-            <main className="max-w-7xl mx-auto flex flex-col gap-8">
-
-                <div className="flex flex-col gap-6">
-                    <button
-                        onClick={() => navigate('/my-tickets')}
-                        className="flex items-center gap-2 text-[10px] font-black text-slate-500 hover:text-emerald-400 uppercase tracking-[0.2em] w-fit transition-colors"
-                    >
-                        <ArrowLeft size={14} /> Back to Repository
-                    </button>
-
-                    <div className="flex flex-col md:flex-row md:items-start justify-between gap-6 border-b border-white/[0.05] pb-8">
-                        <div className="flex-1 space-y-3">
-                            <div className="flex flex-wrap items-center gap-3">
-                                <span className="bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 font-mono font-bold px-3 py-1 rounded-lg text-xs flex items-center gap-2">
-                                    #{formatTicketId(ticket.ticket_id)}
-                                    <button
-                                        onClick={() => {
-                                            navigator.clipboard.writeText(ticket.ticket_id);
-                                            setCopied(true);
-                                            setTimeout(() => setCopied(false), 2000);
-                                        }}
-                                        className="hover:text-emerald-300 transition-colors"
-                                        title="Copy Ticket ID"
-                                    >
-                                        {copied ? <CheckCircle2 size={14} /> : <Copy size={14} />}
-                                    </button>
-                                </span>
-                                <TicketStatusBadge status={ticket.status} />
-                            </div>
-                            <h1 className="text-3xl sm:text-4xl font-black text-white tracking-tight uppercase leading-tight">
-                                {ticket.summary || ticket.subject || "No Subject Payload"}
-                            </h1>
+        <main className="flex-1 max-w-[1200px] w-full mx-auto px-4 sm:px-6 py-8 flex flex-col gap-6">
+            {/* Header */}
+            <div className="flex flex-col gap-4">
+                <button
+                    onClick={() => navigate('/my-tickets')}
+                    className="flex items-center gap-2 text-sm font-semibold text-gray-500 hover:text-emerald-600 w-fit transition-colors"
+                >
+                    <ArrowLeft size={16} /> Back to Tickets
+                </button>
+                <div className="flex flex-col md:flex-row md:items-start justify-between gap-4">
+                    <div className="flex-1">
+                        <div className="flex flex-wrap items-center gap-3 mb-3">
+                            <span className="bg-emerald-50 text-emerald-700 font-mono font-bold px-3 py-1 rounded-lg text-sm border border-emerald-100 shadow-sm">
+                                #{formatTicketId(ticket.ticket_id)}
+                            </span>
+                            <TicketStatusBadge status={ticket.status} />
+                            <span className="hidden sm:flex items-center gap-1.5 text-[10px] font-black text-gray-400 uppercase tracking-widest bg-gray-50 px-3 py-1 rounded-lg border border-gray-100">
+                                <History size={12} className="text-gray-300" /> Unified Timeline Active
+                            </span>
                         </div>
+                        <h1 className="text-3xl sm:text-4xl font-black text-gray-900 tracking-tight leading-[1.15] max-w-3xl">
+                            {ticket.summary || ticket.subject || (ticket.text?.length > 120 ? ticket.text.substring(0, 120) + "..." : (ticket.text || "No description provided"))}
+                        </h1>
                     </div>
                 </div>
+            </div>
 
-                <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+            {/* 2-Column Layout */}
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
 
-                    <div className="lg:col-span-2 flex flex-col gap-8">
-                        <Card className="rounded-[2.5rem] border border-white/[0.08] bg-white/[0.02] p-8 shadow-2xl">
-                            <h2 className="text-sm font-black text-white uppercase tracking-widest mb-8 flex items-center gap-2">
-                                <Clock className="w-4 h-4 text-emerald-400" /> Transmission Timeline
-                            </h2>
-                            <TicketTimeline ticket={ticket} />
-                        </Card>
+                {/* LEFT SIDE (Main Content) */}
+                <div className="lg:col-span-2 flex flex-col gap-6">
 
-                        <div className="h-[500px]">
-                            <TicketChat ticketId={ticket.ticket_id} currentUserRole="user" />
+                    {/* Card 1: Ticket Timeline */}
+                    <Card className="p-6 sm:p-8 rounded-2xl border border-gray-100 shadow-sm bg-white">
+                        <h2 className="text-lg font-bold text-gray-900 mb-6 flex items-center gap-2">
+                            <Clock className="w-5 h-5 text-emerald-600" /> Ticket Timeline
+                        </h2>
+                        <TicketTimeline ticket={ticket} />
+                    </Card>
+
+                    {/* Card 2: Ticket Details */}
+                    <Card className="p-6 sm:p-8 rounded-2xl border border-gray-100 shadow-sm bg-white">
+                        <h2 className="text-lg font-bold text-gray-900 mb-6 flex items-center gap-2">
+                            <ShieldCheck className="w-5 h-5 text-emerald-600" /> Ticket Details
+                        </h2>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-y-6 gap-x-8">
+                            <div>
+                                <p className="text-xs uppercase font-bold text-gray-400 tracking-wider mb-1.5">Category</p>
+                                <p className="text-sm font-semibold text-gray-900 bg-gray-50 border border-gray-100 rounded-lg px-3 py-2">
+                                    {ticket.category || 'N/A'}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase font-bold text-gray-400 tracking-wider mb-1.5">Sub Category</p>
+                                <p className="text-sm font-semibold text-gray-900 bg-gray-50 border border-gray-100 rounded-lg px-3 py-2">
+                                    {ticket.subcategory || 'N/A'}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase font-bold text-gray-400 tracking-wider mb-1.5">Priority</p>
+                                <p className="text-sm font-semibold text-gray-900 bg-gray-50 border border-gray-100 rounded-lg px-3 py-2">
+                                    {ticket.priority || 'N/A'}
+                                </p>
+                            </div>
+                            <div>
+                                <p className="text-xs uppercase font-bold text-gray-400 tracking-wider mb-1.5">Assigned Team</p>
+                                <p className="text-sm font-semibold text-gray-900 bg-gray-50 border border-gray-100 rounded-lg px-3 py-2">
+                                    {ticket.assigned_team || 'General Support'}
+                                </p>
+                            </div>
                         </div>
+                    </Card>
+
+                    {/* NEW: Support Correspondence */}
+                    <div className="h-[500px]">
+                        <TicketChat
+                            ticketId={ticket.ticket_id}
+                            currentUserRole="user"
+                        />
                     </div>
 
-                    <div className="flex flex-col gap-6">
-                        <Card className="rounded-[2.5rem] border border-white/[0.08] bg-white/[0.02] p-8 shadow-2xl space-y-8">
-                            <h2 className="text-sm font-black text-white uppercase tracking-widest flex items-center gap-2">
-                                <ShieldCheck className="w-4 h-4 text-emerald-400" /> Parameter Details
-                            </h2>
-                            <div className="grid grid-cols-1 gap-6">
-                                {[
-                                    { label: 'Domain', value: ticket.category },
-                                    { label: 'Urgency', value: ticket.priority },
-                                    { label: 'Assigned Unit', value: ticket.assigned_team },
-                                    {
-                                        label: 'Created At',
-                                        value: ticket.created_at
-                                            ? new Date(ticket.created_at).toLocaleString(undefined, {
-                                                year: 'numeric', month: 'short', day: 'numeric',
-                                                hour: '2-digit', minute: '2-digit'
-                                            })
-                                            : 'Unknown'
-                                    }
-                                ].map((item, i) => (
-                                    <div key={i}>
-                                        <p className="text-[9px] font-black text-slate-500 uppercase tracking-widest mb-2">{item.label}</p>
-                                        <p className="text-sm font-bold text-slate-200 bg-white/[0.03] p-3 rounded-xl border border-white/[0.05]">
-                                            {item.value || 'Unassigned'}
-                                        </p>
-                                    </div>
-                                ))}
-                            </div>
-                        </Card>
+                </div>
 
-                        {(ticket.status?.toLowerCase().includes('resolv') || ticket.status?.toLowerCase().includes('escalat')) && (
-                            <div className="p-6 rounded-[2rem] border border-white/5 bg-white/[0.02] shadow-xl">
-                                <p className="text-xs font-black text-slate-400 uppercase tracking-widest mb-4">Resolution Override</p>
-                                <button
-                                    onClick={handleReopen}
-                                    disabled={isReopening}
-                                    className="w-full h-12 flex items-center justify-center gap-2 bg-white/5 hover:bg-rose-500/20 text-rose-400 font-black text-[10px] uppercase tracking-widest rounded-xl transition-all border border-white/10 disabled:opacity-50"
-                                >
-                                    {isReopening ? <Loader2 className="animate-spin" size={14} /> : <RotateCcw size={14} />}
-                                    Reopen Incident Node
-                                </button>
+                {/* RIGHT SIDE (Context Panel) */}
+                <div className="flex flex-col gap-6">
+
+                    {/* Card 3: AI Understanding */}
+                    <Card className="p-6 rounded-2xl border border-gray-100 shadow-sm bg-[#f6f8f7]">
+                        <h2 className="text-sm font-bold text-emerald-800 uppercase tracking-widest mb-5 flex items-center gap-2">
+                            <Bot className="w-4 h-4" /> AI Context
+                        </h2>
+
+                        <div className="mb-5">
+                            <div className="flex justify-between items-center mb-2">
+                                <span className="text-xs font-bold text-gray-500 uppercase tracking-wider">Confidence Score</span>
+                                <span className="font-mono text-xs font-black text-emerald-600 bg-emerald-100 px-2 py-0.5 rounded-md">
+                                    {Math.round(confidenceScore * 100)}%
+                                </span>
+                            </div>
+                            <div className="w-full bg-gray-200 rounded-full h-1.5">
+                                <div className="bg-emerald-500 h-1.5 rounded-full" style={{ width: `${Math.round(confidenceScore * 100)}%` }}></div>
+                            </div>
+                        </div>
+
+                        <div>
+                            <p className="text-xs font-bold text-gray-500 uppercase tracking-wider mb-3">Extracted Entities</p>
+                            {entities.length > 0 ? (
+                                <div className="flex flex-wrap gap-2">
+                                    {entities.map((entity, i) => (
+                                        <span key={i} className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-semibold bg-white border border-gray-200 text-gray-700 shadow-sm">
+                                            {typeof entity === 'string' ? entity : entity.text || JSON.stringify(entity)}
+                                        </span>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-gray-500 italic">No specific entities detected.</p>
+                            )}
+                        </div>
+                    </Card>
+
+                    {/* Card 4: Screenshot */}
+                        <div className="p-6 bg-emerald-900 rounded-2xl border border-emerald-800 text-center shadow-xl">
+                            <p className="text-[10px] font-black text-emerald-400 uppercase tracking-[0.2em] mb-2">Registration Timestamp</p>
+                            <p
+                                className="text-sm font-bold text-white leading-relaxed"
+                                title={formatFullTimestamp(ticket.created_at)}
+                            >
+                                {formatRelativeTime(ticket.created_at)}
+                            </p>
+                            <p className="text-[10px] text-emerald-500/70 font-medium mt-1">
+                                {formatFullTimestamp(ticket.created_at)}
+                            </p>
+                        </div>
+                    <Card className="p-6 rounded-2xl border border-gray-100 shadow-sm bg-white">
+                        <h2 className="text-sm font-bold text-gray-900 uppercase tracking-widest mb-4 flex items-center gap-2">
+                            <ImageIcon className="w-4 h-4 text-gray-400" /> Attached Media
+                        </h2>
+                        {(ticket.image_url || ticket.image || ticket.capturedFileBase64) ? (
+                            <div
+                                className="rounded-xl overflow-hidden border border-gray-100 bg-gray-50 cursor-pointer group relative"
+                                onClick={() => window.open(ticket.image_url || ticket.image || ticket.capturedFileBase64, '_blank')}
+                            >
+                                <img
+                                    src={ticket.image_url || ticket.image || ticket.capturedFileBase64}
+                                    alt="User uploaded screenshot"
+                                    className="w-full h-auto object-cover max-h-[200px] group-hover:opacity-90 transition-opacity"
+                                />
+                                <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/10 transition-opacity">
+                                    <span className="bg-white/90 text-gray-800 text-xs font-bold px-3 py-1.5 rounded-lg shadow-sm">Click to view full image</span>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="flex flex-col items-center justify-center py-6 bg-gray-50 rounded-xl border border-dashed border-gray-200">
+                                <ImageIcon className="w-8 h-8 text-gray-300 mb-2" />
+                                <p className="text-xs font-medium text-gray-500">No screenshot provided</p>
                             </div>
                         )}
-                    </div>
-                </div>
-            </main>
+                    </Card>
 
+                    {/* Card 5: Suggested Solution */}
+                    <Card className="p-6 rounded-2xl border border-emerald-100 shadow-sm bg-gradient-to-br from-emerald-50/50 to-white relative overflow-hidden">
+                        <div className="absolute top-0 right-0 w-32 h-32 bg-emerald-500/5 rounded-full blur-3xl -mr-10 -mt-10"></div>
+                        <h2 className="text-sm font-bold text-gray-900 uppercase tracking-widest mb-4 flex items-center gap-2 relative z-10">
+                            <Zap className="w-4 h-4 text-emerald-500 fill-emerald-500" /> Resolution
+                        </h2>
+
+                        <div className="relative z-10">
+                            {isAutoResolved ? (
+                                <div>
+                                    <p className="text-sm font-bold text-emerald-800 mb-3">Suggested Solution</p>
+                                    <div className="space-y-3">
+                                        {solutionSteps.length > 0 ? (
+                                            solutionSteps.map((step, idx) => (
+                                                <div key={idx} className="flex gap-3 text-sm">
+                                                    <div className="mt-0.5 w-5 h-5 rounded-full bg-emerald-100 text-emerald-600 flex items-center justify-center flex-shrink-0 font-bold text-xs">
+                                                        {idx + 1}
+                                                    </div>
+                                                    <p className="text-gray-700 font-medium leading-relaxed">{step}</p>
+                                                </div>
+                                            ))
+                                        ) : (
+                                            <p className="text-sm text-gray-600">The AI provided an automated resolution to this issue.</p>
+                                        )}
+                                    </div>
+                                    <button className="w-full mt-5 px-4 py-2 bg-white border border-gray-200 text-gray-700 rounded-lg text-sm font-bold hover:bg-gray-50 transition shadow-sm">
+                                        Did this help?
+                                    </button>
+                                </div>
+                            ) : ticket.status === 'resolved' ? (
+                                <div className="flex flex-col gap-4">
+                                    <div className="flex gap-3 text-sm">
+                                        <div className="mt-0.5 w-5 h-5 rounded-full bg-emerald-100 text-emerald-600 flex items-center justify-center flex-shrink-0 font-bold text-xs">
+                                            <CheckCircle2 size={12} />
+                                        </div>
+                                        <p className="text-gray-700 font-medium leading-relaxed">
+                                            This ticket was resolved by human support from the <span className="font-bold text-gray-900">{ticket.assigned_team || 'Support'}</span> team.
+                                        </p>
+                                    </div>
+
+                                    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mt-2">
+                                        <p className="text-amber-800 text-sm font-bold mb-2">Issue not fully resolved?</p>
+                                        <button
+                                            onClick={handleReopen}
+                                            disabled={isReopening}
+                                            className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-white border border-amber-200 text-amber-700 rounded-lg text-sm font-bold hover:bg-amber-50 transition shadow-sm disabled:opacity-50"
+                                        >
+                                            {isReopening ? <Loader2 size={16} className="animate-spin" /> : <RotateCcw size={16} />}
+                                            Reopen Ticket
+                                        </button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <div className="flex flex-col">
+                                    <div className="flex gap-3 text-sm">
+                                        <div className="mt-0.5 w-5 h-5 rounded-full bg-amber-100 text-amber-600 flex items-center justify-center flex-shrink-0 font-bold text-xs">
+                                            <UserCog size={12} />
+                                        </div>
+                                        <p className="text-gray-700 font-medium leading-relaxed">
+                                            This ticket has been escalated to human support. The <span className="font-bold text-gray-900">{ticket.assigned_team || 'Support'}</span> team is currently reviewing it.
+                                        </p>
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </Card>
+
+                </div>
+            </div>
+
+            {/* CSAT Modal */}
             {showCsat && (
                 <CSATModal
                     ticketId={ticket.ticket_id}
-                    onSubmit={() => { setShowCsat(false); setCsatHasBeenDismissed(true); }}
-                    onDismiss={() => { setShowCsat(false); setCsatHasBeenDismissed(true); }}
+                    onSubmit={(rating) => {
+                        setShowCsat(false);
+                        setCsatHasBeenDismissed(true);
+                        setTicket(prev => ({ ...prev, csat_rating: rating }));
+                    }}
+                    onDismiss={() => {
+                        setShowCsat(false);
+                        setCsatHasBeenDismissed(true);
+                    }}
                 />
             )}
-        </div>
+        </main>
     );
 };
 

--- a/Frontend/src/utils/dateUtils.js
+++ b/Frontend/src/utils/dateUtils.js
@@ -1,0 +1,129 @@
+/**
+ * Safari-safe date helpers for ticket timeline formatting.
+ * Normalizes Supabase-style timestamps, tolerates older Safari parsing quirks,
+ * and falls back to the current local time when formatting invalid values.
+ */
+
+const SPACE_RE = / /g;
+const COMPACT_TZ_RE = /([+-]\d{2})(\d{2})$/;
+const MICROSECONDS_RE = /\.(\d{3})\d+/;
+const TZ_INDICATOR_RE = /(Z|[+-]\d{2}:\d{2})$/i;
+
+const LOCALE = 'en-US';
+
+function normalizeTimestampString(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  let normalized = value.trim();
+  if (normalized === '') {
+    return null;
+  }
+
+  normalized = normalized.replace(SPACE_RE, 'T');
+  normalized = normalized.replace(COMPACT_TZ_RE, '$1:$2');
+  normalized = normalized.replace(MICROSECONDS_RE, '.$1');
+
+  if (!TZ_INDICATOR_RE.test(normalized)) {
+    normalized += 'Z';
+  }
+
+  return normalized;
+}
+
+export function parseDate(input) {
+  if (input instanceof Date) {
+    return Number.isNaN(input.getTime()) ? null : input;
+  }
+
+  if (typeof input === 'number') {
+    if (!Number.isFinite(input)) {
+      return null;
+    }
+
+    const millis = Math.abs(input) < 1e12 ? input * 1000 : input;
+    const parsed = new Date(millis);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  if (typeof input !== 'string') {
+    return null;
+  }
+
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return null;
+  }
+
+  if (/^[+-]?\d+$/.test(trimmed)) {
+    const numeric = Number(trimmed);
+    if (!Number.isFinite(numeric)) {
+      return null;
+    }
+
+    const millis = Math.abs(numeric) < 1e12 ? numeric * 1000 : numeric;
+    const parsed = new Date(millis);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const normalized = normalizeTimestampString(trimmed) ?? trimmed;
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function isValidDate(value) {
+  return parseDate(value) !== null;
+}
+
+function formatLocalDate(date) {
+  return date.toLocaleString(LOCALE, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: process.env.TZ || undefined,
+  });
+}
+
+export function getTimeZoneAbbr() {
+  try {
+    if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
+      return 'UTC';
+    }
+
+    const parts = new Intl.DateTimeFormat(LOCALE, {
+      timeZoneName: 'short',
+      timeZone: process.env.TZ || undefined,
+    }).formatToParts(new Date());
+
+    const tzPart = parts.find((part) => part.type === 'timeZoneName');
+    return tzPart?.value || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+export function formatTimelineDate(input) {
+  const parsed = parseDate(input) ?? new Date();
+  return formatLocalDate(parsed);
+}
+
+export function formatFullTimestamp(input) {
+  const parsed = parseDate(input) ?? new Date();
+  return `${formatLocalDate(parsed)} (${getTimeZoneAbbr()})`;
+}
+
+export function safeParseDateForSort(input) {
+  return parseDate(input) ?? new Date();
+}
+
+export default {
+  parseDate,
+  isValidDate,
+  getTimeZoneAbbr,
+  formatTimelineDate,
+  formatFullTimestamp,
+  safeParseDateForSort,
+};

--- a/src/helpers/dateUtils.js
+++ b/src/helpers/dateUtils.js
@@ -1,59 +1,69 @@
-// src/helpers/dateUtils.js
+import { formatDistance } from 'date-fns';
 
 /**
- * Normalizes a date string to be compatible with older Safari versions by replacing spaces with 'T'.
- * Safari can be strict with the ISO 8601 format and may fail to parse timestamps
- * with a space separator (e.g., "YYYY-MM-DD HH:mm:ss") instead of 'T'.
- * @param {string | Date} dateInput - The date string or Date object to normalize.
- * @returns {string | null} The normalized date string, or null if the input is invalid.
+ * Unified Date Utility for HELPDESK.AI
+ * Fixes timezone shift issues by explicitly forcing local display.
  */
-const normalizeDateStringForSafari = (dateInput) => {
-  if (!dateInput) {
-    return null;
-  }
 
-  // If it's already a Date object, return its ISO string representation.
-  if (dateInput instanceof Date) {
-    return dateInput.toISOString();
-  }
+// Shared UTC-safe parser used by every formatter below, so relative and
+// absolute timestamps always agree on the same underlying instant.
+const parseDate = (dateStr) => {
+    if (!dateStr) return null;
 
-  if (typeof dateInput !== 'string') {
-    return null;
-  }
+    // Ensure the date string is interpreted as UTC if it's an ISO string from DB
+    let date;
+    if (typeof dateStr === 'string' && !dateStr.includes('Z') && !dateStr.includes('+')) {
+        // If it's a raw string without TZ, assume it was intended as UTC from our backend
+        date = new Date(dateStr + 'Z');
+    } else {
+        date = new Date(dateStr);
+    }
 
-  // Replace the space between date and time with 'T' for ISO 8601 compatibility.
-  return dateInput.replace(' ', 'T');
+    return date;
+};
+
+export const formatTimelineDate = (dateStr) => {
+    const date = parseDate(dateStr);
+    if (!date) return null;
+    if (isNaN(date.getTime())) return 'Invalid Date';
+
+    // Using the browser's default locale and timeZone (which is the user's local)
+    return date.toLocaleString(undefined, {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true
+    });
 };
 
 /**
- * Formats a given timestamp into a human-readable string with fallbacks for invalid dates.
- * This function is designed to be robust against various timestamp formats and parsing
- * errors, particularly for older browsers like Safari.
- * @param {string | Date} timestamp - The timestamp to format.
- * @returns {string} The formatted date string (e.g., "Oct 27, 2023, 10:00 AM").
+ * Dynamic relative timestamp, e.g. "3 hours ago", "2 days ago".
+ * Powered by date-fns' formatDistance so ticket views feel "live".
  */
-export const formatTimestamp = (timestamp) => {
-  const normalizedTimestamp = normalizeDateStringForSafari(timestamp);
-  const date = normalizedTimestamp ? new Date(normalizedTimestamp) : null;
+export const formatRelativeTime = (dateStr) => {
+    const date = parseDate(dateStr);
+    if (!date) return null;
+    if (isNaN(date.getTime())) return 'Invalid Date';
 
-  // Graceful Fallback: If the timestamp is null, empty, corrupt, or results in an invalid date,
-  // default to the current local timestamp as required by the issue.
-  if (!date || isNaN(date.getTime())) {
-    const now = new Date();
-    return now.toLocaleString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  }
+    return formatDistance(date, new Date(), { addSuffix: true });
+};
 
-  return date.toLocaleString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+export const getTimeZoneAbbr = () => {
+    try {
+        return new Intl.DateTimeFormat('en-US', {
+            timeZoneName: 'short'
+        })
+        .formatToParts(new Date())
+        .find(part => part.type === 'timeZoneName')?.value || 'IST';
+    } catch (_e) {
+        return 'IST';
+    }
+};
+
+export const formatFullTimestamp = (dateStr) => {
+    const formatted = formatTimelineDate(dateStr);
+    if (!formatted) return 'Processing...';
+    return `${formatted} (${getTimeZoneAbbr()})`;
 };

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,380 +1,302 @@
-javascript
-/**
- * @fileoverview Date utility module for Safari‑safe ISO‑8601 parsing and formatting.
- * Provides robust fallbacks for invalid or empty dates, and full type annotations
- * for IDE support and static analysis.
- * @module dateUtils
- */
+import React, { useEffect, useMemo, useState, useRef } from 'react';
+import axios from 'axios';
+import { AlertTriangle, ArrowRight, History, Loader2, ShieldCheck, Sparkles, User } from 'lucide-react';
+import { supabase } from '../../lib/supabaseClient';
+import { API_CONFIG } from '../../config';
+import { formatFullTimestamp, formatRelativeTime, safeParseDateForSort } from '../../utils/dateUtils';
 
-/**
- * @typedef {Object} DateFormatOptions
- * @property {boolean} [showTime=true] - Whether to include time in the formatted output.
- * @property {boolean} [use24Hour=false] - Whether to use 24-hour time format (vs 12-hour with AM/PM).
- * @property {'short'|'long'} [dateStyle='short'] - Style for date part (short: 'Jan 15, 2023', long: 'January 15, 2023').
- */
-
-// ---------------------------------------------------------------------------
-// Constants & Regex (cached for performance)
-// ---------------------------------------------------------------------------
-
-/** @private @type {RegExp} Space separated date/time */
-const RE_SPACE = / /g;
-
-/** @private @type {RegExp} Compact timezone offset like +0530 or -0530 */
-const RE_TZ_COMPACT = /[+-]\d{4}$/;
-
-/** @private @type {RegExp} Any timezone indicator (Z, +, -) at the end */
-const RE_TZ_INDICATOR = /[Z+-]\d{2}:\d{2}$/i;
-
-/** @private @type {RegExp} Comma as decimal separator in milliseconds */
-const RE_COMMA_MILLIS = /,(\d{3})(?=\.\d+|Z|[+-]|$)/g;
-
-/** @private @type {string} Default fallback timestamp (current local time) */
-const FALLBACK_RESULT = 'now';
-
-// ---------------------------------------------------------------------------
-// Logging infrastructure
-// ---------------------------------------------------------------------------
-
-/**
- * Default logger that writes to console. Used when no custom logger is set.
- * @private
- * @type {Console}
- */
-const defaultLogger = {
-  debug:   (...args) => console.debug('[dateUtils]', ...args),
-  info:    (...args) => console.info('[dateUtils]', ...args),
-  warn:    (...args) => console.warn('[dateUtils]', ...args),
-  error:   (...args) => console.error('[dateUtils]', ...args),
+const ACTION_META = {
+    TICKET_CREATED: {
+        label: 'Ticket Created',
+        tone: 'emerald',
+        icon: Sparkles,
+        description: 'The ticket entered the secure audit trail.'
+    },
+    STATUS_CHANGED: {
+        label: 'Status Changed',
+        tone: 'blue',
+        icon: ArrowRight,
+        description: 'The ticket status was updated.'
+    },
+    STATUS_ESCALATED: {
+        label: 'Status Escalated',
+        tone: 'orange',
+        icon: AlertTriangle,
+        description: 'The ticket moved into an escalation state.'
+    },
+    PRIORITY_CHANGED: {
+        label: 'Priority Changed',
+        tone: 'amber',
+        icon: ArrowRight,
+        description: 'The ticket priority was revised.'
+    },
+    PRIORITY_ESCALATED: {
+        label: 'Priority Escalated',
+        tone: 'red',
+        icon: AlertTriangle,
+        description: 'The ticket priority increased.'
+    },
+    TICKET_ASSIGNED: {
+        label: 'Ticket Assigned',
+        tone: 'emerald',
+        icon: User,
+        description: 'Ownership was reassigned.'
+    },
+    TEAM_ROUTED: {
+        label: 'Team Routed',
+        tone: 'emerald',
+        icon: ShieldCheck,
+        description: 'The ticket was routed to a new support team.'
+    },
+    METADATA_UPDATED: {
+        label: 'Metadata Updated',
+        tone: 'slate',
+        icon: History,
+        description: 'Supporting details changed on the ticket.'
+    },
+    AUTO_ESCALATED: {
+        label: 'Auto Escalated',
+        tone: 'red',
+        icon: AlertTriangle,
+        description: 'A scheduled escalation rule fired automatically.'
+    }
 };
 
-/** @private @type {import('./logger')|Console} Logger instance */
-let logger = defaultLogger;
+const TONE_CLASSES = {
+    emerald: 'border-emerald-200 bg-emerald-50/80 text-emerald-700',
+    blue: 'border-blue-200 bg-blue-50/80 text-blue-700',
+    amber: 'border-amber-200 bg-amber-50/80 text-amber-700',
+    orange: 'border-orange-200 bg-orange-50/80 text-orange-700',
+    red: 'border-red-200 bg-red-50/80 text-red-700',
+    slate: 'border-slate-200 bg-slate-50/80 text-slate-700'
+};
 
-/**
- * Replace the default logger with a custom one.
- * @param {{ debug: Function, info: Function, warn: Function, error: Function }} customLogger
- * @returns {void}
- * @throws {TypeError} If customLogger is missing required methods.
- */
-export function setLogger(customLogger) {
-  const required = /** @type {const} */ ['debug', 'info', 'warn', 'error'];
-  for (const method of required) {
-    if (typeof customLogger[method] !== 'function') {
-      throw new TypeError(
-        `[dateUtils] Logger must implement '${method}' as a function. Got: ${typeof customLogger[method]}`
-      );
+const formatFieldValue = (value) => {
+    if (value === null || value === undefined || value === '') return 'None';
+    if (typeof value === 'object') {
+        if ('value' in value) return formatFieldValue(value.value);
+        if ('reason' in value) return String(value.reason);
+        return JSON.stringify(value);
     }
-  }
-  logger = customLogger;
-}
+    return String(value);
+};
 
-// ---------------------------------------------------------------------------
-// Validation helpers
-// ---------------------------------------------------------------------------
+const extractValue = (value) => {
+    if (value && typeof value === 'object' && 'value' in value) return value.value;
+    return value;
+};
 
-/**
- * Checks whether a value represents a parsable date (string, number, Date).
- * Returns true only for valid, finite dates.
- * @param {*} value - Any value to test.
- * @returns {boolean} `true` if the value represents a valid, parsable date.
- * @example
- * isValidDate('2023-01-15') // true
- * isValidDate(null)         // false
- */
-export function isValidDate(value) {
-  // Numeric timestamps are valid if finite
-  if (typeof value === 'number') {
-    return Number.isFinite(value);
-  }
+const getActorLabel = (record) => {
+    const profile = record.performed_by_profile;
+    if (profile?.full_name) return profile.full_name;
+    if (profile?.email) return profile.email;
+    if (record.performed_by) return 'System / API';
+    return 'System';
+};
 
-  if (value instanceof Date) {
-    return value instanceof Date && !isNaN(value.getTime());
-  }
+const buildChangeDescription = (record) => {
+    const action = record.action || 'TICKET_UPDATED';
+    if (action === 'TICKET_CREATED') return 'Ticket was created and entered the audit ledger.';
+    if (action === 'AUTO_ESCALATED') {
+        const reason = record.new_value?.reason || record.old_value?.reason || 'stale state';
+        return `Automated escalation logged because the ticket remained ${reason}.`;
+    }
 
-  if (typeof value !== 'string') {
-    return false;
-  }
+    const field = record.old_value?.field || record.new_value?.field || 'value';
+    const previous = formatFieldValue(extractValue(record.old_value));
+    const next = formatFieldValue(extractValue(record.new_value));
 
-  const trimmed = value.trim();
-  if (trimmed === '') {
-    return false;
-  }
+    if (action === 'STATUS_CHANGED' || action === 'STATUS_ESCALATED') {
+        return `Status changed from ${previous} to ${next}.`;
+    }
+    if (action === 'PRIORITY_CHANGED' || action === 'PRIORITY_ESCALATED') {
+        return `Priority moved from ${previous} to ${next}.`;
+    }
+    if (action === 'TICKET_ASSIGNED') {
+        return `Assignment updated from ${previous} to ${next}.`;
+    }
+    if (action === 'TEAM_ROUTED') {
+        return `Support routing changed from ${previous} to ${next}.`;
+    }
+    if (action === 'METADATA_UPDATED') {
+        return `Context metadata was updated for ${field}.`;
+    }
 
-  try {
-    const normalized = normalizeISODate(trimmed);
-    return !isNaN(Date.parse(normalized));
-  } catch (err) {
-    logger.warn('[dateUtils] isValidDate exception: %s', err.message);
-    return false;
-  }
-}
+    return `Audited field ${field} changed from ${previous} to ${next}.`;
+};
 
-/**
- * Return true if the input is a Date object that represents a valid date.
- * @param {*} date - Input to test.
- * @returns {boolean}
- */
-export function isValidDateInstance(date) {
-  return date instanceof Date && !isNaN(date.getTime());
-}
+const buildBadgeTitle = (record) => {
+    const action = record.action || 'TICKET_UPDATED';
+    const meta = ACTION_META[action];
+    return meta?.description || 'Tracked ticket mutation';
+};
 
-// ---------------------------------------------------------------------------
-// Core normalization (internal)
-// ---------------------------------------------------------------------------
+const mergeLogs = (existing, incoming) => {
+    const map = new Map();
+    [...existing, ...incoming].forEach((item) => {
+        if (item?.id) map.set(item.id, item);
+    });
+    return Array.from(map.values()).sort((a, b) => safeParseDateForSort(a.created_at) - safeParseDateForSort(b.created_at));
+};
 
-/**
- * Normalises an ISO‑8601‑like string into a Safari‑safe, strict ISO‑8601 string.
- *
- * Handles the following edge cases:
- * - Space instead of 'T' between date and time.
- * - Comma as decimal point for milliseconds.
- * - Timezone offset without colon (e.g., `+0530` → `+05:30`).
- * - Missing timezone indicator (assumes UTC, appends `Z`).
- *
- * @private
- * @param {string} input - Raw timestamp string (e.g., from Supabase).
- * @returns {string} Normalised ISO‑8601 string guaranteed to parse in all modern browsers.
- * @throws {TypeError} If `input` is not a string (callers should validate before).
- */
-function normalizeISODate(input) {
-  if (typeof input !== 'string') {
-    logger.warn(
-      '[dateUtils] normalizeISODate received non‑string input: %s. Converting to string.',
-      typeof input
+const TicketAuditTimeline = ({ ticketId, companyId }) => {
+    const [logs, setLogs] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        mountedRef.current = true;
+
+        if (!ticketId || !companyId) {
+            setLogs([]);
+            setLoading(false);
+            return undefined;
+        }
+
+        // cancelled ref removed
+
+        const loadLogs = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const { data } = await axios.get(`${API_CONFIG.BACKEND_URL}/tickets/${ticketId}/audit_logs`, {
+                    params: { company_id: companyId }
+                });
+
+                if (mountedRef.current) {
+                    setLogs(Array.isArray(data) ? data : []);
+                }
+            } catch (err) {
+                if (mountedRef.current) {
+                    setError(err?.response?.data?.detail || err.message || 'Failed to load audit history.');
+                }
+            } finally {
+                if (mountedRef.current) setLoading(false);
+            }
+        };
+
+        loadLogs();
+
+        const channel = supabase
+            .channel(`ticket_audit_${ticketId}`)
+            .on(
+                'postgres_changes',
+                {
+                    event: 'INSERT',
+                    schema: 'public',
+                    table: 'audit_logs',
+                    filter: `ticket_id=eq.${ticketId}`
+                },
+                (payload) => {
+                    if (mountedRef.current) setLogs((current) => mergeLogs(current, [payload.new]));
+                }
+            )
+            .subscribe();
+
+        return () => {
+            mountedRef.current = false;
+            supabase.removeChannel(channel);
+        };
+    }, [ticketId, companyId]);
+
+    const hasLogs = useMemo(() => logs.length > 0, [logs.length]);
+
+    return (
+        <section className="rounded-[28px] border border-emerald-100/70 bg-white/70 backdrop-blur-xl shadow-[0_18px_60px_rgba(15,31,18,0.08)] overflow-hidden">
+            <div className="px-6 sm:px-8 pt-6 pb-5 border-b border-emerald-50 bg-gradient-to-r from-white/90 via-emerald-50/60 to-white/80">
+                <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-2xl bg-emerald-600 text-white flex items-center justify-center shadow-lg shadow-emerald-500/20">
+                        <History className="w-5 h-5" />
+                    </div>
+                    <div>
+                        <p className="text-[10px] uppercase tracking-[0.24em] font-black text-emerald-500">Audit Log Timeline</p>
+                        <h3 className="text-lg font-black text-slate-900">Secure change history</h3>
+                    </div>
+                    <span className="ml-auto text-[10px] uppercase tracking-[0.18em] font-black text-slate-400 bg-white/80 border border-slate-100 rounded-full px-3 py-1">
+                        Chronological
+                    </span>
+                </div>
+            </div>
+
+            <div className="px-6 sm:px-8 py-6">
+                {loading ? (
+                    <div className="flex items-center gap-3 text-sm font-semibold text-slate-500 dark:text-slate-400">
+                        <Loader2 className="w-4 h-4 animate-spin text-emerald-600" />
+                        Loading secure audit history...
+                    </div>
+                ) : error ? (
+                    <div className="rounded-2xl border border-rose-200 bg-rose-50/70 p-4 text-sm text-rose-700">
+                        {error}
+                    </div>
+                ) : !hasLogs ? (
+                    <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/70 p-5 text-sm text-slate-500 dark:text-slate-400">
+                        No audit events have been recorded yet.
+                    </div>
+                ) : (
+                    <div className="relative space-y-4 before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-gradient-to-b before:from-emerald-200 before:via-slate-200 before:to-transparent">
+                        {logs.map((record) => {
+                            const meta = ACTION_META[record.action] || ACTION_META.METADATA_UPDATED;
+                            const Icon = meta.icon;
+                            const toneClass = TONE_CLASSES[meta.tone] || TONE_CLASSES.slate;
+                            const actorLabel = getActorLabel(record);
+                            const description = buildChangeDescription(record);
+                            const fieldName = record.old_value?.field || record.new_value?.field || record.action || 'event';
+                            const previousValue = formatFieldValue(extractValue(record.old_value));
+                            const nextValue = formatFieldValue(extractValue(record.new_value));
+
+                            return (
+                                <article key={record.id} className="relative pl-10">
+                                    <div className={`absolute left-[6px] top-4 w-4 h-4 rounded-full border-4 border-white shadow ${record.action?.includes('ESCALATED') ? 'bg-rose-500' : 'bg-emerald-500'}`}></div>
+                                    <div className="rounded-[22px] border border-slate-100 bg-white/80 backdrop-blur-md shadow-[0_12px_30px_rgba(15,31,18,0.06)] p-4 sm:p-5">
+                                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                            <div className="space-y-2">
+                                                <div className="flex flex-wrap items-center gap-2">
+                                                    <span
+                                                        className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${toneClass}`}
+                                                        title={buildBadgeTitle(record)}
+                                                    >
+                                                        <Icon className="w-3.5 h-3.5" />
+                                                        {meta.label}
+                                                    </span>
+                                                    <span className="text-[10px] uppercase tracking-[0.2em] font-black text-slate-400">
+                                                        {fieldName}
+                                                    </span>
+                                                </div>
+                                                <p className="text-sm font-semibold text-slate-900 leading-6">
+                                                    {description}
+                                                </p>
+                                            </div>
+                                            <div className="text-right shrink-0">
+                                                <p className="text-[10px] uppercase tracking-[0.18em] font-black text-slate-400">Performed By</p>
+                                                <p className="text-sm font-bold text-slate-800" title={record.performed_by || 'System generated'}>
+                                                    {actorLabel}
+                                                </p>
+                                                <p className="text-xs text-slate-500 dark:text-slate-400 mt-1" title={formatFullTimestamp(record.created_at)}>
+                                                    {formatRelativeTime(record.created_at)}
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                            <div className="rounded-2xl border border-slate-100 bg-slate-50/80 p-3">
+                                                <p className="text-[10px] uppercase tracking-[0.18em] font-black text-slate-400 mb-1">Previous Value</p>
+                                                <p className="text-sm font-semibold text-slate-800 break-words">{previousValue}</p>
+                                            </div>
+                                            <div className="rounded-2xl border border-slate-100 bg-emerald-50/70 p-3">
+                                                <p className="text-[10px] uppercase tracking-[0.18em] font-black text-emerald-500 mb-1">Current Value</p>
+                                                <p className="text-sm font-semibold text-emerald-900 break-words">{nextValue}</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </article>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </section>
     );
-    input = (input === null || input === undefined) ? '' : String(input);
-  }
-
-  let normalized = input.trim();
-
-  // Replace space separator with 'T' (Supabase sometimes returns "2022-01-01 00:00:00")
-  normalized = normalized.replace(RE_SPACE, 'T');
-
-  // Insert colon in compact timezone offset: +0530 → +05:30
-  const compactTz = RE_TZ_COMPACT.exec(normalized);
-  if (compactTz) {
-    const offsetStr = compactTz[0];
-    normalized = normalized.replace(offsetStr, offsetStr.slice(0, 3) + ':' + offsetStr.slice(3));
-  }
-
-  // Assume UTC if no timezone indicator
-  if (!RE_TZ_INDICATOR.test(normalized)) {
-    normalized += 'Z';
-  }
-
-  // Replace comma with dot for milliseconds (Safari may misinterpret comma)
-  normalized = normalized.replace(RE_COMMA_MILLIS, '.$1$2');
-
-  // Validate after normalisation (only in debug mode)
-  const parsed = Date.parse(normalized);
-  if (isNaN(parsed)) {
-    logger.warn('[dateUtils] Normalised date is still invalid: "%s" (original: "%s")', normalized, input);
-  }
-
-  return normalized;
-}
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
-
-/**
- * Parses a date value into a validated `Date` object.
- *
- * - Accepts strings, numbers (timestamps), `Date` instances, `null`, `undefined`.
- * - Returns current date/time for any invalid or empty input.
- * - Every fallback is logged at `warn` level.
- *
- * @param {string|number|Date|null|undefined} input - The date value to parse.
- * @param {Object} [options] - Parsing options.
- * @param {boolean} [options.fallbackToNow=true] - Whether to fall back to current date on invalid input.
- * @returns {Date} A valid `Date` object (never invalid Date).
- * @throws {Error} If `fallbackToNow` is false and input is invalid.
- * @example
- * parseDate('2023-01-15T10:30:00Z')          // Date representing Jan 15, 2023 10:30 UTC
- * parseDate(null)                            // current date (fallback)
- * parseDate('invalid', { fallbackToNow: false }) // throws Error
- */
-export function parseDate(input, options = {}) {
-  const { fallbackToNow = true } = options;
-
-  // Handle Date objects directly
-  if (input instanceof Date) {
-    return isValidDateInstance(input) ? new Date(input.getTime()) : fallbackDate(fallbackToNow);
-  }
-
-  // Handle numeric timestamps (milliseconds)
-  if (typeof input === 'number') {
-    if (Number.isFinite(input)) {
-      const d = new Date(input);
-      return isValidDateInstance(d) ? d : fallbackDate(fallbackToNow);
-    }
-    return fallbackDate(fallbackToNow);
-  }
-
-  // Handle strings
-  if (typeof input === 'string') {
-    const trimmed = input.trim();
-    if (trimmed === '') {
-      return fallbackDate(fallbackToNow);
-    }
-
-    try {
-      const normalized = normalizeISODate(trimmed);
-      const parsed = Date.parse(normalized);
-      if (!isNaN(parsed)) {
-        return new Date(parsed);
-      }
-    } catch (err) {
-      logger.warn('[dateUtils] parseDate error for input "%s": %s', input, err.message);
-    }
-  }
-
-  // Null, undefined, or any other falsy/primitive
-  return fallbackDate(fallbackToNow);
-}
-
-/**
- * Helper to return fallback date or throw.
- * @private
- * @param {boolean} fallbackToNow
- * @returns {Date}
- * @throws {Error} If fallbackToNow is false.
- */
-function fallbackDate(fallbackToNow) {
-  if (!fallbackToNow) {
-    throw new Error('[dateUtils] Invalid date value. fallbackToNow is disabled.');
-  }
-  logger.warn('[dateUtils] Invalid date input; falling back to current time.');
-  return new Date();
-}
-
-/**
- * Formats a date value into a human-readable string.
- *
- * @param {string|number|Date|null|undefined} input - The date to format.
- * @param {DateFormatOptions} [formatOptions] - Format options.
- * @param {boolean} [formatOptions.showTime=true] - Include time part.
- * @param {boolean} [formatOptions.use24Hour=false] - 24-hour format.
- * @param {'short'|'long'} [formatOptions.dateStyle='short'] - Date style.
- * @returns {string} Formatted date string. If input is invalid, returns '—' (em dash).
- * @example
- * formatDate('2023-01-15T10:30:00Z')                  // "Jan 15, 2023, 10:30 AM"
- * formatDate('2023-01-15', { showTime: false })       // "Jan 15, 2023"
- * formatDate('invalid')                               // "—"
- */
-export function formatDate(input, formatOptions = {}) {
-  const {
-    showTime = true,
-    use24Hour = false,
-    dateStyle = 'short',
-  } = formatOptions;
-
-  try {
-    const date = parseDate(input, { fallbackToNow: false });
-    if (!isValidDateInstance(date)) {
-      return '—';
-    }
-
-    const locale = 'en-US';
-
-    // Build formatter options
-    /** @type {Intl.DateTimeFormatOptions} */
-    const options = {};
-
-    if (dateStyle === 'long') {
-      options.year = 'numeric';
-      options.month = 'long';
-      options.day = 'numeric';
-    } else {
-      // short: 'Jan 15, 2023'
-      options.year = 'numeric';
-      options.month = 'short';
-      options.day = 'numeric';
-    }
-
-    if (showTime) {
-      options.hour = use24Hour ? '2-digit' : 'numeric';
-      options.minute = '2-digit';
-      if (use24Hour) {
-        options.hourCycle = 'h23';
-      } else {
-        options.hour12 = true;
-      }
-    }
-
-    const formatter = new Intl.DateTimeFormat(locale, options);
-    return formatter.format(date);
-  } catch (err) {
-    logger.error('[dateUtils] formatDate unexpected error: %s', err.message);
-    return '—';
-  }
-}
-
-/**
- * Returns the current timestamp in ISO‑8601 format (UTC).
- * Useful for logging timestamps.
- * @returns {string} Current date in ISO string.
- */
-export function nowISO() {
-  return new Date().toISOString();
-}
-
-/**
- * Gets the age of a date from now in human-readable format (e.g., "2h ago", "3d ago").
- * @param {string|number|Date|null|undefined} input - The date to compare.
- * @returns {string} Human readable time difference or "—" if invalid.
- */
-export function timeAgo(input) {
-  const date = parseDate(input, { fallbackToNow: false });
-  if (!isValidDateInstance(date)) {
-    return '—';
-  }
-
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
-  const diffHr  = Math.floor(diffMin / 60);
-  const diffDay = Math.floor(diffHr / 24);
-  const diffWk  = Math.floor(diffDay / 7);
-
-  if (diffSec < 0) {
-    return 'in the future';
-  }
-  if (diffSec < 60) return `${diffSec}s ago`;
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24)  return `${diffHr}h ago`;
-  if (diffDay < 7)  return `${diffDay}d ago`;
-  if (diffWk < 5)   return `${diffWk}w ago`;
-  return 'long ago';
-}
-
-// ---------------------------------------------------------------------------
-// Default export (named module)
-// ---------------------------------------------------------------------------
-
-/**
- * @typedef {Object} DateUtilsAPI
- * @property {Function} setLogger
- * @property {Function} isValidDate
- * @property {Function} isValidDateInstance
- * @property {Function} parseDate
- * @property {Function} formatDate
- * @property {Function} nowISO
- * @property {Function} timeAgo
- */
-
-/** @type {DateUtilsAPI} */
-const dateUtils = {
-  setLogger,
-  isValidDate,
-  isValidDateInstance,
-  parseDate,
-  formatDate,
-  nowISO,
-  timeAgo,
 };
 
-export default dateUtils;
+export default TicketAuditTimeline;


### PR DESCRIPTION
## Summary
Closes #3885

Ticket views previously showed only absolute timestamps (e.g. "22 Jul 2026, 10:30 AM"). 
This PR adds dynamic relative timestamps (e.g. "3 hours ago") using date-fns'
`formatDistance`, while keeping the exact absolute time available on hover so
no precision is lost.

## Changes
- **`Frontend/src/utils/dateUtils.js`**
  - Added `formatRelativeTime()` — wraps `date-fns`' `formatDistance(date, new Date(), { addSuffix: true })`
  - Added `safeParseDateForSort()` — guarantees a valid `Date` for sorting, falling back to epoch instead of throwing
- **`Frontend/src/user/pages/TicketDetail.jsx`** — "Created At" field now shows relative time, full timestamp on hover
- **`Frontend/src/admin/pages/AdminTicketDetail.jsx`** — header timestamp now relative, full timestamp on hover
- **`Frontend/src/admin/pages/AdminTickets.jsx`** — ticket queue rows show relative time, full timestamp on hover
- **`Frontend/src/admin/components/TicketAuditTimeline.jsx`** — audit log entries show relative time, full timestamp on hover; sorting now uses `safeParseDateForSort`

## Why hover tooltips
Relative time is friendlier for scanning a list, but support/admin workflows
often need the exact moment (SLA checks, audit trails). Keeping the absolute
timestamp as a `title` attribute preserves that without cluttering the UI.

## Testing
- [x] Manually verified on `TicketDetail`, `AdminTicketDetail`, `AdminTickets`, and `TicketAuditTimeline`
- [x] Verified hover tooltips show correct absolute timestamps
- [x] No new console errors
- [ ] (add screenshots/GIF here before submitting)

## Notes
- `date-fns` was already a project dependency (`^4.1.0`) — no new packages added