### PR TITLE
Fix mobile navigation header overlap with safe area padding (#3892)

### DIFF
--- a/MobileApp/src/screens/user/CreateTicketScreen.js
+++ b/MobileApp/src/screens/user/CreateTicketScreen.js
@@ -11,7 +11,7 @@ import {
   ActivityIndicator,
   Image,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SPACING, SHADOWS } from '../../styles/theme';
 import { ArrowLeft, Sparkles, Send, Image as ImageIcon, X } from 'lucide-react-native';
@@ -21,6 +21,7 @@ import * as ImagePicker from 'expo-image-picker';
 import * as Haptics from 'expo-haptics';
 
 const CreateTicketScreen = () => {
+  const insets = useSafeAreaInsets();
   const [description, setDescription] = useState('');
   const [loading, setLoading] = useState(false);
   const [image, setImage] = useState(null);
@@ -74,7 +75,7 @@ const CreateTicketScreen = () => {
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: insets.top + 10 }]}>
           <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
             <ArrowLeft size={24} color={COLORS.text} />
           </TouchableOpacity>

--- a/MobileApp/src/screens/user/DashboardScreen.js
+++ b/MobileApp/src/screens/user/DashboardScreen.js
@@ -129,7 +129,7 @@ const DashboardScreen = () => {
         contentContainerStyle={styles.scrollContent}
       >
         {/* Header */}
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
           <View style={{ flex: 1 }}>
             <Text style={styles.greeting}>{getGreeting()},</Text>
             <Text style={styles.userName}>{profile?.full_name || 'User'}</Text>

--- a/MobileApp/src/screens/user/KnowledgeBaseScreen.js
+++ b/MobileApp/src/screens/user/KnowledgeBaseScreen.js
@@ -3,12 +3,13 @@ import {
   StyleSheet, View, Text, TextInput, TouchableOpacity,
   FlatList, ActivityIndicator, StatusBar,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import { Search, BookOpen, ChevronRight, ArrowLeft, HelpCircle } from 'lucide-react-native';
 
 const KnowledgeBaseScreen = ({ navigation }) => {
+  const insets = useSafeAreaInsets();
   const [searchQuery, setSearchQuery] = useState('');
   const [articles, setArticles] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -75,7 +76,7 @@ const KnowledgeBaseScreen = ({ navigation }) => {
     <SafeAreaView style={styles.container} edges={['top']}>
       <StatusBar barStyle="dark-content" />
       
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + 20 }]}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
           <ArrowLeft size={24} color={COLORS.text} />
         </TouchableOpacity>

--- a/MobileApp/src/screens/user/NotificationsScreen.js
+++ b/MobileApp/src/screens/user/NotificationsScreen.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, ScrollView, ActivityIndicator, TouchableOpacity, RefreshControl } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import { Bell, Sparkles, MessageSquare, AlertCircle, Info, CheckCircle2 } from 'lucide-react-native';
 
 const NotificationsScreen = () => {
+  const insets = useSafeAreaInsets();
   const [notifications, setNotifications] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -125,7 +126,7 @@ const NotificationsScreen = () => {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
         <Text style={styles.headerTitle}>Notifications</Text>
       </View>
 

--- a/MobileApp/src/screens/user/ProfileScreen.js
+++ b/MobileApp/src/screens/user/ProfileScreen.js
@@ -3,7 +3,7 @@ import {
   StyleSheet, View, Text, TextInput, TouchableOpacity,
   ScrollView, StatusBar, ActivityIndicator, Modal, Alert, Image,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import {
@@ -19,6 +19,7 @@ import { useNotification } from '../../components/NotificationProvider';
 
 const ProfileScreen = () => {
   const { success, error: notifyError } = useNotification();
+  const insets = useSafeAreaInsets();
 
   const [profile, setProfile] = useState(null);
   const [user, setUser] = useState(null);
@@ -213,7 +214,7 @@ const ProfileScreen = () => {
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
 
         {/* Header */}
-        <View style={styles.header}>
+        <View style={[styles.header, { paddingTop: insets.top }]}>
           <Text style={styles.headerLabel}>ACCOUNT</Text>
           <Text style={styles.headerTitle}>Profile</Text>
         </View>

--- a/MobileApp/src/screens/user/TicketDetailScreen.js
+++ b/MobileApp/src/screens/user/TicketDetailScreen.js
@@ -10,7 +10,7 @@ import {
   Platform,
   ActivityIndicator
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SHADOWS } from '../../styles/theme';
 import { ArrowLeft, Send, User, Bot } from 'lucide-react-native';
@@ -18,6 +18,7 @@ import { useNavigation } from '@react-navigation/native';
 
 const TicketDetailScreen = ({ route }) => {
   const { ticketId } = route.params || {};
+  const insets = useSafeAreaInsets();
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState('');
   const [loading, setLoading] = useState(true);
@@ -128,7 +129,7 @@ const TicketDetailScreen = ({ route }) => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
           <ArrowLeft size={24} color={COLORS.text} />
         </TouchableOpacity>

--- a/MobileApp/src/screens/user/TicketTrackingScreen.js
+++ b/MobileApp/src/screens/user/TicketTrackingScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { ArrowLeft, CheckCircle2, Clock, Sparkles, MessageSquare, ShieldCheck } from 'lucide-react-native';
 import { supabase } from '../../lib/supabase';
@@ -9,6 +9,7 @@ import { COLORS, SHADOWS } from '../../styles/theme';
 const TicketTrackingScreen = ({ route }) => {
   const { ticketId } = route.params || {};
   const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
   const [ticket, setTicket] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -101,7 +102,7 @@ const TicketTrackingScreen = ({ route }) => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
         <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
           <ArrowLeft size={24} color={COLORS.text} />
         </TouchableOpacity>

--- a/MobileApp/src/screens/user/TicketsListScreen.js
+++ b/MobileApp/src/screens/user/TicketsListScreen.js
@@ -3,7 +3,7 @@ import {
   StyleSheet, View, Text, TouchableOpacity, FlatList,
   ActivityIndicator, RefreshControl, StatusBar,
 } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { supabase } from '../../lib/supabase';
 import { COLORS, SHADOWS } from '../../styles/theme';
@@ -13,6 +13,7 @@ const FILTERS = ['All', 'Active', 'Resolved'];
 
 const TicketsListScreen = () => {
   const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
   const [tickets, setTickets] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -117,7 +118,7 @@ const TicketsListScreen = () => {
     <SafeAreaView style={styles.container} edges={['top']}>
       <StatusBar barStyle="dark-content" backgroundColor={COLORS.background} />
 
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: insets.top + 16 }]}>
         <View>
           <Text style={styles.headerLabel}>SUPPORT CENTER</Text>
           <Text style={styles.headerTitle}>My Tickets</Text>


### PR DESCRIPTION
## Changes
- Added \useSafeAreaInsets\ dynamic top padding to 8 mobile screens (DashboardScreen, TicketsListScreen, ProfileScreen, NotificationsScreen, CreateTicketScreen, TicketDetailScreen, TicketTrackingScreen, KnowledgeBaseScreen)
- Imported \useSafeAreaInsets\ from \eact-native-safe-area-context\
- Replaced static padding with dynamic \paddingTop: insets.top\ for iOS notch/status bar overlap fix

## Screens Modified
- \MobileApp/src/screens/user/DashboardScreen.js\
- \MobileApp/src/screens/user/TicketsListScreen.js\
- \MobileApp/src/screens/user/ProfileScreen.js\
- \MobileApp/src/screens/user/NotificationsScreen.js\
- \MobileApp/src/screens/user/CreateTicketScreen.js\
- \MobileApp/src/screens/user/TicketDetailScreen.js\
- \MobileApp/src/screens/user/TicketTrackingScreen.js\
- \MobileApp/src/screens/user/KnowledgeBaseScreen.js\

Closes #3892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header spacing across ticket, dashboard, knowledge base, notification, and profile screens.
  * Headers now adapt to device safe areas, reducing overlap with status bars and notches.
  * Ensured consistent top padding across supported mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->