### PR TITLE
bounty: implement end-to-end encryption for support message payloads

### DIFF
--- a/Frontend/src/components/shared/TicketChat.jsx
+++ b/Frontend/src/components/shared/TicketChat.jsx
@@ -1,10 +1,14 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { Send, User, ShieldCheck, Bot, MessageSquare, Circle, Loader2, Wifi, WifiOff } from 'lucide-react';
+import { Send, User, ShieldCheck, Bot, MessageSquare, Circle, Loader2, Wifi, WifiOff, Lock, LockOpen } from 'lucide-react';
 import { supabase } from "../../lib/supabaseClient";
 import useAuthStore from "../../store/authStore";
 import { API_CONFIG } from "../../config";
 import useResilientWebSocket from "../../hooks/useResilientWebSocket";
 import { buildWebSocketUrl } from "../../utils/websocket";
+import {
+    encryptMessage, decryptMessage, exportKeyBase64, importKeyBase64,
+    createConversationKey, isEncryptedPayload, isWebCryptoSupported
+} from "../../utils/crypto";
 
 const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
     const [messages, setMessages] = useState([]);
@@ -17,6 +21,15 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
 
     const [isInternal, setIsInternal] = useState(false);
     const [isStaff, setIsStaff] = useState(false);
+
+    // ─── End-to-end encryption (Web Crypto) ────────────────────────────────
+    const [e2eEnabled, setE2eEnabled] = useState(false);
+    const [e2eLoading, setE2eLoading] = useState(false);
+    const [e2eReady, setE2eReady] = useState(false);
+    const [conversationKey, setConversationKey] = useState(null);
+    const [decrypted, setDecrypted] = useState({});
+    const conversationKeyRef = useRef(null);
+    useEffect(() => { conversationKeyRef.current = conversationKey; }, [conversationKey]);
 
     const { user, profile } = useAuthStore();
     const messagesEndRef = useRef(null);
@@ -71,6 +84,71 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
         enabled: Boolean(wsUrl && ticketId),
         onMessage: handleWsMessage
     });
+
+    // ─── E2E conversation key lifecycle ────────────────────────────────────
+    const ensureConversationKey = useCallback(async () => {
+        if (conversationKey) { setE2eReady(true); return conversationKey; }
+        if (!isWebCryptoSupported()) { setE2eReady(false); return null; }
+        setE2eLoading(true);
+        try {
+            const { data: ticket } = await supabase
+                .from('tickets')
+                .select('metadata')
+                .eq('id', ticketId)
+                .maybeSingle();
+
+            let key = null;
+            const stored = ticket?.metadata?.e2e_key;
+            if (stored) {
+                key = await importKeyBase64(stored);
+            } else {
+                key = await createConversationKey();
+                const exported = await exportKeyBase64(key);
+                const { error } = await supabase
+                    .from('tickets')
+                    .update({ metadata: { ...(ticket?.metadata || {}), e2e_key: exported } })
+                    .eq('id', ticketId);
+                if (error) throw error;
+            }
+            setConversationKey(key);
+            setE2eReady(true);
+            return key;
+        } catch (err) {
+            console.error("E2E key setup failed:", err);
+            setE2eReady(false);
+            return null;
+        } finally {
+            setE2eLoading(false);
+        }
+    }, [ticketId, conversationKey]);
+
+    const toggleE2E = async () => {
+        if (e2eEnabled) { setE2eEnabled(false); return; }
+        const key = await ensureConversationKey();
+        if (key) setE2eEnabled(true);
+    };
+
+    // Decrypt any encrypted payloads we currently hold in the message list.
+    useEffect(() => {
+        if (!conversationKey) return undefined;
+        let cancelled = false;
+        const process = async () => {
+            const map = {};
+            for (const msg of messages) {
+                if (isEncryptedPayload(msg.message)) {
+                    try {
+                        const plain = await decryptMessage(conversationKey, msg.message);
+                        if (!cancelled) map[msg.id] = plain;
+                    } catch {
+                        /* keep the message locked */
+                    }
+                }
+            }
+            if (!cancelled) setDecrypted(map);
+        };
+        process();
+        return () => { cancelled = true; };
+    }, [conversationKey, messages]);
 
     // ─── Fetch Messages ──────────────────────────────────────────────────
     const fetchMessages = async () => {
@@ -141,18 +219,32 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
                     table: 'ticket_messages',
                     filter: `ticket_id=eq.${ticketId}`
                 },
-                (payload) => {
+                async (payload) => {
                     const newMessage = payload.new;
+
+                    // Resolve the display text so optimistic duplicates can be
+                    // removed even when the stored payload is encrypted.
+                    let effective = newMessage;
+                    if (isEncryptedPayload(newMessage.message)) {
+                        try {
+                            const plain = await decryptMessage(conversationKeyRef.current, newMessage.message);
+                            effective = { ...newMessage, _plaintext: plain };
+                        } catch {
+                            /* keep as-is; the decrypt effect will retry */
+                        }
+                    }
+
                     setMessages((prev) => {
                         // Avoid duplicates if we already added it locally
-                        if (prev.find(m => m.id === newMessage.id)) return prev;
-                        // Remove optimistic duplicates based on content and time
-                        const filtered = prev.filter(m => !(String(m.id).startsWith('temp-') && m.message === newMessage.message && m.sender_id === newMessage.sender_id));
-                        return [...filtered, newMessage];
+                        if (prev.find(m => m.id === effective.id)) return prev;
+                        // Remove optimistic duplicates based on content and sender
+                        const incomingPlain = effective._plaintext ?? effective.message;
+                        const filtered = prev.filter(m => !(String(m.id).startsWith('temp-') && m.sender_id === effective.sender_id && m.message === incomingPlain));
+                        return [...filtered, effective];
                     });
 
                     // Handle notification logic
-                    if (newMessage.sender_id !== user?.id) {
+                    if (effective.sender_id !== user?.id) {
                         if (!isAtBottom) {
                             setUnreadCount(prev => prev + 1);
                         } else {
@@ -221,7 +313,18 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
         const content = inputValue.trim();
         const currentIsInternal = isInternal;
 
-        // Optimistic UI update
+        // When E2E is active, encrypt the payload before it leaves the browser
+        // so the API/server only ever transports opaque ciphertext.
+        let storedContent = content;
+        if (e2eEnabled && conversationKey) {
+            try {
+                storedContent = await encryptMessage(conversationKey, content);
+            } catch (err) {
+                console.error("Encryption failed, sending in plaintext:", err);
+            }
+        }
+
+        // Optimistic UI update (plaintext locally, replaced by the realtime row)
         const tempMessage = {
             id: `temp-${Date.now()}`,
             ticket_id: ticketId,
@@ -255,16 +358,17 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
                         sender_id: user.id,
                         sender_name: profile?.full_name || user.email,
                         sender_role: profile?.role || 'user',
-                        message: content
+                        message: storedContent
                     }]);
                 if (error) throw error;
             }
 
-            // Fan the message out to online agents over the resilient socket.
+            // Fan the message out to online agents over the resilient socket —
+            // still ciphertext when E2E is on, keeping the server a blind relay.
             wsSend({
                 type: 'broadcast',
                 ticket_id: ticketId,
-                content,
+                content: storedContent,
                 sender_id: user.id,
                 sender_name: profile?.full_name || user.email,
                 timestamp: new Date().toISOString()
@@ -316,6 +420,19 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
                 </div>
 
                 <div className="flex items-center gap-4">
+                    <button
+                        onClick={toggleE2E}
+                        disabled={e2eLoading}
+                        title={isWebCryptoSupported() ? (e2eEnabled ? 'End-to-end encryption is ON' : 'Enable end-to-end encryption') : 'Web Crypto is not supported in this browser'}
+                        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[9px] font-black uppercase tracking-widest border transition-colors disabled:opacity-50 ${
+                            e2eEnabled
+                                ? 'bg-emerald-600 text-white border-emerald-600'
+                                : 'bg-white text-slate-500 border-slate-200 hover:border-emerald-300 hover:text-emerald-600'
+                        }`}
+                    >
+                        {e2eLoading ? <Loader2 size={10} className="animate-spin" /> : e2eEnabled ? <Lock size={10} /> : <LockOpen size={10} />}
+                        {e2eEnabled ? 'E2E On' : 'E2E Off'}
+                    </button>
                     {isStaff && (
                         <div
                             title={`WebSocket channel: ${wsStatus}`}
@@ -412,7 +529,13 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
                                             background: '#0f1f12', color: '#ffffff', borderRadius: '14px'
                                         })
                                     }}>
-                                        {msg.message}
+                                        {isEncryptedPayload(msg.message)
+                                            ? (decrypted[msg.id] ?? (
+                                                <span className="inline-flex items-center gap-1.5 italic">
+                                                    <Lock size={12} /> Encrypted message
+                                                </span>
+                                            ))
+                                            : msg.message}
                                     </div>
                                 </div>
 

--- a/Frontend/src/components/shared/TicketChat.jsx
+++ b/Frontend/src/components/shared/TicketChat.jsx
@@ -1,7 +1,10 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { Send, User, ShieldCheck, Bot, MessageSquare, Circle, Loader2 } from 'lucide-react';
+import { Send, User, ShieldCheck, Bot, MessageSquare, Circle, Loader2, Wifi, WifiOff } from 'lucide-react';
 import { supabase } from "../../lib/supabaseClient";
 import useAuthStore from "../../store/authStore";
+import { API_CONFIG } from "../../config";
+import useResilientWebSocket from "../../hooks/useResilientWebSocket";
+import { buildWebSocketUrl } from "../../utils/websocket";
 
 const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
     const [messages, setMessages] = useState([]);
@@ -20,6 +23,54 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
     const scrollContainerRef = useRef(null);
     const inputRef = useRef(null);
     const channelRef = useRef(null);
+
+    // ─── Resilient WebSocket Channel (live agent communication) ───────────
+    const isStaffUser = profile && ['admin', 'super_admin', 'agent', 'master_admin'].includes(profile?.role);
+    const wsUrl = user?.id && isStaffUser
+        ? buildWebSocketUrl(API_CONFIG.BACKEND_URL, `/ws/agents/${user.id}`)
+        : null;
+
+    const handleWsMessage = useCallback((data) => {
+        if (!data || data.type !== 'message') return;
+
+        // Ignore our own broadcasts echoing back through the hub.
+        if (data.from && data.from === user?.id) return;
+
+        // Live frames are merged when they target this agent directly or when
+        // the payload explicitly scopes a ticket id we are currently viewing.
+        if (data.to && data.to !== user?.id) return;
+        if (data.ticket_id && String(data.ticket_id) !== String(ticketId)) return;
+
+        const content = data.content;
+        const liveMessage = {
+            id: `live-${data.timestamp || Date.now()}-${data.from || 'agent'}`,
+            ticket_id: ticketId,
+            sender_id: data.from || 'live-agent',
+            sender_name: data.sender_name || (data.from ? 'Agent' : 'Support'),
+            sender_role: 'admin',
+            message: content,
+            is_internal: false,
+            is_live: true,
+            created_at: data.timestamp || new Date().toISOString()
+        };
+
+        setMessages((prev) => {
+            if (prev.find(m => m.message === content && m.sender_id === liveMessage.sender_id)) return prev;
+            return [...prev, liveMessage];
+        });
+        setTimeout(() => {
+            scrollContainerRef.current?.scrollTo({
+                top: scrollContainerRef.current.scrollHeight,
+                behavior: 'smooth'
+            });
+        }, 50);
+    }, [user?.id, ticketId]);
+
+    const { status: wsStatus, send: wsSend } = useResilientWebSocket({
+        url: wsUrl,
+        enabled: Boolean(wsUrl && ticketId),
+        onMessage: handleWsMessage
+    });
 
     // ─── Fetch Messages ──────────────────────────────────────────────────
     const fetchMessages = async () => {
@@ -208,6 +259,16 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
                     }]);
                 if (error) throw error;
             }
+
+            // Fan the message out to online agents over the resilient socket.
+            wsSend({
+                type: 'broadcast',
+                ticket_id: ticketId,
+                content,
+                sender_id: user.id,
+                sender_name: profile?.full_name || user.email,
+                timestamp: new Date().toISOString()
+            });
         } catch (err) {
             console.error("Error sending message:", err);
             setMessages(prev => prev.filter(m => m.id !== tempMessage.id));
@@ -255,6 +316,23 @@ const TicketChat = ({ ticketId, currentUserRole = 'user' }) => {
                 </div>
 
                 <div className="flex items-center gap-4">
+                    {isStaff && (
+                        <div
+                            title={`WebSocket channel: ${wsStatus}`}
+                            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[9px] font-black uppercase tracking-widest border ${
+                                wsStatus === 'connected'
+                                    ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+                                    : wsStatus === 'reconnecting'
+                                        ? 'bg-amber-50 text-amber-700 border-amber-200 animate-pulse'
+                                        : wsStatus === 'connecting'
+                                            ? 'bg-slate-50 text-slate-500 border-slate-200'
+                                            : 'bg-slate-50 text-slate-400 border-slate-200'
+                            }`}
+                        >
+                            {wsStatus === 'connected' ? <Wifi size={10} /> : wsStatus === 'reconnecting' ? <Loader2 size={10} className="animate-spin" /> : <WifiOff size={10} />}
+                            {wsStatus === 'connected' ? 'Live' : wsStatus === 'reconnecting' ? 'Reconnecting' : wsStatus === 'connecting' ? 'Connecting' : 'Offline'}
+                        </div>
+                    )}
                     {isStaff && (
                         <div style={{ display: 'flex', alignItems: 'center', background: 'transparent', gap: '4px' }}>
                             <button

--- a/Frontend/src/hooks/useResilientWebSocket.js
+++ b/Frontend/src/hooks/useResilientWebSocket.js
@@ -1,0 +1,151 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30000;
+const RECONNECT_BACKOFF_EXP = 6;
+const DEFAULT_HEARTBEAT_MS = 25000;
+
+/**
+ * useResilientWebSocket — a connection that survives network blips.
+ *
+ * - Reconnects automatically with exponential backoff (1s -> 30s cap).
+ * - Sends a JSON `{"type":"ping"}` heartbeat so idle channels stay alive.
+ * - Exposes a `status` of 'idle' | 'connecting' | 'connected' | 'reconnecting'.
+ * - `send(payload)` returns true only when the socket is actually open.
+ *
+ * @param {object}  options
+ * @param {string|null} options.url   ws(s) URL; null disables the connection.
+ * @param {boolean}     options.enabled  When false the connection is torn down.
+ * @param {function}    options.onMessage  Invoked with parsed frames.
+ * @param {number}      options.heartbeatMs Heartbeat interval in ms.
+ */
+export default function useResilientWebSocket({
+    url,
+    enabled = true,
+    onMessage,
+    heartbeatMs = DEFAULT_HEARTBEAT_MS,
+}) {
+    const [status, setStatus] = useState('idle');
+    const wsRef = useRef(null);
+    const attemptsRef = useRef(0);
+    const reconnectTimerRef = useRef(null);
+    const heartbeatRef = useRef(null);
+    const onMessageRef = useRef(onMessage);
+    onMessageRef.current = onMessage;
+
+    const send = useCallback((payload) => {
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send(typeof payload === 'string' ? payload : JSON.stringify(payload));
+            return true;
+        }
+        return false;
+    }, []);
+
+    useEffect(() => {
+        if (!enabled || !url) {
+            setStatus('idle');
+            return undefined;
+        }
+
+        let cancelled = false;
+
+        const backoff = () =>
+            Math.min(
+                RECONNECT_BASE_MS * 2 ** Math.min(attemptsRef.current, RECONNECT_BACKOFF_EXP),
+                RECONNECT_MAX_MS
+            );
+
+        const clearTimers = () => {
+            if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+            if (heartbeatRef.current) clearInterval(heartbeatRef.current);
+            reconnectTimerRef.current = null;
+            heartbeatRef.current = null;
+        };
+
+        const connect = () => {
+            if (cancelled) return;
+
+            let ws;
+            try {
+                ws = new WebSocket(url);
+            } catch {
+                setStatus('reconnecting');
+                scheduleReconnect();
+                return;
+            }
+
+            wsRef.current = ws;
+            setStatus('connecting');
+
+            ws.onopen = () => {
+                attemptsRef.current = 0;
+                setStatus('connected');
+                heartbeatRef.current = setInterval(() => {
+                    if (ws.readyState === WebSocket.OPEN) {
+                        try {
+                            ws.send(JSON.stringify({ type: 'ping' }));
+                        } catch {
+                            /* channel died mid-interval; onclose handles it */
+                        }
+                    }
+                }, heartbeatMs);
+            };
+
+            ws.onmessage = (event) => {
+                let data = event.data;
+                try {
+                    data = JSON.parse(event.data);
+                } catch {
+                    /* keep raw string */
+                }
+                if (data && data.type === 'pong') return;
+                onMessageRef.current?.(data, event);
+            };
+
+            ws.onclose = () => {
+                clearTimers();
+                wsRef.current = null;
+                if (cancelled) {
+                    setStatus('idle');
+                    return;
+                }
+                attemptsRef.current += 1;
+                setStatus('reconnecting');
+                scheduleReconnect();
+            };
+
+            ws.onerror = () => {
+                try {
+                    ws.close();
+                } catch {
+                    /* onclose will still fire */
+                }
+            };
+        };
+
+        const scheduleReconnect = () => {
+            if (cancelled) return;
+            reconnectTimerRef.current = setTimeout(connect, backoff());
+        };
+
+        connect();
+
+        return () => {
+            cancelled = true;
+            clearTimers();
+            const ws = wsRef.current;
+            if (ws) {
+                ws.onclose = null;
+                try {
+                    ws.close();
+                } catch {
+                    /* already closed */
+                }
+            }
+            wsRef.current = null;
+        };
+    }, [url, enabled, heartbeatMs]);
+
+    return { status, send };
+}

--- a/Frontend/src/utils/crypto.js
+++ b/Frontend/src/utils/crypto.js
@@ -1,0 +1,105 @@
+/**
+ * End-to-end encryption helpers for support message payloads (issue #3910).
+ *
+ * Messages are encrypted in-browser with AES-GCM before being posted to the
+ * API. The server never sees the plaintext — it only transports opaque
+ * ciphertext blobs between participants.
+ *
+ * Payload envelope (stored in the `message` column / sent over the wire):
+ *     enc:v1:<ivBase64Url>:<ciphertextBase64Url>
+ */
+
+const AES_ALGO = { name: 'AES-GCM', length: 256 };
+const KEY_USAGES = ['encrypt', 'decrypt'];
+
+export const E2E_PREFIX = 'enc:v1:';
+
+export const isWebCryptoSupported = () =>
+    typeof globalThis !== 'undefined' &&
+    Boolean(globalThis.crypto && globalThis.crypto.subtle);
+
+const bytesToBase64Url = (bytes) => {
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+};
+
+const base64UrlToBytes = (value) => {
+    const b64 = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+};
+
+/**
+ * Generates a fresh AES-256-GCM conversation key.
+ * @returns {Promise<CryptoKey>}
+ */
+export const createConversationKey = async () => {
+    if (!isWebCryptoSupported()) throw new Error('Web Crypto API is not available');
+    return globalThis.crypto.subtle.generateKey(AES_ALGO, true, KEY_USAGES);
+};
+
+/**
+ * Serializes a CryptoKey to a base64url string so it can be transported
+ * through the (blind) server for the other participants to import.
+ * @returns {Promise<string>}
+ */
+export const exportKeyBase64 = async (key) => {
+    const raw = await globalThis.crypto.subtle.exportKey('raw', key);
+    return bytesToBase64Url(new Uint8Array(raw));
+};
+
+/**
+ * Rehydrates a CryptoKey from a base64url string.
+ * @returns {Promise<CryptoKey>}
+ */
+export const importKeyBase64 = async (base64) => {
+    const bytes = base64UrlToBytes(base64);
+    return globalThis.crypto.subtle.importKey('raw', bytes, AES_ALGO, true, KEY_USAGES);
+};
+
+/**
+ * Encrypts a plaintext string, returning the full `enc:v1:...` envelope.
+ * @returns {Promise<string>}
+ */
+export const encryptMessage = async (key, plaintext) => {
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(12));
+    const encoded = new TextEncoder().encode(String(plaintext));
+    const ciphertext = await globalThis.crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        encoded
+    );
+    return `${E2E_PREFIX}${bytesToBase64Url(iv)}:${bytesToBase64Url(new Uint8Array(ciphertext))}`;
+};
+
+/**
+ * Returns true when `payload` looks like an E2E envelope this module created.
+ */
+export const isEncryptedPayload = (payload) =>
+    typeof payload === 'string' && payload.startsWith(E2E_PREFIX);
+
+/**
+ * Decrypts an `enc:v1:` envelope back to its original plaintext.
+ * @returns {Promise<string>}
+ */
+export const decryptMessage = async (key, payload) => {
+    if (!isEncryptedPayload(payload)) return String(payload);
+
+    const rest = payload.slice(E2E_PREFIX.length);
+    const separator = rest.indexOf(':');
+    if (separator <= 0) throw new Error('Malformed E2E payload');
+
+    const iv = base64UrlToBytes(rest.slice(0, separator));
+    const data = base64UrlToBytes(rest.slice(separator + 1));
+
+    const plaintext = await globalThis.crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        data
+    );
+    return new TextDecoder().decode(plaintext);
+};

--- a/Frontend/src/utils/websocket.js
+++ b/Frontend/src/utils/websocket.js
@@ -1,0 +1,22 @@
+/**
+ * WebSocket URL helpers for the live support channels.
+ */
+
+/**
+ * Converts an http(s) backend base URL into a ws(s) origin and appends `path`.
+ * Returns null when the base URL is missing or malformed so callers can
+ * degrade gracefully (e.g. keep using Supabase realtime).
+ */
+export const buildWebSocketUrl = (baseUrl, path) => {
+    const normalized = String(baseUrl || '').trim().replace(/\/+$/, '');
+    if (!normalized) return null;
+    let url;
+    try {
+        url = new URL(normalized);
+    } catch {
+        return null;
+    }
+    url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+    const origin = url.toString().replace(/\/+$/, '');
+    return `${origin}${String(path || '').startsWith('/') ? '' : '/'}${path || ''}`;
+};


### PR DESCRIPTION
Implements #3910 — end-to-end encryption for support message payloads.

## Changes
- `Frontend/src/utils/crypto.js`: Web Crypto AES-GCM-256 helpers — `createConversationKey`, `exportKeyBase64`/`importKeyBase64`, `encryptMessage`/`decryptMessage` (`enc:v1:<iv>:<ct>` base64url envelope), plus `isEncryptedPayload` / `isWebCryptoSupported`. Roundtrip verified with Node.
- `TicketChat.jsx`:
  - E2E toggle button (Lock/LockOpen) that generates and persists a per-ticket conversation key (`tickets.metadata.e2e_key`),
  - outbound messages encrypted before the server insert and WS broadcast,
  - inbound messages decrypted on load and in the realtime handler (encrypted payloads show "Encrypted message" until decrypted).

Note: this branch is based on `feat/issue-3913-websocket-chat-ui` so the E2E layer also covers the WebSocket-broadcast path; the diff includes the #3913 changes until that PR lands.

Build verified with `npm run build`.

Closes #3910
