### PR TITLE
feat(auth): refresh JWT token automatically on expiry warnings

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -78,6 +78,7 @@ import AdminProtectedRoute from "./components/shared/AdminProtectedRoute";
 import MasterAdminProtectedRoute from "./components/shared/MasterAdminProtectedRoute";
 import ProtectedRoute from "./components/shared/ProtectedRoute";
 import useAuthStore from "./store/authStore";
+import useSilentSessionRefresh from "./hooks/useSilentSessionRefresh";
 import NotApproved from "./pages/NotApproved";
 
 // Master Admin Components
@@ -154,6 +155,14 @@ function AppLayout() {
 
   // Initialize Global Realtime Notifications Listener
   useRealtimeNotifications();
+
+  // Silently rotate JWTs before expiry (Supabase + HttpOnly-cookie flow)
+  useSilentSessionRefresh({
+    enabled: Boolean(user),
+    onError: (err) => {
+      console.warn("Silent session refresh failed:", err?.message || err);
+    },
+  });
 
   useEffect(() => {
     if (!user) return;

--- a/Frontend/src/hooks/useSilentSessionRefresh.js
+++ b/Frontend/src/hooks/useSilentSessionRefresh.js
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { supabase } from '../lib/supabaseClient';
+import {
+    decodeJwtExpiry, refreshSessionSilently,
+    REFRESH_MARGIN_MS, MIN_REFRESH_DELAY_MS, MAX_REFRESH_DELAY_MS,
+} from '../utils/sessionRefresh';
+
+/**
+ * useSilentSessionRefresh — keeps the JWT fresh without user interaction.
+ *
+ * Decodes the current access token's `exp`, schedules a silent refresh just
+ * before it expires, and re-arms the timer after every successful rotation.
+ * Also refreshes immediately when the tab becomes visible again or the browser
+ * regains connectivity, so stale tokens never leak into API calls.
+ *
+ * @param {object}   options
+ * @param {boolean}  options.enabled   Active only while a user is signed in.
+ * @param {function} options.onRefresh Called after every successful rotation.
+ * @param {function} options.onError   Called when the Supabase refresh fails.
+ */
+export default function useSilentSessionRefresh({
+    enabled = true,
+    onRefresh,
+    onError,
+} = {}) {
+    const [lastRefreshedAt, setLastRefreshedAt] = useState(null);
+    const [nextRefreshAt, setNextRefreshAt] = useState(null);
+    const timerRef = useRef(null);
+    const runningRef = useRef(false);
+    const onRefreshRef = useRef(onRefresh);
+    const onErrorRef = useRef(onError);
+    onRefreshRef.current = onRefresh;
+    onErrorRef.current = onError;
+
+    const computeDelay = useCallback(async () => {
+        const { data } = await supabase.auth.getSession();
+        const exp = decodeJwtExpiry(data?.session?.access_token);
+        if (exp === null) {
+            return { delay: MIN_REFRESH_DELAY_MS, due: Date.now() + MIN_REFRESH_DELAY_MS };
+        }
+        const delay = Math.max(
+            MIN_REFRESH_DELAY_MS,
+            Math.min(exp - Date.now() - REFRESH_MARGIN_MS, MAX_REFRESH_DELAY_MS)
+        );
+        return { delay, due: Date.now() + delay };
+    }, []);
+
+    const refresh = useCallback(async () => {
+        if (runningRef.current) return;
+        runningRef.current = true;
+        try {
+            await refreshSessionSilently();
+            const stamp = new Date().toISOString();
+            setLastRefreshedAt(stamp);
+            onRefreshRef.current?.(stamp);
+        } catch (err) {
+            onErrorRef.current?.(err);
+        } finally {
+            runningRef.current = false;
+            const { delay, due } = await computeDelay();
+            setNextRefreshAt(new Date(due).toISOString());
+            if (timerRef.current) clearTimeout(timerRef.current);
+            timerRef.current = setTimeout(refresh, delay);
+        }
+    }, [computeDelay]);
+
+    useEffect(() => {
+        if (!enabled) return undefined;
+
+        let mounted = true;
+        const schedule = (delay) => {
+            if (!mounted) return;
+            if (timerRef.current) clearTimeout(timerRef.current);
+            timerRef.current = setTimeout(refresh, delay);
+        };
+
+        const onVisibility = () => {
+            if (document.visibilityState === 'visible') refresh();
+        };
+
+        const onOnline = () => refresh();
+
+        (async () => {
+            const { delay, due } = await computeDelay();
+            if (!mounted) return;
+            setNextRefreshAt(new Date(due).toISOString());
+            schedule(delay);
+        })();
+
+        document.addEventListener('visibilitychange', onVisibility);
+        window.addEventListener('online', onOnline);
+
+        return () => {
+            mounted = false;
+            if (timerRef.current) clearTimeout(timerRef.current);
+            timerRef.current = null;
+            document.removeEventListener('visibilitychange', onVisibility);
+            window.removeEventListener('online', onOnline);
+        };
+    }, [enabled, computeDelay, refresh]);
+
+    return { lastRefreshedAt, nextRefreshAt };
+}

--- a/Frontend/src/utils/sessionRefresh.js
+++ b/Frontend/src/utils/sessionRefresh.js
@@ -1,0 +1,61 @@
+import { supabase } from '../lib/supabaseClient';
+import { API_CONFIG } from '../config';
+
+export const REFRESH_MARGIN_MS = 60 * 1000; // refresh 60s before expiry
+export const MIN_REFRESH_DELAY_MS = 15 * 1000;
+export const MAX_REFRESH_DELAY_MS = 60 * 60 * 1000;
+
+/**
+ * Decodes the `exp` claim of a JWT (in ms since epoch), or null when the
+ * token is missing/malformed.
+ */
+export const decodeJwtExpiry = (token) => {
+    if (!token) return null;
+    const payload = token.split('.')[1];
+    if (!payload) return null;
+    try {
+        const json = JSON.parse(
+            atob(payload.replace(/-/g, '+').replace(/_/g, '/'))
+        );
+        return typeof json.exp === 'number' ? json.exp * 1000 : null;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Tries to rotate the server-issued HttpOnly session cookies. The refresh
+ * cookie is sent automatically by the browser (`credentials: 'include'`); the
+ * response re-issues the access/refresh cookies. Fails quietly when the
+ * backend does not expose the endpoint yet (e.g. HTTP 404/405).
+ */
+export const refreshHttpOnlyCookies = async () => {
+    const url = `${API_CONFIG.BACKEND_URL}/auth/refresh`;
+    const res = await fetch(url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        cache: 'no-store',
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res;
+};
+
+/**
+ * Silent session refresh:
+ *  1. Tries the backend HttpOnly-cookie rotation (best effort).
+ *  2. Falls back to the Supabase refresh token rotation so the local session
+ *     stays fresh even when the cookie endpoint is unavailable.
+ * Throws only when the Supabase refresh itself fails (session truly expired).
+ */
+export const refreshSessionSilently = async () => {
+    try {
+        await refreshHttpOnlyCookies();
+    } catch {
+        // Cookie endpoint missing/unreachable — fall through to Supabase.
+    }
+
+    const { data, error } = await supabase.auth.refreshSession();
+    if (error) throw error;
+    return Boolean(data?.session);
+};


### PR DESCRIPTION
Implements #3896 — automatic JWT refresh on expiry warnings.

## Changes
- `Frontend/src/utils/sessionRefresh.js`: `decodeJwtExpiry()` (node-verified), `refreshHttpOnlyCookies()` (POST `/auth/refresh` with `credentials: 'include'`), and `refreshSessionSilently()` — a best-effort background refresh covering the cookie-based flow plus a Supabase fallback.
- `Frontend/src/hooks/useSilentSessionRefresh.js`: schedules the refresh at `exp - 60s` (15s floor / 1h cap), re-arms after each rotation, and re-triggers on tab `visibilitychange` and `online` events.
- Wired into `AppLayout` in `Frontend/src/App.jsx` when a user session is present; failures are warn-logged and never block the UI.

Closes #3896
