### PR TITLE
fix(backend): catch CORS configuration errors on deployment envs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,3 +16,8 @@ SENTENCE_TRANSFORMER_MODEL_PATH=
 # Readiness Check
 # Set REQUIRE_SUPABASE=true to include Supabase configuration in the strict readiness gate
 REQUIRE_SUPABASE=false
+
+# CORS Origins
+# Comma-separated list of allowed frontend origins (e.g. https://app.example.com,http://localhost:5173).
+# If unset, the backend falls back to the hardcoded production + local-dev defaults.
+CORS_ALLOWED_ORIGINS=

--- a/backend/main.py
+++ b/backend/main.py
@@ -274,14 +274,27 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-# CORS — locked to production + local dev only
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[
+# CORS — origins loaded from environment so deployment-specific frontend
+# hosts (or "*" for development) can be configured without redeploying code.
+# Supported env var: CORS_ALLOWED_ORIGINS (comma-separated list, e.g.
+# "https://app.example.com,https://admin.example.com").
+def _parse_cors_origins() -> list[str]:
+    raw = os.environ.get("CORS_ALLOWED_ORIGINS", "").strip()
+    if raw:
+        return [origin.strip() for origin in raw.split(",") if origin.strip()]
+    # Fallback: production frontend + local dev origins.
+    return [
         "https://helpdeskaiv1.vercel.app",
         "http://localhost:5173",
         "http://localhost:3000",
-    ],
+    ]
+
+
+CORS_ALLOWED_ORIGINS = _parse_cors_origins()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Implements #3884 — CORS configuration errors on deployment envs.

## Changes
- `backend/main.py`: CORS origins are now parsed from the `CORS_ALLOWED_ORIGINS` environment variable via a new `_parse_cors_origins()` helper, falling back to a safe default set.
- `backend/.env.example`: documents the new `CORS_ALLOWED_ORIGINS` variable with comma-separated origin syntax.
- CORS middleware is configured with `allow_credentials=True`, `allow_methods=["*"]`, `allow_headers=["*"]`.

This keeps the backend runnable on any deployment where the env var is missing (fails safe instead of failing to boot).

Closes #3884


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable allowed frontend origins through the `CORS_ALLOWED_ORIGINS` environment setting.
  * Supports comma-separated origin values for flexible deployment configuration.
  * Retains existing production and local development origins when the setting is not provided.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->