### PR TITLE
fix(backend): add query parameter sanitization utility to prevent SQL injection

### DIFF
--- a/backend/routers/tickets.py
+++ b/backend/routers/tickets.py
@@ -7,7 +7,7 @@ from backend.auth_cookie import get_current_user
 from backend.dependencies import supabase, duplicate_service
 from backend.models import TicketSaveRequest, TicketRecord, TICKETS_DB
 from backend.sanitization import sanitize_ticket_data
-
+from backend.utils.query_sanitizer import sanitize_uuid, sanitize_int
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
@@ -16,9 +16,14 @@ async def get_tickets(company_id: str | None = None, user: dict = Depends(get_cu
     """Fetch persistent tickets from Supabase."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    try:
+        company_id = sanitize_uuid(company_id, "company_id")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
     from backend.services.redis_cache import redis_cache
-    
+
     cache_key = f"helpdesk:tickets:list:{company_id or 'all'}"
     if redis_cache.available:
         cached_data = redis_cache.get_json(cache_key)
@@ -178,7 +183,12 @@ async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user
     """Fetch single persistent ticket."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    try:
+        ticket_id = sanitize_uuid(ticket_id, "ticket_id")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
     res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
@@ -203,6 +213,11 @@ async def create_ticket(ticket: TicketRecord, user: dict = Depends(get_current_u
 @router.patch("/{ticket_id}", response_model=TicketRecord)
 async def update_ticket(ticket_id: str, updates: dict, user: dict = Depends(get_current_user)):
     """Partially update a ticket's fields (e.g., status, viewed_at)."""
+    try:
+        ticket_id = sanitize_uuid(ticket_id, "ticket_id")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
     sanitized_updates = sanitize_ticket_data(updates)
     for i, ticket in enumerate(TICKETS_DB):
         if str(ticket.ticket_id) == str(ticket_id):

--- a/backend/tests/test_query_sanitizer.py
+++ b/backend/tests/test_query_sanitizer.py
@@ -1,0 +1,106 @@
+"""Tests for query parameter sanitization — issue #3890."""
+
+import pytest
+from backend.utils.query_sanitizer import (
+    sanitize_string,
+    sanitize_uuid,
+    sanitize_int,
+    sanitize_enum,
+    MAX_PARAM_LENGTH,
+)
+
+
+class TestSanitizeString:
+    def test_normal_string_passes(self):
+        assert sanitize_string("VPN not working") == "VPN not working"
+
+    def test_strips_whitespace(self):
+        assert sanitize_string("  hello  ") == "hello"
+
+    def test_none_returns_none(self):
+        assert sanitize_string(None) is None
+
+    def test_empty_returns_none(self):
+        assert sanitize_string("") is None
+
+    def test_sql_union_select_blocked(self):
+        with pytest.raises(ValueError):
+            sanitize_string("' UNION SELECT * FROM users--")
+
+    def test_sql_drop_table_blocked(self):
+        with pytest.raises(ValueError):
+            sanitize_string("DROP TABLE tickets")
+
+    def test_sql_comment_blocked(self):
+        with pytest.raises(ValueError):
+            sanitize_string("admin'--")
+
+    def test_or_1_equals_1_blocked(self):
+        with pytest.raises(ValueError):
+            sanitize_string("' OR 1=1")
+
+    def test_sleep_injection_blocked(self):
+        with pytest.raises(ValueError):
+            sanitize_string("SLEEP(5)")
+
+    def test_truncates_long_string(self):
+        long_str = "a" * (MAX_PARAM_LENGTH + 100)
+        result = sanitize_string(long_str)
+        assert len(result) == MAX_PARAM_LENGTH
+
+
+class TestSanitizeUUID:
+    def test_valid_uuid_passes(self):
+        uuid = "123e4567-e89b-12d3-a456-426614174000"
+        assert sanitize_uuid(uuid) == uuid
+
+    def test_none_returns_none(self):
+        assert sanitize_uuid(None) is None
+
+    def test_invalid_uuid_raises(self):
+        with pytest.raises(ValueError):
+            sanitize_uuid("not-a-uuid")
+
+    def test_sql_injection_in_uuid_raises(self):
+        with pytest.raises(ValueError):
+            sanitize_uuid("' OR 1=1--")
+
+    def test_uuid_normalised_to_lowercase(self):
+        uuid = "123E4567-E89B-12D3-A456-426614174000"
+        assert sanitize_uuid(uuid) == uuid.lower()
+
+    def test_empty_returns_none(self):
+        assert sanitize_uuid("") is None
+
+
+class TestSanitizeInt:
+    def test_normal_int_passes(self):
+        assert sanitize_int(50) == 50
+
+    def test_clamps_above_max(self):
+        assert sanitize_int(9999, max_val=1000) == 1000
+
+    def test_clamps_below_min(self):
+        assert sanitize_int(-5, min_val=0) == 0
+
+    def test_none_returns_min(self):
+        assert sanitize_int(None, min_val=0) == 0
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError):
+            sanitize_int("abc")
+
+
+class TestSanitizeEnum:
+    def test_valid_value_passes(self):
+        assert sanitize_enum("open", ["open", "closed", "pending"]) == "open"
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            sanitize_enum("hacked", ["open", "closed"])
+
+    def test_none_returns_none(self):
+        assert sanitize_enum(None, ["open", "closed"]) is None
+
+    def test_empty_returns_none(self):
+        assert sanitize_enum("", ["open", "closed"]) is None

--- a/backend/utils/query_sanitizer.py
+++ b/backend/utils/query_sanitizer.py
@@ -1,0 +1,130 @@
+"""
+query_sanitizer.py — Input sanitization for query parameters to prevent SQL injection.
+
+Even though Supabase PostgREST uses parameterized queries internally,
+this utility enforces an additional layer of validation and sanitization
+on all user-supplied query parameters before they reach the ORM layer.
+"""
+
+import re
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Patterns that indicate SQL injection attempts
+_SQL_INJECTION_PATTERNS = re.compile(
+    r"""
+    (--|;|/\*|\*/|xp_|UNION\s+SELECT|INSERT\s+INTO|DROP\s+TABLE|
+    DELETE\s+FROM|UPDATE\s+SET|ALTER\s+TABLE|EXEC\s*\(|
+    CAST\s*\(|CONVERT\s*\(|DECLARE\s+@|WAITFOR\s+DELAY|
+    SLEEP\s*\(|BENCHMARK\s*\(|OR\s+1\s*=\s*1|AND\s+1\s*=\s*1|
+    '\s*OR\s*'|'\s*AND\s*'|1=1|1\s*=\s*1)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# UUID pattern
+_UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+# Safe string pattern — alphanumeric, spaces, hyphens, underscores, dots, @
+_SAFE_STRING_PATTERN = re.compile(r"^[\w\s\-_.@]+$")
+
+MAX_PARAM_LENGTH = 500
+
+
+def sanitize_string(value: Optional[str], field_name: str = "parameter") -> Optional[str]:
+    """
+    Sanitize a string query parameter.
+
+    - Strips leading/trailing whitespace
+    - Enforces max length
+    - Rejects SQL injection patterns
+    - Returns None if value is None or empty after stripping
+
+    Raises:
+        ValueError if the value contains SQL injection patterns
+    """
+    if value is None:
+        return None
+
+    value = str(value).strip()
+
+    if not value:
+        return None
+
+    if len(value) > MAX_PARAM_LENGTH:
+        logger.warning(f"[QuerySanitizer] {field_name} exceeds max length, truncating.")
+        value = value[:MAX_PARAM_LENGTH]
+
+    if _SQL_INJECTION_PATTERNS.search(value):
+        logger.warning(f"[QuerySanitizer] Potential SQL injection in {field_name}: {value[:50]!r}")
+        raise ValueError(f"Invalid characters detected in {field_name}.")
+
+    return value
+
+
+def sanitize_uuid(value: Optional[str], field_name: str = "id") -> Optional[str]:
+    """
+    Validate and sanitize a UUID parameter.
+
+    Raises:
+        ValueError if value is not a valid UUID format
+    """
+    if value is None:
+        return None
+
+    value = str(value).strip()
+
+    if not value:
+        return None
+
+    if not _UUID_PATTERN.match(value):
+        logger.warning(f"[QuerySanitizer] Invalid UUID format for {field_name}: {value[:50]!r}")
+        raise ValueError(f"Invalid UUID format for {field_name}.")
+
+    return value.lower()
+
+
+def sanitize_int(value: Optional[int], field_name: str = "limit", min_val: int = 0, max_val: int = 1000) -> int:
+    """
+    Validate and clamp an integer parameter within safe bounds.
+    """
+    if value is None:
+        return min_val
+
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field_name} must be an integer.")
+
+    if value < min_val:
+        return min_val
+    if value > max_val:
+        return max_val
+
+    return value
+
+
+def sanitize_enum(value: Optional[str], allowed: list, field_name: str = "field") -> Optional[str]:
+    """
+    Validate that a string parameter is within an allowed set of values.
+
+    Raises:
+        ValueError if value is not in allowed set
+    """
+    if value is None:
+        return None
+
+    value = str(value).strip()
+
+    if not value:
+        return None
+
+    if value not in allowed:
+        raise ValueError(f"Invalid value '{value}' for {field_name}. Allowed: {allowed}")
+
+    return value


### PR DESCRIPTION
## 🔐 Summary

Resolves #3890 by adding a reusable query parameter sanitization utility and applying it to all ticket search endpoints, preventing SQL injection via user-supplied query parameters.

---

## 🛠️ Changes Made

### 1. `backend/utils/query_sanitizer.py` — New Sanitization Utility

- `sanitize_string(value, field_name)` — strips whitespace, enforces max length (500 chars), rejects SQL injection patterns (UNION SELECT, DROP TABLE, OR 1=1, SLEEP(), etc.)
- `sanitize_uuid(value, field_name)` — validates strict UUID format, rejects non-UUID strings
- `sanitize_int(value, field_name, min_val, max_val)` — clamps integers within safe bounds
- `sanitize_enum(value, allowed, field_name)` — validates against an allowlist of values
- Logs warnings on suspicious inputs without exposing details to the client

### 2. `backend/routers/tickets.py` — Apply Sanitization

- `GET /tickets` — `company_id` now sanitized via `sanitize_uuid()` before ORM query
- `GET /tickets/{ticket_id}` — `ticket_id` now sanitized via `sanitize_uuid()` before ORM query
- `PATCH /tickets/{ticket_id}` — `ticket_id` now sanitized via `sanitize_uuid()` before update

### 3. `backend/tests/test_query_sanitizer.py` — Unit Tests

- Tests for SQL injection patterns (UNION SELECT, DROP TABLE, OR 1=1, SLEEP, comments)
- Tests for valid/invalid UUID formats
- Tests for integer clamping and type validation
- Tests for enum allowlist enforcement

---

## ✅ Security Issues Fixed
- 🔒 SQL injection via `company_id` query param blocked
- 🔒 SQL injection via `ticket_id` path param blocked
- 🔒 Invalid UUID formats rejected with 400 before reaching ORM
- 🔒 Suspicious patterns logged for monitoring
- 🔒 Defense-in-depth layer added on top of Supabase parameterized queries

---

Closes #3890