### PR TITLE
feat(ui): integrate toast notifications for system alerts

### DIFF
--- a/Frontend/src/components/shared/ConfirmDialog.jsx
+++ b/Frontend/src/components/shared/ConfirmDialog.jsx
@@ -1,0 +1,83 @@
+/**
+ * ConfirmDialog — sleek in-app confirmation dialog (issue #3891).
+ *
+ * Replaces the generic browser `window.confirm`/`window.alert` dialogs with a
+ * consistent, animated modal that matches the design system.
+ */
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { AlertTriangle, X } from 'lucide-react';
+
+const ConfirmDialog = ({
+    open,
+    title = 'Are you sure?',
+    message = 'This action cannot be undone.',
+    confirmLabel = 'Confirm',
+    cancelLabel = 'Cancel',
+    destructive = false,
+    onConfirm,
+    onCancel,
+}) => {
+    return (
+        <AnimatePresence>
+            {open && (
+                <motion.div
+                    className="fixed inset-0 z-[9998] flex items-center justify-center p-6"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                >
+                    <div
+                        className="absolute inset-0 bg-slate-950/60 backdrop-blur-sm"
+                        onClick={onCancel}
+                    />
+                    <motion.div
+                        role="alertdialog"
+                        aria-modal="true"
+                        aria-label={title}
+                        className="relative w-full max-w-md rounded-3xl border border-slate-200 bg-white p-8 shadow-2xl"
+                        initial={{ opacity: 0, y: 40, scale: 0.92 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: 20, scale: 0.95 }}
+                        transition={{ type: 'spring', stiffness: 320, damping: 28 }}
+                    >
+                        <button
+                            onClick={onCancel}
+                            aria-label="Close dialog"
+                            className="absolute right-4 top-4 p-1.5 rounded-xl text-slate-400 hover:bg-slate-100 hover:text-slate-600 transition-colors"
+                        >
+                            <X className="w-4 h-4" />
+                        </button>
+
+                        <div className="flex items-start gap-4">
+                            <div className={`shrink-0 w-11 h-11 rounded-2xl flex items-center justify-center ${destructive ? 'bg-red-100 text-red-600' : 'bg-amber-100 text-amber-600'}`}>
+                                <AlertTriangle className="w-5 h-5" />
+                            </div>
+                            <div>
+                                <h3 className="text-lg font-bold text-slate-900">{title}</h3>
+                                <p className="mt-1.5 text-sm text-slate-500 leading-relaxed">{message}</p>
+                            </div>
+                        </div>
+
+                        <div className="mt-8 flex justify-end gap-3">
+                            <button
+                                onClick={onCancel}
+                                className="px-5 py-2.5 rounded-xl text-sm font-semibold text-slate-600 hover:bg-slate-100 transition-colors"
+                            >
+                                {cancelLabel}
+                            </button>
+                            <button
+                                onClick={onConfirm}
+                                className={`px-5 py-2.5 rounded-xl text-sm font-semibold text-white shadow-lg transition-all hover:shadow-xl ${destructive ? 'bg-red-600 hover:bg-red-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
+                            >
+                                {confirmLabel}
+                            </button>
+                        </div>
+                    </motion.div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+};
+
+export default ConfirmDialog;

--- a/Frontend/src/user/pages/Profile.jsx
+++ b/Frontend/src/user/pages/Profile.jsx
@@ -32,10 +32,14 @@ import useAuthStore from "../../store/authStore";
 import useToastStore from "../../store/toastStore";
 import { supabase } from "../../lib/supabaseClient";
 import BugReportWidget from "../../components/shared/BugReportWidget";
+import ConfirmDialog from "../../components/shared/ConfirmDialog";
 const Profile = () => {
     const navigate = useNavigate();
     const { profile, user, logout, loading: authLoading, updateProfile } = useAuthStore();
     const { showToast } = useToastStore();
+
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [deleteLoading, setDeleteLoading] = useState(false);
 
     const [userTickets, setUserTickets] = useState([]);
     const [isEditing, setIsEditing] = useState(false);
@@ -187,19 +191,22 @@ const Profile = () => {
     };
 
     const handleDeleteAccount = async () => {
-        if (!window.confirm("Are you absolutely sure you want to permanently delete your account and all associated data? This action cannot be undone.")) return;
-
+        setDeleteLoading(true);
         try {
             const { error: rpcError } = await supabase.rpc('delete_user');
             if (rpcError) {
                 console.warn("RPC delete_user not found or failed. Attempting profile removal...", rpcError);
                 await supabase.from('profiles').delete().eq('id', user.id);
             }
+            setDeleteConfirmOpen(false);
             await logout();
             navigate('/login');
             showToast("Account deleted and securely wiped successfully.", "success");
         } catch (err) {
+            setDeleteConfirmOpen(false);
             showToast("Failed to wipe account: " + err.message, "error");
+        } finally {
+            setDeleteLoading(false);
         }
     };
 
@@ -521,7 +528,7 @@ const Profile = () => {
                                         </button>
 
                                         <button
-                                            onClick={handleDeleteAccount}
+                                            onClick={() => setDeleteConfirmOpen(true)}
                                             className="w-full p-8 flex items-center justify-between hover:bg-red-50/30 transition-all group rounded-b-3xl"
                                         >
                                             <div className="flex items-center gap-6">
@@ -608,6 +615,17 @@ const Profile = () => {
                 )}
             </AnimatePresence>
 
+            {/* Account Deletion Confirmation */}
+            <ConfirmDialog
+                open={deleteConfirmOpen}
+                title="Delete your account?"
+                message="This will permanently delete your account and all associated data. This action cannot be undone."
+                confirmLabel={deleteLoading ? "Deleting..." : "Delete Account"}
+                cancelLabel="Keep Account"
+                destructive
+                onCancel={() => setDeleteConfirmOpen(false)}
+                onConfirm={handleDeleteAccount}
+            />
 
         </div>
     );


### PR DESCRIPTION
Implements #3891 — toast notifications for system alerts.

## Changes
- `Frontend/src/components/shared/ConfirmDialog.jsx`: new reusable confirmation dialog for destructive actions.
- `ProfileScreen` account deletion now uses the ConfirmDialog and surfaces success/error feedback via toast notifications instead of abrupt browser dialogs.

Closes #3891
