### PR TITLE
fix(frontend): validate phone number on Get Started form

### DIFF
--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -61,6 +61,14 @@ function AdminSignup() {
         return null; // valid
     };
 
+    const validatePhone = (phone) => {
+        if (!phone || !phone.trim()) return null;
+        if (/[^0-9+()\-.\s]/.test(phone)) return 'Please enter a valid phone number (digits only).';
+        const digitCount = phone.replace(/[^0-9]/g, '').length;
+        if (digitCount < 7 || digitCount > 15) return 'Phone number must contain between 7 and 15 digits.';
+        return null;
+    };
+
     // Password strength calculation
     useEffect(() => {
         const pw = formData.password;
@@ -94,6 +102,11 @@ function AdminSignup() {
             }
             if (formData.password !== formData.confirmPassword) {
                 setError("Passwords do not match.");
+                return;
+            }
+            const phoneError = validatePhone(formData.phone);
+            if (phoneError) {
+                setError(phoneError);
                 return;
             }
         } else if (step === 2) {


### PR DESCRIPTION
Closes #4032

## Summary
The **Get Started** (admin signup) form accepted invalid phone numbers such as \123abc\ with no validation or feedback.

## Changes
- Added \alidatePhone\ — the field is optional, but when filled it must contain only digits and the separators \+ ( ) - .\ and spaces, with 7–15 digits.
- Wired the validator into the step-1 \
extStep\ flow so invalid numbers block progression and show a clear error message.
- Example rejected inputs: \123abc\, \123\, 16+ digit strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added phone-number validation to the admin signup form.
  * Accepts common phone-number formatting while requiring 7–15 digits.
  * Prevents moving forward when an entered phone number is invalid.
  * Phone numbers remain optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->