### PR TITLE
fix(frontend): validate Company Website URL on Get Started form

### DIFF
--- a/Frontend/src/pages/AdminSignup.jsx
+++ b/Frontend/src/pages/AdminSignup.jsx
@@ -61,6 +61,26 @@ function AdminSignup() {
         return null; // valid
     };
 
+    const validateWebsite = (website) => {
+        if (!website || !website.trim()) return null;
+        const value = website.trim();
+        const hostPart = value.replace(/^https?:\/\//i, '').split(/[/?#]/)[0];
+        if (hostPart && hostPart.toLowerCase() !== 'localhost' && !hostPart.includes('.')) {
+            return 'Please enter a valid website URL (e.g. https://acme.com).';
+        }
+        const url = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+        let parsed;
+        try {
+            parsed = new URL(url);
+        } catch {
+            return 'Please enter a valid website URL (e.g. https://acme.com).';
+        }
+        if (!parsed.hostname || !/^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(parsed.hostname)) {
+            return 'Please enter a valid website URL (e.g. https://acme.com).';
+        }
+        return null;
+    };
+
     // Password strength calculation
     useEffect(() => {
         const pw = formData.password;
@@ -99,6 +119,11 @@ function AdminSignup() {
         } else if (step === 2) {
             if (!formData.companyName || !formData.companySize || !formData.industry || !formData.country) {
                 setError("Please fill in all required company details.");
+                return;
+            }
+            const websiteError = validateWebsite(formData.website);
+            if (websiteError) {
+                setError(websiteError);
                 return;
             }
         }


### PR DESCRIPTION
Closes #4033

## Summary
The **Company Details** step of the **Get Started** (admin signup) form accepted plain-text values (e.g. \bc123A!1\) in the **Company Website** field with no validation.

## Changes
- Added \alidateWebsite\ — the field is optional, but when filled it must be a valid URL:
  - Scheme is optional (\cme.com\ is normalized to \https://acme.com\).
  - Hostname must contain at least one dot-separated label and a valid TLD.
  - Rejects plain text, missing TLDs, and malformed hosts (e.g. \bc123A!1\, \
ot a url\, \123\).
- Wired the validator into the step-2 \
extStep\ flow so invalid URLs block progression and show a clear error message.