### PR TITLE
fix(ui): standardize authentication heading font styling

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -3,10 +3,10 @@
 
 <head>
  
-  <!-- Google Fonts: Syne + Inter -->
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap" rel="stylesheet" />
+<!-- Google Fonts: Inter (Syne dropped for auth heading consistency) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 
   <title>HELPDESK.AI - Professional AI Ticketing</title>
   

--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -189,7 +189,7 @@ function AdminSignup() {
                     <div className="w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-6" style={{ background: '#f0fdf4', border: '1px solid #d1fae5' }}>
                         <Mail className="w-10 h-10" style={{ color: '#16a34a' }} />
                     </div>
-                    <h2 style={{ fontFamily: "'Syne', sans-serif", fontSize: '28px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.02em', marginBottom: '16px' }}>Check Your Email</h2>
+                    <h2 style={{ fontFamily: "'Inter', sans-serif", fontSize: '28px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.02em', marginBottom: '16px' }}>Check Your Email</h2>
                     <p style={{ color: '#374151', fontSize: '15px', lineHeight: 1.7, marginBottom: '32px' }}>
                         Registration request received! We've sent a verification link to <span style={{ fontWeight: 700, color: '#16a34a' }}>{formData.email}</span>.
                     </p>
@@ -242,7 +242,7 @@ function AdminSignup() {
                         <BrainCircuit className="w-10 h-10" style={{ color: '#16a34a' }} />
                     </div>
                     <p style={{ color: '#16a34a', fontWeight: 700, fontSize: '11px', letterSpacing: '0.1em', textTransform: 'uppercase', marginBottom: '16px' }}>Enterprise Edition</p>
-                    <h1 style={{ fontFamily: "'Syne', sans-serif", fontSize: '42px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.03em', lineHeight: 1.1, marginBottom: '32px' }}>
+                    <h1 style={{ fontFamily: "'Inter', sans-serif", fontSize: '42px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.03em', lineHeight: 1.1, marginBottom: '32px' }}>
                         Scale your <span style={{ color: '#16a34a' }}>IT Support</span> globally.
                     </h1>
 

--- a/Frontend/src/pages/ForgotPassword.jsx
+++ b/Frontend/src/pages/ForgotPassword.jsx
@@ -135,7 +135,7 @@ function ForgotPassword() {
                 <div className="flex justify-center mb-10">
                     <Link to="/" className="flex items-center gap-2 bg-white/40 backdrop-blur-xl px-5 py-2.5 rounded-2xl border border-white/40 shadow-xl shadow-emerald-900/5 transition hover:bg-white/60 group">
                         <BrainCircuit className="w-6 h-6 text-emerald-600 transition-transform group-hover:rotate-12" />
-                        <span className="font-extrabold text-xl tracking-tight text-[#0f1f12]" style={{ fontFamily: 'Syne' }}>HelpDesk<span className="text-emerald-600">.ai</span></span>
+                        <span className="font-extrabold text-xl tracking-tight text-[#0f1f12]" style={{ fontFamily: 'Inter' }}>HelpDesk<span className="text-emerald-600">.ai</span></span>
                     </Link>
                 </div>
 
@@ -148,7 +148,7 @@ function ForgotPassword() {
                     <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-emerald-400 to-emerald-600 opacity-20"></div>
 
                     <div className="text-center mb-10">
-                        <h2 className="text-3xl font-black text-[#0f1f12] tracking-tight" style={{ fontFamily: 'Syne' }}>
+                        <h2 className="text-3xl font-black text-[#0f1f12] tracking-tight" style={{ fontFamily: 'Inter' }}>
                             {step === 1 ? "Recovery Access" : step === 2 ? "Verify Identity" : "Secure Protocol"}
                         </h2>
                         <p className="text-gray-500 mt-2 font-medium">

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -130,7 +130,7 @@ function Login() {
           {/* Headline */}
           <h1
             style={{
-              fontFamily: "'Syne', sans-serif",
+              fontFamily: "'Inter', sans-serif",
               fontSize: '48px',
               fontWeight: 800,
               color: '#0f1f12',
@@ -201,7 +201,7 @@ function Login() {
           <div className="text-center" style={{ marginBottom: '40px' }}>
             <h2
               style={{
-                fontFamily: "'Syne', sans-serif",
+                fontFamily: "'Inter', sans-serif",
                 fontSize: '28px',
                 fontWeight: 800,
                 color: '#0f1f12',

--- a/Frontend/src/pages/Signup.jsx
+++ b/Frontend/src/pages/Signup.jsx
@@ -193,7 +193,7 @@ function Signup() {
           <div className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6" style={{ background: '#f0fdf4', border: '1px solid #d1fae5' }}>
             <CheckCircle2 className="w-8 h-8" style={{ color: '#16a34a' }} />
           </div>
-          <h2 style={{ fontFamily: "'Syne', sans-serif", fontSize: '24px', fontWeight: 800, color: '#0f1f12', marginBottom: '16px' }}>Registration Successful</h2>
+          <h2 style={{ fontFamily: "'Inter', sans-serif", fontSize: '24px', fontWeight: 800, color: '#0f1f12', marginBottom: '16px' }}>Registration Successful</h2>
           <p style={{ color: '#374151', fontSize: '14px', lineHeight: 1.7, marginBottom: '32px' }}>{successMsg}</p>
           <Link
             to="/login"
@@ -246,7 +246,7 @@ function Signup() {
 
         <div className="bg-white rounded-3xl p-6 sm:p-8" style={{ boxShadow: '0 8px 40px rgba(0,0,0,0.08)', border: '1px solid #f0fdf4' }}>
           <div className="text-center" style={{ marginBottom: '32px' }}>
-            <h2 style={{ fontFamily: "'Syne', sans-serif", fontSize: '28px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.02em', marginBottom: '8px' }}>Create Account</h2>
+            <h2 style={{ fontFamily: "'Inter', sans-serif", fontSize: '28px', fontWeight: 800, color: '#0f1f12', letterSpacing: '-0.02em', marginBottom: '8px' }}>Create Account</h2>
             <p style={{ color: '#6b7280', fontSize: '14px' }}>Start automating your IT support today</p>
           </div>
 


### PR DESCRIPTION
Fixes #3937 — inconsistent and stretched font style on authentication headings ("Create Account", "Welcome Back", "Automate your IT Support").

## Changes
- Replaced the Syne font with Inter on the 4 auth page headings (`Login`, `Signup`, `AdminSignup`, `ForgotPassword`), matching the app's standard font and fixing the stretched/oversized appearance.
- Removed the now-unused Syne font link from `Frontend/index.html`.

Build verified with `npm run build`.

Closes #3937
