### PR TITLE
fix(frontend): validate Full Name and Work Email on Get Started form

### DIFF
--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -61,6 +61,20 @@ function AdminSignup() {
         return null; // valid
     };
 
+    const validateFullName = (name) => {
+        if (!name || !name.trim()) return null;
+        if (name.trim().length < 2) return 'Full Name must be at least 2 characters long.';
+        if (!/^[\p{L}\s'-]+$/u.test(name)) return 'Full Name can only contain letters, spaces, hyphens, and apostrophes.';
+        if (/\s{2,}|^['\s-]|['\s-]$/.test(name)) return 'Full Name contains invalid spacing or punctuation.';
+        return null;
+    };
+
+    const validateEmail = (email) => {
+        if (!email || !email.trim()) return null;
+        if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(email)) return 'Please enter a valid work email (e.g. name@company.com).';
+        return null;
+    };
+
     // Password strength calculation
     useEffect(() => {
         const pw = formData.password;
@@ -85,6 +99,16 @@ function AdminSignup() {
         if (step === 1) {
             if (!formData.fullName || !formData.email || !formData.password || !formData.confirmPassword) {
                 setError("Please fill in all required personal information.");
+                return;
+            }
+            const nameError = validateFullName(formData.fullName);
+            if (nameError) {
+                setError(nameError);
+                return;
+            }
+            const emailError = validateEmail(formData.email);
+            if (emailError) {
+                setError(emailError);
                 return;
             }
             const pwError = validatePassword(formData.password);


### PR DESCRIPTION
Closes #4031

## Summary
The **Get Started** (admin signup) form's Personal Information step accepted invalid values: the Full Name field allowed numbers/special characters (e.g. \12d!\) and the Work Email field accepted incomplete addresses like \bc@a\.

## Changes
- Added \alidateFullName\ — allows only letters, spaces, hyphens and apostrophes, rejects digits/symbols and malformed spacing.
- Added \alidateEmail\ — requires a proper \local@domain.tld\ format, rejecting incomplete addresses such as \bc@a\.
- Wired both validators into the step-1 \
extStep\ flow so invalid values block progression and show a clear error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for administrator full names and work email addresses during registration.
  * Registration cannot proceed until the information meets the required format.
  * Clear error messages are shown when invalid details are entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->