### PR TITLE
fix: replace broken System Presentation link with GitHub Wiki.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pinned: false
     <img src="https://img.shields.io/badge/✉️_CONTACT_ENTERPRISE-111827?style=for-the-badge&logo=minutemailer&logoColor=white&labelColor=10b981" height="42" alt="Contact Enterprise" />
   </a>
   &nbsp;&nbsp;
-  <a href="https://ritesh-1918.github.io/HELPDESK.AI/">
+<a href="https://github.com/riteshbonthalakoti/HELPDESK.AI/wiki">
     <img src="https://img.shields.io/badge/📊_SYSTEM_PRESENTATION-111827?style=for-the-badge&logo=googleslides&logoColor=white&labelColor=3b82f6" height="42" alt="System Presentation" />
   </a>
   &nbsp;&nbsp;


### PR DESCRIPTION
## Description

Fixed a broken "System Presentation" link in the README.

### Changes
- Replaced the broken GitHub Pages URL (404)
- Updated the link to the project's GitHub Wiki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s top navigation link to direct readers to the project’s GitHub Wiki.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->