### PR TITLE
[Security]: Enforce Strict Multi-Tenant Isolation & JWT Scope Verification on Ticket Queries

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,6 @@ import datetime
 import traceback
 import warnings
 import logging
-import hashlib
 from contextlib import asynccontextmanager
 
 # Suppress harmless PyTorch CPU pin_memory warning
@@ -59,6 +58,7 @@ from backend.services.classifier_v3 import classifier_v3 # V3 Power Model
 from backend.services.ner_service import NERService
 from backend.services.duplicate_service import DuplicateService
 from backend.services.rag_service import RagService
+from backend.services.security_utils import constant_time_compare, secure_compare_sha256
 
 
 # ---------------------------------------------------------------------------
@@ -578,7 +578,7 @@ async def save_ticket(request_body: TicketSaveRequest):
             except HTTPException:
                 raise
             except Exception as profile_error:
-                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+                user_hash = secure_compare_sha256(str(request_body.user_id))
                 logger.error(f"Tenant resolution error for user {user_hash}: {profile_error}")
                 raise HTTPException(status_code=503, detail="Failed to resolve tenant linkage") from profile_error
 
@@ -586,8 +586,10 @@ async def save_ticket(request_body: TicketSaveRequest):
         profile_company_id = profile.get("company_id")
         if final_data.get("company_id"):
             # User provided company_id: verify it matches their profile.
-            if profile_company_id and final_data["company_id"] != profile_company_id:
-                user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+            if profile_company_id and not constant_time_compare(
+                str(final_data["company_id"]), str(profile_company_id)
+            ):
+                user_hash = secure_compare_sha256(str(request_body.user_id))
                 logger.warning(f"Tenant mismatch: user {user_hash} attempted {final_data['company_id']}, assigned to {profile_company_id}")
                 raise HTTPException(status_code=403, detail="User not authorized for this tenant")
         elif profile_company_id:
@@ -601,7 +603,7 @@ async def save_ticket(request_body: TicketSaveRequest):
         if not final_data.get("company") and profile.get("company"):
             final_data["company"] = profile["company"]
 
-        user_hash = hashlib.sha256(str(request_body.user_id).encode()).hexdigest()[:8]
+        user_hash = secure_compare_sha256(str(request_body.user_id))
         logger.info(f"Tenant linkage: user_hash={user_hash}, company_id={final_data.get('company_id')}")
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -536,15 +536,18 @@ async def log_correction(raw_request: Request):
 # Ticket operations (Now via Supabase)
 # ---------------------------------------------------------------------------
 @app.get("/tickets")
-async def get_tickets(company_id: str | None = None):
-    """Fetch persistent tickets from Supabase."""
+async def get_tickets(company_id: str | None = None, user: dict = Depends(get_current_user)):
+    """Fetch persistent tickets from Supabase, scoped to the caller's tenant."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    profile = get_profile_for_user(user)
+    effective_company = enforce_ticket_scope(profile, company_id)
+
     query = supabase.table("tickets").select("*").order("created_at", desc=True)
-    if company_id:
-        query = query.eq("company_id", company_id)
-        
+    if effective_company:
+        query = query.eq("company_id", effective_company)
+
     res = query.execute()
     return res.data
 
@@ -654,14 +657,23 @@ async def save_ticket(request_body: TicketSaveRequest):
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/tickets/{ticket_id}")
-async def get_ticket_by_id(ticket_id: str):
-    """Fetch single persistent ticket."""
+async def get_ticket_by_id(ticket_id: str, user: dict = Depends(get_current_user)):
+    """Fetch single persistent ticket, enforcing tenant scope."""
     if not supabase:
         raise HTTPException(status_code=500, detail="Database connection not initialized")
-    
+
+    profile = get_profile_for_user(user)
+    effective_company = enforce_ticket_scope(profile, None)
+
     res = supabase.table("tickets").select("*").eq("id", ticket_id).single().execute()
     if not res.data:
         raise HTTPException(status_code=404, detail="Ticket not found")
+
+    ticket_company = res.data.get("company_id")
+    if effective_company and ticket_company and not constant_time_compare(
+        str(ticket_company), str(effective_company)
+    ):
+        raise HTTPException(status_code=403, detail="User not authorized for this tenant")
     return res.data
 
 
@@ -1144,6 +1156,46 @@ async def get_current_user(request: Request) -> dict:
 class LoginBody(BaseModel):
     email: str
     password: str
+
+def get_profile_for_user(user: dict) -> dict:
+    """Resolve the caller's company profile (tenant + role) from Supabase."""
+    if not supabase:
+        raise HTTPException(status_code=503, detail="Database connection not initialized")
+    user_id = user.get("id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid session payload")
+    try:
+        res = supabase.table("profiles").select("company_id, company, role").eq("id", user_id).single().execute()
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail=f"Profile lookup failed: {exc}") from exc
+    if not res.data:
+        raise HTTPException(status_code=404, detail="User profile not found")
+    return res.data
+
+
+def is_master_admin(profile: dict) -> bool:
+    return str(profile.get("role", "")).lower() == "master_admin"
+
+
+def enforce_ticket_scope(profile: dict, requested_company_id: str | None) -> str | None:
+    """
+    Validate JWT-derived tenant scope for a ticket query.
+
+    Master admins may query any tenant. Regular users are pinned to their
+    profile's company_id and may not request another tenant's scope.
+    """
+    profile_company = profile.get("company_id")
+    if is_master_admin(profile):
+        return requested_company_id or profile_company
+    if requested_company_id is not None:
+        if not profile_company or not constant_time_compare(
+            str(requested_company_id), str(profile_company)
+        ):
+            raise HTTPException(status_code=403, detail="User not authorized for this tenant")
+        return requested_company_id
+    if not profile_company:
+        raise HTTPException(status_code=403, detail="User has no tenant assignment")
+    return profile_company
 
 class SignupBody(BaseModel):
     email: str

--- a/backend/services/security_utils.py
+++ b/backend/services/security_utils.py
@@ -1,0 +1,81 @@
+"""
+Security utilities.
+
+Provides constant-time comparison helpers and password hashing/verification
+primitives so that secret/credential checks are resilient against timing
+attacks. Authentication for the public API is delegated to Supabase Auth, but
+any local secret comparison (tenant scopes, reset tokens, stored hashes) must
+go through these helpers instead of the standard equality operator.
+"""
+
+import hashlib
+import hmac
+import secrets
+
+PBKDF2_ROUNDS = 260_000
+HASH_SCHEME = "pbkdf2_sha256"
+
+
+def constant_time_compare(value_a, value_b) -> bool:
+    """
+    Compare two values in constant time.
+
+    Accepts ``str`` or ``bytes``. Returning ``False`` for inputs of different
+    lengths is inherent to the API, but identical-length comparisons no longer
+    leak byte-by-byte timing information the way ``==`` would.
+    """
+    if isinstance(value_a, str):
+        value_a = value_a.encode("utf-8")
+    if isinstance(value_b, str):
+        value_b = value_b.encode("utf-8")
+    if not isinstance(value_a, (bytes, bytearray)) or not isinstance(value_b, (bytes, bytearray)):
+        raise TypeError("constant_time_compare expects str or bytes inputs")
+    return hmac.compare_digest(value_a, value_b)
+
+
+def hash_password(password: str, *, salt: str | None = None, rounds: int = PBKDF2_ROUNDS) -> str:
+    """
+    Hash a password using PBKDF2-HMAC-SHA256 with a random per-call salt.
+
+    Returns a self-describing string of the form:
+        pbkdf2_sha256$<iterations>$<salt_hex>$<hash_hex>
+    """
+    if not isinstance(password, str):
+        raise TypeError("password must be a str")
+    salt_bytes = bytes.fromhex(salt) if salt else secrets.token_bytes(16)
+    salt_hex = salt_bytes.hex()
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt_bytes, rounds)
+    return f"{HASH_SCHEME}${rounds}${salt_hex}${digest.hex()}"
+
+
+def verify_password(password: str, stored_hash: str) -> bool:
+    """
+    Verify a password against a stored ``hash_password`` output.
+
+    Both the candidate and stored digests are recomputed/parsed and compared
+    with :func:`constant_time_compare`, so verification time does not depend
+    on how many leading characters match.
+    """
+    if not isinstance(password, str) or not isinstance(stored_hash, str):
+        return False
+    try:
+        scheme, rounds_str, salt_hex, hash_hex = stored_hash.split("$", 3)
+        if scheme != HASH_SCHEME:
+            return False
+        rounds = int(rounds_str)
+        salt_bytes = bytes.fromhex(salt_hex)
+        candidate = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt_bytes, rounds)
+        expected = bytes.fromhex(hash_hex)
+        return constant_time_compare(candidate, expected)
+    except (ValueError, TypeError):
+        return False
+
+
+def secure_compare_sha256(secret: str) -> str:
+    """
+    One-way redact helper for logging (e.g. user ids).
+
+    Replaces the ad-hoc ``hashlib.sha256(...).hexdigest()[:8]`` pattern used in
+    log lines so redacted identifiers are produced consistently.
+    """
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()[:8]

--- a/backend/tests/test_security_utils.py
+++ b/backend/tests/test_security_utils.py
@@ -1,0 +1,111 @@
+"""
+Unit tests for backend.services.security_utils.
+
+Run with:  python -m unittest backend.tests.test_security_utils -v
+"""
+
+import time
+import unittest
+
+from backend.services.security_utils import (
+    constant_time_compare,
+    hash_password,
+    verify_password,
+    secure_compare_sha256,
+)
+
+
+class ConstantTimeCompareTests(unittest.TestCase):
+    def test_equal_bytes(self):
+        self.assertTrue(constant_time_compare(b"secret", b"secret"))
+
+    def test_equal_str(self):
+        self.assertTrue(constant_time_compare("secret", "secret"))
+
+    def test_mixed_types(self):
+        self.assertTrue(constant_time_compare("secret", b"secret"))
+
+    def test_different_values(self):
+        self.assertFalse(constant_time_compare("secret", "wrong"))
+
+    def test_different_lengths(self):
+        self.assertFalse(constant_time_compare("abc", "abcd"))
+
+    def test_empty_values(self):
+        self.assertTrue(constant_time_compare("", ""))
+        self.assertFalse(constant_time_compare("", "x"))
+
+    def test_invalid_type(self):
+        with self.assertRaises(TypeError):
+            constant_time_compare(None, "secret")
+        with self.assertRaises(TypeError):
+            constant_time_compare(123, 123)
+
+    def test_whitespace_matters(self):
+        self.assertFalse(constant_time_compare(" secret", "secret"))
+
+    def test_unicode(self):
+        self.assertTrue(constant_time_compare("pässwörd", "pässwörd"))
+        self.assertFalse(constant_time_compare("pässwörd", "passwörd"))
+
+    def test_timing_is_constant_for_equal_length(self):
+        a = "x" * 1000
+        b = "y" * 1000
+        c = "y" * 1000
+        # Compare the near-match and exact-match timings; both scan the full
+        # buffer so they should be in the same ballpark.
+        near_start = time.perf_counter()
+        constant_time_compare(a, b)
+        near_elapsed = time.perf_counter() - near_start
+        exact_start = time.perf_counter()
+        constant_time_compare(b, c)
+        exact_elapsed = time.perf_counter() - exact_start
+        self.assertLess(abs(near_elapsed - exact_elapsed), 0.5)
+
+
+class PasswordHashTests(unittest.TestCase):
+    def test_hash_and_verify_roundtrip(self):
+        stored = hash_password("hunter2")
+        self.assertTrue(stored.startswith("pbkdf2_sha256$"))
+        self.assertTrue(verify_password("hunter2", stored))
+
+    def test_verify_rejects_wrong_password(self):
+        stored = hash_password("hunter2")
+        self.assertFalse(verify_password("hunter3", stored))
+
+    def test_salt_is_random(self):
+        self.assertNotEqual(hash_password("same"), hash_password("same"))
+
+    def test_verify_malformed_hash(self):
+        self.assertFalse(verify_password("pw", "not-a-real-hash"))
+        self.assertFalse(verify_password("pw", "bcrypt$4$salt$hash"))
+        self.assertFalse(verify_password("pw", ""))
+        self.assertFalse(verify_password("pw", None))
+
+    def test_verify_empty_password(self):
+        stored = hash_password("")
+        self.assertTrue(verify_password("", stored))
+        self.assertFalse(verify_password(" ", stored))
+
+    def test_verify_wrong_type(self):
+        self.assertFalse(verify_password(None, hash_password("pw")))
+        self.assertFalse(verify_password("pw", 42))
+
+    def test_hash_rejects_non_str(self):
+        with self.assertRaises(TypeError):
+            hash_password(None)
+
+
+class SecureCompareSha256Tests(unittest.TestCase):
+    def test_short_prefix(self):
+        self.assertEqual(len(secure_compare_sha256("user-123")), 8)
+
+    def test_deterministic(self):
+        self.assertEqual(secure_compare_sha256("abc"), secure_compare_sha256("abc"))
+
+    def test_differs_for_distinct_inputs(self):
+        self.assertNotEqual(secure_compare_sha256("abc"), secure_compare_sha256("abd"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary
Enforces multitenant JWT scoping on all ticket endpoints so users can only access tickets for their assigned tenant/company.

## Changes
- Added get_profile_for_user, enforce_ticket_scope, and is_master_admin helpers in ackend/main.py.
- All ticket read/write endpoints now scope queries by the authenticated user's company; non-master-admins are blocked from cross-tenant access with 403.
- Login now fails with 400 for users without a tenant assignment instead of returning 401.

## Testing
- Backend changes verified by code review; run the backend suite (python -m unittest discover backend/tests -v) on a Python host.

Closes #3947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened password protection and secure credential verification.
  * Added safeguards against timing-based attacks and malformed security data.

* **Bug Fixes**
  * Ticket lists and individual ticket details now enforce account and company access boundaries.
  * Administrators with elevated permissions retain access where appropriate.
  * Improved protection against unauthorized cross-company ticket access.

* **Tests**
  * Added comprehensive coverage for password security, secure comparisons, malformed inputs, and Unicode handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->