### PR TITLE
Fix auth subscription leak and add missing rate limit on /ai/analyze

### DIFF
--- a/Frontend/src/store/authStore.js
+++ b/Frontend/src/store/authStore.js
@@ -271,13 +271,14 @@ const useAuthStore = create(
             },
 
             _initialized: false,
+            _authSubscription: null,
             initialize: () => {
                 if (get()._initialized) return;
                 set({ _initialized: true });
 
                 get().getCurrentUser();
 
-                supabase.auth.onAuthStateChange(async (event, session) => {
+                const { data: { subscription } } = supabase.auth.onAuthStateChange(async (event, session) => {
                     console.log("Auth state change:", event);
                     if (session?.user) {
                         set({ user: session.user });
@@ -287,6 +288,15 @@ const useAuthStore = create(
                     }
                     set({ loading: false });
                 });
+
+                set({ _authSubscription: subscription });
+            },
+            cleanup: () => {
+                const sub = get()._authSubscription;
+                if (sub) {
+                    sub.unsubscribe();
+                    set({ _authSubscription: null, _initialized: false });
+                }
             }
         }),
         {

--- a/backend/main.py
+++ b/backend/main.py
@@ -728,10 +728,11 @@ async def analyze_ticket(request_body: TicketRequest, request: Request):
             print(f"[AI] OCR added {len(local_ocr_text)} chars to context.")
 
     # Initalize Timeline
-    return await analyze_only(request_body)
+    return await analyze_only(request_body, request)
 
 @app.post("/ai/analyze")
-async def analyze_only(request_body: TicketRequest):
+@limiter.limit("10/minute")
+async def analyze_only(request_body: TicketRequest, request: Request):
     """
     PERFORMANCE UPGRADE: AI Analysis phase only. 
     Does NOT persist to DB. This allows the user to review the analysis 
@@ -1044,12 +1045,13 @@ async def analyze_stream(request_body: TicketRequest):
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 @app.post("/ai/analyze_ticket/legacy")
-async def legacy_analyze_and_save(request_body: TicketRequest):
+@limiter.limit("10/minute")
+async def legacy_analyze_and_save(request_body: TicketRequest, request: Request):
     """
     BACKWARD COMPATIBILITY: Strictly performs analysis only. 
     Does NOT persist to DB to avoid foreign key violations.
     """
-    return await analyze_only(request_body)
+    return await analyze_only(request_body, request)
 
 @app.post("/ai/analyze-v2")
 async def analyze_ticket_v2(request: TicketRequest):


### PR DESCRIPTION
### Fix 1: Auth state change subscription leak (authStore.js)
- Stored the `onAuthStateChange` subscription returned by Supabase
- Added `cleanup()` method to unsubscribe listeners
- Prevents duplicate listeners when `initialize()` is called more than once (e.g. StrictMode in dev)

### Fix 2: Missing rate limiting on /ai/analyze (backend/main.py)
- Added `@limiter.limit("10/minute")` to the `/ai/analyze` endpoint
- The main `/ai/analyze_ticket` endpoint already had rate limiting, but it delegated to `analyze_only()` which was also directly exposed at `/ai/analyze` without rate limiting
- Also rate-limited the legacy `/ai/analyze_ticket/legacy` endpoint
- Passed `request` parameter through internal calls to satisfy slowapi dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication lifecycle handling by properly cleaning up session listeners.
  * Enhanced ticket analysis request processing for more reliable behavior.

* **Security & Performance**
  * Added rate limits to ticket analysis endpoints, allowing up to 10 requests per minute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->