### PR TITLE
fix(security): Implement Constant-Time Password Verification to Prevent Timing Attacks (#3982)

### DIFF
--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -1,0 +1,49 @@
+"""
+Authentication Service providing constant-time password and token verification
+to prevent timing side-channel attacks.
+"""
+
+import hashlib
+import hmac
+import secrets
+from typing import Optional
+
+
+def hash_password(password: str, salt: Optional[bytes] = None) -> tuple[str, str]:
+    """Hash a password using PBKDF2-SHA256 with a random salt."""
+    if salt is None:
+        salt = secrets.token_bytes(16)
+    
+    derived = hashlib.pbkdf2_hmac(
+        hash_name="sha256",
+        password=password.encode("utf-8"),
+        salt=salt,
+        iterations=100000,
+        dklen=32,
+    )
+    return derived.hex(), salt.hex()
+
+
+def verify_password_constant_time(provided_password: str, stored_hash_hex: str, salt_hex: str) -> bool:
+    """
+    Verify a password in constant time using secrets.compare_digest.
+    
+    Prevents side-channel timing attacks that measure comparison duration.
+    """
+    if not provided_password or not stored_hash_hex or not salt_hex:
+        return False
+    
+    try:
+        salt = bytes.fromhex(salt_hex)
+        computed_hash_hex, _ = hash_password(provided_password, salt=salt)
+        return secrets.compare_digest(computed_hash_hex, stored_hash_hex)
+    except (ValueError, TypeError):
+        return False
+
+
+def verify_token_constant_time(provided_token: str, expected_token: str) -> bool:
+    """Verify an API token or secret in constant time."""
+    if not provided_token or not expected_token:
+        return False
+    
+    return secrets.compare_digest(provided_token.strip(), expected_token.strip())

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -4,7 +4,6 @@ to prevent timing side-channel attacks.
 """
 
 import hashlib
-import hmac
 import secrets
 from typing import Optional
 

--- a/backend/tests/test_constant_time_auth.py
+++ b/backend/tests/test_constant_time_auth.py
@@ -1,0 +1,30 @@
+import pytest
+from backend.services.auth_service import (
+    hash_password,
+    verify_password_constant_time,
+    verify_token_constant_time,
+)
+
+
+def test_password_hashing_and_constant_time_verification():
+    password = "SuperSecretPassword123!"
+    hash_hex, salt_hex = hash_password(password)
+
+    # Valid password should match
+    assert verify_password_constant_time(password, hash_hex, salt_hex) is True
+
+    # Invalid password should fail
+    assert verify_password_constant_time("WrongPassword123!", hash_hex, salt_hex) is False
+
+
+def test_empty_or_invalid_inputs():
+    assert verify_password_constant_time("", "abc", "123") is False
+    assert verify_password_constant_time("pass", "", "123") is False
+    assert verify_password_constant_time("pass", "abc", "") is False
+
+
+def test_token_constant_time_verification():
+    token = "secret-api-token-xyz"
+    assert verify_token_constant_time(token, "secret-api-token-xyz") is True
+    assert verify_token_constant_time(token, "attacker-token-abc") is False
+    assert verify_token_constant_time("", token) is False


### PR DESCRIPTION
## Description

Implements constant-time password hash and token comparison using `secrets.compare_digest` to prevent side-channel timing attacks during user authentication.

## Related Issue

Fixes #3982

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration change

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Ensures password hash comparison runs in constant time regardless of string prefix matches.