### PR TITLE
test(utils): add basic test suite for date helper functions (#3867)

### DIFF
--- a/Frontend/src/utils/dateUtils.test.js
+++ b/Frontend/src/utils/dateUtils.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { formatTimelineDate, getTimeZoneAbbr, formatFullTimestamp } from './dateUtils';
+
+describe('formatTimelineDate', () => {
+  it('returns null for falsy input', () => {
+    expect(formatTimelineDate(null)).toBeNull();
+    expect(formatTimelineDate(undefined)).toBeNull();
+    expect(formatTimelineDate('')).toBeNull();
+  });
+
+  it('returns Invalid Date for garbage string', () => {
+    expect(formatTimelineDate('not-a-date')).toBe('Invalid Date');
+  });
+
+  it('formats ISO string with Z suffix', () => {
+    const result = formatTimelineDate('2025-06-15T10:30:00Z');
+    expect(result).toBeTruthy();
+    expect(result).not.toBe('Invalid Date');
+  });
+
+  it('appends Z to naive datetime string', () => {
+    const result = formatTimelineDate('2025-06-15T10:30:00');
+    expect(result).toBeTruthy();
+    expect(result).not.toBe('Invalid Date');
+  });
+
+  it('handles Date object input', () => {
+    const date = new Date('2025-01-01T00:00:00Z');
+    const result = formatTimelineDate(date);
+    expect(result).toBeTruthy();
+    expect(result).not.toBe('Invalid Date');
+  });
+
+  it('handles timestamp number input', () => {
+    const result = formatTimelineDate(1700000000000);
+    expect(result).toBeTruthy();
+    expect(result).not.toBe('Invalid Date');
+  });
+});
+
+describe('getTimeZoneAbbr', () => {
+  it('returns a non-empty string', () => {
+    const tz = getTimeZoneAbbr();
+    expect(typeof tz).toBe('string');
+    expect(tz.length).toBeGreaterThan(0);
+  });
+
+  it('returns a short timezone abbreviation', () => {
+    const tz = getTimeZoneAbbr();
+    expect(tz.length).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('formatFullTimestamp', () => {
+  it('returns Processing... for falsy input', () => {
+    expect(formatFullTimestamp(null)).toBe('Processing...');
+    expect(formatFullTimestamp(undefined)).toBe('Processing...');
+    expect(formatFullTimestamp('')).toBe('Processing...');
+  });
+
+  it('returns formatted string with timezone for valid input', () => {
+    const result = formatFullTimestamp('2025-06-15T10:30:00Z');
+    expect(result).toContain('(');
+    expect(result).toContain(')');
+  });
+
+  it('returns Invalid Date in full format for garbage string', () => {
+    const result = formatFullTimestamp('not-a-date');
+    expect(result).toContain('Invalid Date');
+  });
+});


### PR DESCRIPTION
Add unit tests for formatTimelineDate, getTimeZoneAbbr, and formatFullTimestamp covering edge cases. Closes #3867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for timeline date formatting, timezone abbreviations, and full timestamp display.
  * Verified handling of empty, invalid, ISO-formatted, `Date`, and numeric timestamp inputs.
  * Confirmed expected processing states and timezone information are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->