### PR TITLE
fix(backend): add server startup time log in main.py (#3870)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -218,6 +218,8 @@ except ImportError:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Load all models at startup."""
+    startup_time = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    print(f"[Startup] Server initialization started at {startup_time}")
     print("[Startup] Loading AI models ...")
     try:
         classifier_service.load()


### PR DESCRIPTION
Log the exact UTC timestamp of server initialization at startup for observability. Closes #3870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a startup log entry showing when server initialization begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->